### PR TITLE
chore(taxonomy): drop empty wikidata comments

### DIFF
--- a/taxonomies/additives_classes.txt
+++ b/taxonomies/additives_classes.txt
@@ -402,7 +402,6 @@ ru: Наполнитель, фруктово-ягодный наполнител
 sk: Objemové činidlo
 sl: Sredstvo za povečanje prostornine
 sv: Fyllnadsmedel
-#wikidata:en:
 description:en: Bulking agents are substances which contribute to the volume of a foodstuff without contributing significantly to its available energy value.
 description:cs: Plnidly se rozumějí látky, které přispívají k objemu potraviny, aniž významně zvyšují její využitelnou energetickou hodnotu.
 description:da: Fyldemidler: stoffer, der øger en fødevares volumen uden at øge dens energiindhold væsentligt.
@@ -1803,7 +1802,6 @@ ru: Минералы
 sk: Minerálne látky
 sl: Minerali
 sv: Mineraler
-#wikidata:en:
 
 en: Amino acids, amino acid
 bg: Аминокиселини
@@ -1827,7 +1825,6 @@ ro: Aminoacizi
 sk: Aminokyseliny
 sl: Aminokisline
 sv: Aminosyror
-#wikidata:en:
 
 en: Nucleotides
 bg: Нуклеотиди
@@ -1850,7 +1847,6 @@ ro: Nucleotide
 sk: Nukleotidy
 sl: Nukleotidi
 sv: Nukleotider
-#wikidata:en:
 
 en: Other nutritional substances
 de: Andere Nährstoffe

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -1990,7 +1990,6 @@ fr: Absinthe de Pontarlier
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01870
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: Rice wines
@@ -2465,7 +2464,6 @@ hr: Četverostruki ales, Četverostruki pivo
 hu: Quadrupel sör
 it: Birre quadruple
 nl: Quadrupel bieren
-#wikidata:en:
 
 ########################
 
@@ -3195,7 +3193,6 @@ lt: Kaimiškas Jovarų alus
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-02237
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Country specific beers
 en: Belgian beers, Beers from Belgium
@@ -3281,14 +3278,12 @@ fr: Vieille Gueuze, Vieille Gueuze-Lambic, Vieux Lambic, Oude Geuze, Oude Geuze-
 origins:en: en:belgium
 protected_name_file_number:en: TSG-BE-0007
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Belgian beers
 fr: Vieille Kriek, Vieille Kriek-Lambic, Vieille Framboise-Lambic, Vieux fruit-Lambic, Oude Kriek, Oude Kriekenlambiek, Oude Frambozenlambiek, Oude Fruit-lambiek
 origins:en: en:belgium
 protected_name_file_number:en: TSG-BE-0009
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Country specific beers
 en: Bulgarian beers, Beers from Bulgaria
@@ -3334,61 +3329,52 @@ cs: Brněnské pivo, Starobrněnské pivo
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0373
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Czech republic
 cs: Budějovické pivo
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0444
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Czech republic
 cz: Budějovický měsťanský var
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Beers from Czech republic
 cz: České pivo
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0375
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Czech republic
 cs: Budějovický měšťanský var
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0445
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Czech republic
 cs: Českobudějovické pivo
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0446
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Czech republic
 cz: Černá Hora
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0409
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Czech republic
 cs: Znojemské pivo
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0376
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Czech republic
 cs: Chodské pivo
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0363
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Country specific beers
 en: Danish beers, Beers from Denmark
@@ -3468,14 +3454,12 @@ nl: Bremense bieren, Bieren uit Bremen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0514
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Germany
 de: Hofer Biere, Hofer Bier
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0472
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Germany
 en: Kölsch
@@ -3492,19 +3476,16 @@ de: Mainfranken Biere, Mainfranken Bier
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1102
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Germany
 de: Münchner Biere, Münchner Bier
 origins:en: en:germany
-#wikidata:en:
 
 < en: Beers from Germany
 de: Reuther Biere, Reuther Bier
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1324
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from Germany
 de: Wernesgrüner Biere, Wernesgrüner Bier
@@ -3586,7 +3567,6 @@ en: Kentish ale, Kentish strong ale
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0296
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from United Kingdom
 en: Newcastle Brown Ale
@@ -3598,7 +3578,6 @@ en: Rutland Bitter
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0373
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beers from United Kingdom
 en: Scottish beers
@@ -3777,7 +3756,6 @@ wikidata:en: Q13428821
 < en: Spirit drinks
 en: Austrian spirit drinks
 fr: Boissons spiritueuses autrichiennes
-#wikidata:en:
 
 < en: Austrian spirit drinks
 de: Inländerrum
@@ -3799,12 +3777,10 @@ hr: Hrvatske travarice, Hrvatska travarica
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-01958
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spirit drinks
 en: French spirit drinks
 # disabled by safety: origins:en: en:France
-#wikidata:en:
 
 < en: French spirit drinks
 fr: Pommeau de Bretagne
@@ -3857,19 +3833,16 @@ de: Ostpreußischer Bärenfang
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02013
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German spirit drinks
 de: Bärwurz
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02078
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spirit drinks
 en: Lithuanian spirit drinks
 origins:en: en:lithuania
-#wikidata:en:
 
 < en: Lithuanian spirit drinks
 lt: Trauktinė Palanga
@@ -3901,7 +3874,6 @@ sl: Domači rum
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-01832
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spirit drinks
 en: Spanish spirit drinks
@@ -3912,21 +3884,18 @@ es: Ronmiel de Canarias
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01943
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish spirit drinks
 es: Aguardiente de hierbas de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01913
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish spirit drinks
 es: Herbero de la Sierra de Mariola
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01894
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish spirit drinks
 es: Aperitivo Café de Alcoy
@@ -3975,7 +3944,6 @@ el: Ούζο Μυτιλήνης
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01838
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek distilled anis
 en: Ouzo of Plomari
@@ -3983,7 +3951,6 @@ el: Ούζο Πλωμαρίου
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01839
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek distilled anis
 en: Ouzo of Kalamata
@@ -3991,7 +3958,6 @@ el: Ούζο Καλαμάτας, Ouzo of Kalamata
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01840
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek distilled anis
 en: Ouzo of Thrace
@@ -3999,7 +3965,6 @@ el: Ούζο Θράκης, Ouzo of Thrace
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01841
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek distilled anis
 en: Ouzo of Macedonia
@@ -4007,7 +3972,6 @@ el: Ούζο Μακεδονίας, Ouzo of Macedonia
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01842
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hard liquors
 en: Mezcal
@@ -4072,7 +4036,6 @@ de: Wachauer Weinbrand
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-01919
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: German Weinbrand
@@ -4082,14 +4045,12 @@ de: Pfälzer Weinbrand
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01930
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German Weinbrand
 de: Deutscher Weinbrand
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02059
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Eaux de vie
 en: Brandys, Brandies
@@ -4130,7 +4091,6 @@ en: Somerset Cider Brandy
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-01823
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: Austrian fruit spirit
@@ -4146,14 +4106,12 @@ de: Pregler, Osttiroler Pregler
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-02512
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Austrian fruit spirit
 de: Wachauer Marillenbrand
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-01918
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: Bulgarian fruit spirit
@@ -4168,7 +4126,6 @@ bg: Троянска сливова ракия, Сливова ракия от �
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01862
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Slivova rakya
 en: Slivova rakya from Lovech
@@ -4176,34 +4133,29 @@ bg: Ловешка сливова ракия, Сливова ракия от Л�
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01863
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: Croatian fruit spirit
 hu: Horvát gyümölcspárlatok
 # disabled for safety: origins:en: en:Croatia
-#wikidata:en:
 
 < en: Croatian fruit spirit
 hr: Hrvatske loze, Hrvatska loza
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-02018
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Croatian fruit spirit
 hr: Slavonske šljivovice, Slavonska šljivovica
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-01961
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Croatian fruit spirit
 hr: Hrvatske stare šljivovice, Hrvatska stara šljivovica
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-01957
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: Slovakian fruit spirit
@@ -4222,14 +4174,12 @@ ru: Медовача
 en: French fruit spirit
 hu: Francia gyümölcspárlatok
 # disabled for safety: origins:en: en:France
-#wikidata:en:
 
 < en: French fruit spirit
 fr: Kirsch d'Alsace
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01983
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French fruit spirit
 fr: Mirabelle de Lorraine
@@ -4243,14 +4193,12 @@ fr: Quetsch d'Alsace
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02024
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French fruit spirit
 fr: Mirabelle d'Alsace
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01985
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French fruit spirit
 fr: Kirsch de Fougerolles
@@ -4264,69 +4212,59 @@ fr: Framboise d'Alsace
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01984
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German fruit spirit
 de: Hohenloher Birnenbrand, Hohenloher Birnenwasser
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02495
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: German fruit spirit
 hu: Német gyümölcspárlatok
 # disabled for safety: origins:en: en:Germany
-#wikidata:en:
 
 < en: German fruit spirit
 de: Schwarzwälder Williamsbirne
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01999
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German fruit spirit
 de: Fränkisches Kirschwasser
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02056
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German fruit spirit
 de: Schwarzwälder Kirschwasser
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01947
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German fruit spirit
 de: Fränkischer Obstler
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02051
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German fruit spirit
 de: Schwarzwälder Zwetschgenwasser
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01995
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German fruit spirit
 de: Fränkisches Zwetschgenwasser
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02055
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German fruit spirit
 de: Schwarzwälder Mirabellenwasser
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01993
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: Hungarian fruit spirit
@@ -4336,166 +4274,142 @@ hu: Magyar gyümölcspárlatok
 en: Italian fruit spirit
 hu: Olasz gyümölcspárlatok
 # disabled for safety: origins:en: en:Italy
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Williams trentino, Williams del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01902
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Williams friulano, Williams del Friuli
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01887
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Südtiroler Zwetschgeler, Zwetschgeler dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01883
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Südtiroler Williams, Williams dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01880
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Südtiroler Obstler, Obstler dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01884
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Südtiroler Marille, Marille dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01881
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Südtiroler Kirsch, Kirsch dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01882
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Südtiroler Gravensteiner, Gravensteiner dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01885
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Südtiroler Golden Delicious, Golden Delicious dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01886
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Sliwovitz trentino, Sliwovitz del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01903
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Sliwovitz del Friuli-Venezia Giulia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01889
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Kirsch Trentino, Kirschwasser Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01905
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Kirsch Friulano, Kirschwasser Friulano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01888
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Distillato di mele trentino, Distillato di mele del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01901
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian fruit spirit
 it: Aprikot trentino, Aprikot del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01904
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: Romanian fruit spirit
 hu: Romániai gyümölcspárlatok, Román gyümölcspárlatok
 # disabled for safety: origins:en: en:Romania
-#wikidata:en:
 
 < en: Romanian fruit spirit
 ro: Pălincă
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02005
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Romanian fruit spirit
 ro: Țuică de Argeș
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02003
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Romanian fruit spirit
 ro: Horincă de Cămârzana
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02004
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Romanian fruit spirit
 ro: Țuică Zetea de Medieșu Aurit
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02001
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: Slovenian fruit spirit
 hu: Szlovén gyümölcspárlatok
 # disabled for safety: origins:en: en:Slovenia
-#wikidata:en:
 
 < en: Slovenian fruit spirit
 sl: Brinjevec
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-01830
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Slovenian fruit spirit
 sl: Dolenjski sadjevec
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-01826
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Fruit brandy
 en: Pálinka
@@ -4525,48 +4439,41 @@ wikidata:en: Q782901
 en: Hungarian Pálinka
 hu: Magyar pálinka
 origins:en: en:hungary
-#wikidata:en:
 
 < en: Pálinka
 en: Austrian Pálinka
 hu: Osztrák pálinka, Ausztriai pálinka
 origins:en: en:austria
-#wikidata:en:
 
 < en: Hungarian Pálinka
 hu: Madarasi birspálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02489
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian Pálinka
 hu: Sárréti kökénypálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02490
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian Pálinka
 hu: Nagykörűi cseresznyepálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02477
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian Pálinka
 hu: Homokháti őszibarack pálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02471
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian Pálinka
 hu: Vasi vadkörte pálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02408
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian Pálinka
 hu: Újfehértói meggypálinka
@@ -4581,14 +4488,12 @@ hu: Nagykunsági birspálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02233
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian Pálinka
 hu: Nagykunsági szilvapálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02232
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian Pálinka
 hu: Gönci barackpálinka
@@ -4762,7 +4667,6 @@ it: Whisky belga
 nl: Belgische whiskies
 pt: Whisky belga
 # disabled for safety: origins:en: en:Belgium
-#wikidata:en:
 
 < en: Whisky
 en: Canadian whiskeys
@@ -4792,7 +4696,6 @@ origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-01854, PGI-GB-01854-AM01
 protected_name_type:en: gi
 wikidata:en: Q8718387
-#wikidata:en:
 
 < en: Scotch whisky
 < fr: Blended whisky
@@ -4821,7 +4724,6 @@ pt: Whisky francês
 zh: 法国威士忌
 origins:en: en:france
 wikidata_wikipedia_category:en: Q15975338
-#wikidata:en:
 
 < en: French Whisky
 en: Alsatian whiskey
@@ -4978,7 +4880,6 @@ fr: Eau-de-vie de Faugères
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02076
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 en: Calvados
@@ -4999,14 +4900,12 @@ fr: Calvados Domfrontais
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01837
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Calvados
 fr: Calvados Pays d'Auge
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02034
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Eaux de vie
 en: Cognac
@@ -5034,7 +4933,6 @@ fr: Eaux-de-vie suisses, Eau-de-vie suisse, Eaux-de-vie de Suisse, Eau-de-vie de
 hr: Švicarski eaux-de-vie
 it: Acquaviti svizzere, Acquaviti della Svizzera
 nl: Zwitserse eau-de-vies
-#wikidata:en:
 origins:en: en:switzerland
 
 < en: Eaux de vie
@@ -5044,12 +4942,10 @@ fr: Eaux-de-vie françaises, Eau-de-vie française, Eaux-de-vie de France, Eau-d
 hr: Francuski eaux-de-vie
 it: Acquaviti francesi, Acquaviti della Francia
 nl: Franse eau-de-vies
-#wikidata:en:
 origins:en: en:france
 
 < en: French Eaux-de-vie
 en: French cider eau-de-vies
-#wikidata:en:
 
 < en: French cider eau-de-vies
 fr: Eau-de-vie de cidre de Bretagne
@@ -5058,7 +4954,6 @@ nl: Bretons cider eau-de-vies
 origins:en: en:france, en:brittany
 protected_name_file_number:en: PGI-FR-02035
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French cider eau-de-vies
 fr: Eau-de-vie de cidre de Normandie
@@ -5067,7 +4962,6 @@ nl: Normandische cider eau-de-vies
 origins:en: en:france, en:normandy
 protected_name_file_number:en: PGI-FR-01988
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French cider eau-de-vies
 fr: Eau-de-vie de cidre du Maine
@@ -5076,7 +4970,6 @@ nl: Eau-de-vies uit de Maine-streek
 origins:en: en:france, fr:maine-france
 protected_name_file_number:en: PGI-FR-02036
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de Cognac
@@ -5087,7 +4980,6 @@ ciqual_food_code:en: 1023
 ciqual_food_name:en: Spirit made from wine, armagnac or cognac type
 ciqual_food_name:fr: Eau de vie de vin, type armagnac, cognac
 origins:en: en:france
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de Jura
@@ -5108,21 +5000,18 @@ nl: Peren eau-de-vies uit Normandië
 origins:en: en:france, en:normandy
 protected_name_file_number:en: PGI-FR-01980
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de poiré du Maine
 de: Birnenbrand aus Maine
 nl: Peren-eau-de-vies uit de Maine-streek
 origins:en: en:france, fr:maine-france
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin de Bourgogne
 de: Branntwein aus der Bourgogne
 nl: Wijn-eau-de-vies uit de Bourgogne
 origins:en: en:france, en:burgundy
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin de la Marne
@@ -5130,14 +5019,12 @@ de: Branntwein aus Marne, Branntwein aus dem Marne Tal
 origins:en: en:marne
 protected_name_file_number:en: PGI-FR-02029, en: PGI-FR-02029-AM01
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin de Savoie
 de: Branntwein aus Savoie, Branntwein aus Savoyen
 nl: Wijn eau-de-vies uit de Savoie
 origins:en: en:france, en:savoy
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin des Côtes-du-Rhône
@@ -5146,35 +5033,30 @@ nl: Wijn-eau-de-vies uit de Côtes-du-Rhône
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02070
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin originaire d'Aquitaine
 de: Branntwein aus Aquitaine, Branntwein aus Aquitanien
 nl: Wijn-eau-de-vies uit Aquitaine
 origins:en: en:france, en:aquitaine
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin originaire de Franche-Comté
 de: Branntwein aus der Freigrafschaft Burgund, Branntwein aus Franche-Comté
 nl: Wijn eau-de-vies uit de Franche-Comté
 origins:en: en:france, en:franche-comte
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin originaire de Provence
 de: Branntwein aus der Provence
 nl: Wijn-eau-de-vies uit de Provence
 origins:en: en:france, en:provence
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin originaire des Coteaux de la Loire
 de: Branntwein aus dem Loire Tal, Branntwein aus Coteaux de la Loire
 nl: Wijn-eau-de-vies uit de Coteaux de la Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin originaire du Bugey
@@ -5183,14 +5065,12 @@ nl: Wijn-eau-de-vies uit de Bugey
 origins:en: en:bugey
 protected_name_file_number:en: PGI-FR-02068
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin originaire du Centre-Est
 de: Branntwein aus Centre-Est
 nl: Wijn eau-de-vies uit de Centre-Est
 origins:en: en:france, en:center-east-france
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de vin originaire du Languedoc
@@ -5199,14 +5079,12 @@ nl: Wijn eau-de-vies uit de Languedoc
 origins:en: en:france, en:languedoc
 protected_name_file_number:en: PGI-FR-02067
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie des Charentes
 de: Branntwein aus Charente
 nl: Eau-de-vies uit de Charante
 origins:en: en:france, en:charente
-#wikidata:en:
 
 < en: Swiss Eaux-de-vie
 fr: Abricotine
@@ -5241,7 +5119,6 @@ hr: Tuniski eaux-de-vie
 it: Acquaviti tunesine, Acquaviti della Tunesia
 nl: Tunesische eau-de-vies
 # disabled for safety: origins:en: en:Tunisia
-#wikidata:en:
 
 < en: Tunisian Eaux-de-vie
 en: Boukha
@@ -5287,21 +5164,18 @@ nl: Balegemse jenever
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-02008
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Jenever
 nl: Hasseltse jenever, Hasselt
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-02010
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Jenever
 nl: O' de Flander-Oost-Vlaamse Graanjenever
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-02009
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Eaux de vie
 en: Gentian spirit
@@ -5419,14 +5293,12 @@ hr: Portugalski rumovi
 hu: Portugál rumok
 nl: Portugese rum
 pt: Rum português
-#wikidata:en:
 
 < en: Portuguese rums
 pt: Rum da Madeira
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02046
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Rums
 en: Barbadian rum
@@ -5435,7 +5307,6 @@ fr: Rhums barbadiens, Rhum barbadien
 hr: Barbadoški rum
 nl: Barbados rums, Barbados-rum, Barbados rum
 origins:en: en:barbados
-#wikidata:en:
 
 < en: Rums
 en: Cuban rums, Rums from Cuba
@@ -5447,7 +5318,6 @@ nl: Cubaanse rums, Rum uit Cuba
 pl: Rum kubański
 ro: Rom cubanez, Rom Cuba
 # Disabled for safety: origins:en: en:Cuba
-#wikidata:en:
 
 < en: Rums
 en: Dominican rums
@@ -5458,7 +5328,6 @@ hr: Dominikanski rumovi
 hu: Dominikai rumok
 nl: Dominicaanse rums, Dominicaanse rum
 origins:en: en:dominican-republic
-#wikidata:en:
 
 < en: Rums
 en: French rums
@@ -5468,14 +5337,12 @@ fr: Rhums français, Rhum français
 hr: Francuski rumovi
 hu: Francia rumok
 nl: Franse rums, Franse rum
-#wikidata:en:
 
 < en: French rums
 fr: Rhum de sucrerie de la Baie du Galion
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02065
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French rums
 fr: Rhum des Antilles françaises
@@ -5488,7 +5355,6 @@ fr: Rhum des départements français d'outre-mer
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02072
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French rums
 fr: Rhum de la Martinique
@@ -5509,7 +5375,6 @@ fr: Rhum de la Guadeloupe
 origins:en: en:france, en:guadeloupe
 protected_name_file_number:en: PGI-FR-02071
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French rums
 fr: Rhum de la Guyane
@@ -5530,7 +5395,6 @@ pl: Rum haitański
 pt: Rums haitianos, Rums do Haiti
 ro: Rom haitian, Rom Haiti
 # Disabled for safety: origins:en: en:Haiti
-#wikidata:en:
 
 < en: Rums
 en: Jamaican rum, Rums from Jamaica
@@ -5541,7 +5405,6 @@ hu: Jamaicai rumok
 nl: Jamaicaanse rums, Rum uit Jamaica
 ro: Rom jamaican, Rom Jamaica
 # Disabled for safety: origins:en: en:Jamaica
-#wikidata:en:
 # Catégorie:Rhum jamaïcain (Q27310984)
 
 < en: Rums
@@ -5562,7 +5425,6 @@ de: Dunkler Rum
 fr: Rhums ambrés, rhum ambré
 hr: Jantarni rum
 nl: Donkere rums
-#wikidata:en:
 
 < en: Rums
 en: White rums, white rum
@@ -5574,7 +5436,6 @@ hu: Fehér rum
 nl: Blanke rums, Blanke rum
 pl: Rum biały, Biały rum
 ro: Rom alb
-#wikidata:en:
 
 < en: Rums
 en: Brown rum
@@ -5584,13 +5445,11 @@ hr: Smeđi rum
 hu: Barna rum
 nl: Bruine rums, Bruine rum
 pl: Rum brązowy
-#wikidata:en:
 
 < en: Rums
 fr: Rhums industriels, rhum industriel
 de: Industrieller Rum
 nl: Industriële rums
-#wikidata:en:
 
 < en: Rums
 en: old rums, old rum
@@ -5598,7 +5457,6 @@ de: Alter Rum
 fr: Rhums vieux, rhum vieux
 hr: Stari rumovi
 nl: Oude rums, Oude rum
-#wikidata:en:
 
 < en: Spirits
 en: Cachaça, pinga, caninha
@@ -5614,7 +5472,6 @@ de: Getreidebrände
 fr: Eaux-de-vie de céréales
 hr: Žitna žestoka pića
 nl: Graanbrandewijnen
-#wikidata:en:
 
 < en: Grain spirits
 en: German grain spirit
@@ -5628,35 +5485,30 @@ de: Hasetaler Korn
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01925
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German grain spirit
 de: Sendenhorster Korn
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01922
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German grain spirit
 de: Münsterländer Korn
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01921
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German grain spirit
 de: Haselünner Korn
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01924
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German grain spirit
 de: Emsländer Korn
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01923
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German grain spirit
 de: Doppelkorn
@@ -5692,7 +5544,6 @@ fr: Vodka aromatisée, vodka parfumée
 hr: Votka s okusom
 hu: Ízesített vodka
 it: Vodka aromatizzato, Vodka con aroma
-#wikidata:en:
 
 < en: Flavored vodka
 en: Nastoyka
@@ -5710,7 +5561,6 @@ nl: Wodkas uit Litouwen, Litouwse wodkas
 pl: Wódki litewskie, Litewska wódka
 ru: Литовская водка
 # disabled for safety: origins:en: en:Lithuania
-#wikidata:en:
 
 < en: Lithuanian vodka
 < en: flavoured vodka
@@ -5719,7 +5569,6 @@ lt: Originali lietuviška degtinė
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-01871
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Vodka
 en: Polish vodkas
@@ -5734,14 +5583,12 @@ lt: Lenkiška degtinė
 nl: Poolse wodkas, Poolse wodka
 pl: Polskie wódki
 origins:en: en:poland
-#wikidata:en:
 
 < en: Polish vodkas
 pl: Polska wódka
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-01967
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Polish vodkas
 en: Herbal vodka from the North Podlasie Lowland aromatised with an extract of bison grass
@@ -5749,7 +5596,6 @@ pl: Żubrówka, Wódka ziołowa z Niziny Północnopodlaskiej aromatyzowana ekst
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-01966
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Vodka
 en: Russian vodkas
@@ -5767,7 +5613,6 @@ ru: Русская водка
 zh: 俄罗斯伏特加, 俄罗斯伏特加酒
 origins:en: en:russia
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Vodka
 en: Ukrainian vodkas
@@ -5781,7 +5626,6 @@ lt: Ukrainietiška degtinė
 nl: Ukraïnse wodkas
 pl: Ukraińska wódka
 # disabled for safety: origins:en: en:Ukraine
-#wikidata:en:
 
 < en: Vodka
 en: Estonian vodkas
@@ -5796,7 +5640,6 @@ nl: Estse wodkas
 origins:en: en:estonia
 protected_name_file_number:en: PGI-EE-01971
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Vodka
 en: Latvian vodkas
@@ -5811,7 +5654,6 @@ nl: Letse wodkas
 pl: Łotewska wódka
 ru: Латвийская водка
 # disabled for safety: origins:en: en:Latvia
-#wikidata:en:
 
 
 < en: Vodka
@@ -5833,7 +5675,6 @@ zh: 挪威伏特加, Norwegian Vodka
 origins:en: en:norway
 protected_name_file_number:en: PGI-NO-02240
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Vodka
 en: Czech vodkas
@@ -5849,14 +5690,12 @@ nl: Tsjechische wodkas
 pl: Czeska wódka
 ru: Чешская водка
 # disabled for safety: origins:en: en:Czech Republic
-#wikidata:en:
 
 < en: Vodka
 sv: Svensk Vodka, Swedish Vodka
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-01926
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Vodka
 fi: Suomalainen Vodka, Finsk Vodka, Vodka of Finland
@@ -5864,7 +5703,6 @@ hu: Finn vodka
 origins:en: en:finland
 protected_name_file_number:en: PGI-FI-02040
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Vodka
 en: Kazak Vodkas
@@ -5897,7 +5735,6 @@ wikidata:en: Q959362
 < en: Wine-based drinks
 en: Spritz cocktails
 fr: Cocktails spritz
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: Whiskey-based cocktail
@@ -5909,7 +5746,6 @@ nl: Whiskycocktail
 agribalyse_food_code:en: 1013
 ciqual_food_code:en: 1013
 ciqual_food_name:en: Whiskey-based cocktail
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: Wine-based drinks
@@ -5924,7 +5760,6 @@ agribalyse_food_code:en: 1007
 ciqual_food_code:en: 1007
 ciqual_food_name:en: Wine-based aperitif
 ciqual_food_name:fr: Apéritif à base de vin ou vermouth
-#wikidata:en:
 
 < en: Wine-based drinks
 en: Vermouth
@@ -5938,7 +5773,6 @@ agribalyse_food_code:en: 1007
 ciqual_food_code:en: 1007
 ciqual_food_name:en: Wine or fortified wine-based aperitif
 ciqual_food_name:fr: Apéritif à base de vin ou vermouth
-#wikidata:en:
 
 < en: Vermouth
 en: Red Vermouth
@@ -5954,7 +5788,6 @@ fr: Apéritif anisé sans alcool
 ciqual_food_code:en: 1011
 ciqual_food_name:en: Pastis (anise-flavoured spirit)
 ciqual_food_name:fr: Apéritif anisé sans alcool
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: Bulgarian wines spirit
@@ -5964,70 +5797,60 @@ bg: Ямболска гроздова ракия, Гроздова ракия о
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01867
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Карнобатска гроздова ракия, Гроздова ракия от Карнобат, Karnobatska grozdova rakya, Grozdova rakya ot Karnobat
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01865
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Гроздова ракия от Търговище, Grozdova rakya ot Targovishte
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01864
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Сухиндолска гроздова ракия, Гроздова ракия от Сухиндол, Suhindolska grozdova rakya, Grozdova rakya from Suhindol
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01860
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Сунгурларска гроздова ракия, Гроздова ракия от Сунгурларе, Sungurlarska grozdova rakya, Grozdova rakya from Sungurlare
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01855
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Стралджанска Мускатова ракия, Мускатова ракия от Стралджа, Straldjanska Muscatova rakya, Muscatova rakya from Straldja
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01857
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Сливенска перла (Сливенска гроздова ракия, Гроздова ракия от Сливен), Slivenska perla (Slivenska grozdova rakya, Grozdova rakya from Sliven)
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01856
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Поморийска гроздова ракия, Гроздова ракия от Поморие, Pomoriyska grozdova rakya, Grozdova rakya from Pomorie
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01858
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Карловска гроздова ракия, Гроздова Ракия от Карлово, Karlovska grozdova rakya, Grozdova Rakya from Karlovo
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01861
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Bulgarian wines spirit
 bg: Бургаска Мускатова ракия, Мускатова ракия от Бургас, Bourgaska Muscatova rakya, Muscatova rakya from Bourgas
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-01859
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: Ciders
@@ -6068,35 +5891,30 @@ en: Traditional Welsh Cider
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-01251
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Ciders
 en: Gloucestershire cider
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0290
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Ciders
 en: Worcestershire cider
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0291
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Ciders
 en: Herefordshire cider
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0292
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Ciders
 fr: Cidre Cotentin, Cotentin
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02206
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Ciders
 en: Sparkling ciders, sparkling cider
@@ -6119,7 +5937,6 @@ agribalyse_food_code:en: 5006
 ciqual_food_code:en: 5006
 ciqual_food_name:en: Cider, dry
 ciqual_food_name:fr: Cidre brut
-#wikidata:en:
 
 < en: Ciders
 en: Half-dry ciders
@@ -6131,7 +5948,6 @@ agribalyse_food_code:en: 5021
 ciqual_food_code:en: 5021
 ciqual_food_name:en: Cider, half-dry
 ciqual_food_name:fr: Cidre bouché demi-sec
-#wikidata:en:
 
 < en: Ciders
 en: Sweet ciders, sweet cider
@@ -6155,7 +5971,6 @@ hr: Ružičasti cideri
 it: Cidri rosati, Cidro rosato, Cidri rosè, Cidro rosè, Cidri rosé, Cidro rosé
 nl: Roséciders
 pl: Cydr różowy
-#wikidata:en:
 
 < en: Ciders
 en: Flavoured ciders
@@ -6190,14 +6005,12 @@ fr: Cidre de Bretagne, Cidre Breton
 origins:en: en:france, en:brittany
 protected_name_file_number:en: PGI-FR-0088
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Ciders
 fr: Cidre de Normandie, Cidre Normand
 origins:en: en:france, en:normandy
 protected_name_file_number:en: PGI-FR-0089
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: Perry, pear cider
@@ -6218,7 +6031,6 @@ agribalyse_food_code:en: 1018
 ciqual_food_code:en: 1018
 ciqual_food_name:en: Kir (Cocktail of white wine with red fruit liqueur)
 ciqual_food_name:fr: Kir (au vin blanc)
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: Schnapps
@@ -6310,7 +6122,6 @@ agribalyse_food_code:en: 1012
 ciqual_food_code:en: 1012
 ciqual_food_name:en: Rum-based cocktail
 ciqual_food_name:fr: Cocktail à base de rhum
-#wikidata:en:
 
 < en: Rum-based cocktail
 en: Daiquiri
@@ -6340,7 +6151,6 @@ cs: Tuzemský, Tuzemák
 
 < en: Non-alcoholic beverages
 fr: Daïquiri sans alcool
-#wikidata:en:
 
 < en: Alcoholic beverages
 en: Liqueurs
@@ -6393,14 +6203,12 @@ de: Bayerischer Blutwurz
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02581
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German liqueur
 de: Hüttentee
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01954
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German liqueur
 de: Blutwurz
@@ -6414,66 +6222,56 @@ de: Bayerischer Kräuterlikör
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01900
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German liqueur
 de: Ettaler Klosterlikör
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02060
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German liqueur
 de: Benediktbeurer Klosterlikör
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02002
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German liqueur
 de: Hamburger Kümmel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01972
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German liqueur
 de: Münchener Kümmel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01992
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German liqueur
 de: Chiemseer Klosterlikör
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02020
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 en: Italian liqueurs, Liqueurs from Italy
 hu: Olasz likőrök
-#wikidata:en:
 
 < en: Italian liqueurs
 it: Nocino di Modena
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01879
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 en: Portuguese liqueur, Liqueurs from Portugal
 hu: Portugál likőrök
-#wikidata:en:
 
 < en: Portuguese liqueur
 pt: Poncha da Madeira
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02044
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 en: Herbal liqueur, Kräuterlikör
@@ -6503,7 +6301,6 @@ hu: Kávélikőr, Kávés likőr
 < en: Liqueurs
 en: Croatian liqueur
 hu: Horvát likőr
-#wikidata:en:
 
 < en: Croatian liqueur
 en: pelinkovac
@@ -6511,19 +6308,16 @@ hr: pelinkovac, Hrvatski pelinkovac
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-01959
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 en: French liqueur, Liqueurs from France
 hu: Francia likőr
-#wikidata:en:
 
 < en: French liqueur
 fr: Ratafia de Champagne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02062, PGI-FR-02062-AM01
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 fr: Génépi des Alpes
@@ -6531,47 +6325,40 @@ it: Genepì delle Alpi
 origins:en: en:france, en:italy
 protected_name_file_number:en: PGI-FR+IT-01909
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 en: Italian liqueur
 hu: Olasz likőr
-#wikidata:en:
 
 < en: Italian liqueur
 it: Genepì del Piemonte
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01849
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian liqueur
 it: Liquore di limone della Costa d'Amalfi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01907
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian liqueur
 it: Mirto di Sardegna
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01853
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian liqueur
 it: Liquore di limone di Sorrento
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01852
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian liqueur
 it: Genepì della Valle d'Aosta
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01910
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 en: Spanish liqueur, Liqueurs from Spain
@@ -6581,14 +6368,12 @@ hr: Španjolski liker
 hu: Spanyol likőr
 it: Liquore spagnolo
 nl: Spaanse Likeur
-#wikidata:en:
 
 < en: Spanish liqueur
 es: Cantueso Alicantino
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01892
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Coffee liqueur
 < en: Spanish liqueur
@@ -6596,7 +6381,6 @@ es: Licor café de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01911
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Herbal liqueur
 < en: Spanish liqueur
@@ -6604,14 +6388,12 @@ es: Licor de hierbas de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01912
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish liqueur
 es: Palo de Mallorca
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01868
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish liqueur
 ca: Ratafia
@@ -6619,7 +6401,6 @@ es: Ratafia catalana
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01945
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 en: Raspberry liqueurs
@@ -6637,28 +6418,24 @@ wikidata:en: Q968019
 < en: Blackcurrant liqueur
 en: French Crème de cassis
 fr: Crèmes de cassis françaises
-#wikidata:en:
 
 < en: French Crème de cassis
 fr: Cassis de Saintonge
 origins:en: en:saintonge
 protected_name_file_number:en: PGI-FR-01986
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Crème de cassis
 fr: Cassis de Bourgogne
 origins:en: en:france, en:burgundy
 protected_name_file_number:en: PGI-FR-02075
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Crème de cassis
 fr: Cassis de Dijon
 origins:en: en:dijon
 protected_name_file_number:en: PGI-FR-01991
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Liqueurs
 fr: Crèmes de pèche
@@ -6710,35 +6487,30 @@ wikidata:en: Q496934
 < en: Liqueurs
 en: Austrian liqueur, Liqueurs from Austria
 origins:en: en:austria
-#wikidata:en:
 
 < en: Austrian liqueur
 de: Jägertee, Jagertee, Jagatee
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-01917
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Austrian liqueur
 de: Wachauer Marillenlikör
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-02037
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Austrian liqueur
 de: Steinfelder Magenbitter
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-01916
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Austrian liqueur
 de: Mariazeller Magenlikör
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-01920
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Non-alcoholic beverages
 en: Soft drinks
@@ -7564,7 +7336,6 @@ agribalyse_food_code:en: 18018
 ciqual_food_code:en: 18018
 ciqual_food_name:en: Cola, with sugar
 ciqual_food_name:fr: Cola, sucré
-#wikidata:en:
 
 < en: Colas
 en: Cola with sugar and artificial sweetener, Cola with sugar and artificial sweeteners
@@ -7602,7 +7373,6 @@ pt: Cola sem cafeína
 ro: Cola fără cafeină
 tr: Kafeinsiz kola
 zh: 无咖啡因可乐
-#wikidata:en:
 
 < en: Cola sodas without caffeine
 < en: Cola with sugar
@@ -7811,7 +7581,6 @@ it: Bevande all'Aloe Vera
 lt: Aloe Vera gėrimai
 nl: Aloe Vera sappen
 pl: Napoje z aloesem, Napoje aloesowe
-#wikidata:en:
 
 < en: Fruit and vegetable juices
 en: Ginger juices
@@ -7928,7 +7697,6 @@ it: Frappè alla frutta, Milkshake alla frutta, Smoothie alla frutta
 lt: Vaisių glotnutis, vaisinis glotnutis
 nl: Fruitsmoothies
 pl: Smoothie owocowe, Owocowe smoothie
-#wikidata:en:
 
 < en: Smoothies
 en: Kiwifruit apple and pineapple smoothies
@@ -8086,7 +7854,6 @@ hu: Klementinlevek, Klementinlé
 it: Succo di mandarancio, Succo di clementina
 lt: Klementinų sultys
 nl: Clementinesappen, Clementinesap
-#wikidata:en:
 
 < en: Clementine juices
 en: Squeezed clementine juices, Pure clementine juice
@@ -8493,7 +8260,6 @@ de: Pink Grapefruit Säfte
 fr: Jus de pamplemousse rose, Jus de pamplemousses roses
 hr: Sokovi od ružičastog grejpa
 nl: Roze grapefruitsappen, Roze grapefruitsap
-#wikidata:en:
 
 #Comment:en:edited out as there are no mango juice products
 #<en:Fruit juices
@@ -8790,7 +8556,6 @@ nl: Perzikensappen, Perzikensap
 pl: Soki brzoskwiniowe, Soki z brzoskwini
 tr: Şeftali suları
 zh: 桃子汁, 桃汁
-#wikidata:en:
 
 < en: Fruit juices from concentrate
 < en: Peach juices
@@ -9219,7 +8984,6 @@ pl: Nektary jabłkowe
 pt: Néctares de maçã
 ru: Нектары яблочные, Яблочные нектары, Нектар яблочный, Яблочный нектар
 zh: 苹果花蜜
-#wikidata:en:
 
 < en: Apple nectars
 < en: Carbonated drinks
@@ -9267,7 +9031,6 @@ pt: Néctares de papaia
 ciqual_food_code:en: 2045
 ciqual_food_name:en: Papaya nectar
 ciqual_food_name:fr: Nectar de papaye
-#wikidata:en:
 
 < en: Fruit nectars
 en: Banana nectars
@@ -9303,7 +9066,6 @@ lt: Mėlynių nektarai, Mėlynių nektaras
 nl: Blauwe bessennectars, Blauwe bessennectar
 pt: Néctares de mirtilo
 zh: 蓝莓花蜜
-#wikidata:en:
 
 < en: Fruit nectars
 en: Grape nectars
@@ -9318,7 +9080,6 @@ lt: Vynuogių nektarai, Vynuogių nektaras
 nl: Druivennectars, Druivennectar
 pt: Néctares de uva
 zh: 葡萄花蜜
-#wikidata:en:
 
 < en: Fruit nectars
 en: Grapefruit nectars
@@ -9331,7 +9092,6 @@ it: Nettare di pompelmo
 lt: Greipfrutų nektarai, Greipfrutų nektaras
 nl: Grapefruitnectars, Grapefruitnectar
 pl: Nektary grejpfrutowe, Nektary z grejpfruta
-#wikidata:en:
 
 < en: Fruit nectars
 en: Guava nectars
@@ -9376,7 +9136,6 @@ agribalyse_food_code:en: 2370
 ciqual_food_code:en: 2370
 ciqual_food_name:en: Mango nectar
 ciqual_food_name:fr: Nectar de mangue
-#wikidata:en:
 
 < en: Fruit nectars
 en: Melon nectars
@@ -9390,7 +9149,6 @@ lt: Melionų nektarai, melionų nektaras
 nl: Meloennectars, Meloennectar, Meloenennectar
 pl: Nektary z melona
 zh: 甜瓜花蜜
-#wikidata:en:
 
 < en: Fruit nectars
 en: Multifruit nectars, Mixed fruits nectars
@@ -9410,7 +9168,6 @@ agribalyse_food_code:en: 2061
 ciqual_food_code:en: 2061
 ciqual_food_name:en: Mixed fruits nectar
 ciqual_food_name:fr: Nectar multifruit, standard
-#wikidata:en:
 
 < en: Fruit nectars
 en: Multivitamin mixed fruits nectars
@@ -9419,7 +9176,6 @@ agribalyse_food_code:en: 2060
 ciqual_food_code:en: 2060
 ciqual_food_name:en: Mixed fruits nectar, multivitamin
 ciqual_food_name:fr: Nectar multifruit, multivitaminé
-#wikidata:en:
 
 < en: Fruit nectars
 en: Orange nectars
@@ -9442,7 +9198,6 @@ ciqual_food_name:en: Orange nectar
 ciqual_food_name:fr: Nectar d'orange
 #expected_ingredients:en: en:orange
 opposite:en: en:orange juices
-#wikidata:en:
 
 < en: Fruit nectars
 en: Passion fruit nectars, Passionfruit nectars
@@ -9459,7 +9214,6 @@ pt: Néctares de maracujá
 ciqual_food_code:en: 2365
 ciqual_food_name:en: Passion fruit nectar
 ciqual_food_name:fr: Nectar de fruit de la passion ou maracuja
-#wikidata:en:
 
 < en: Passion fruit nectars
 en: Fresh passion fruit juices
@@ -9508,7 +9262,6 @@ agribalyse_food_code:en: 2054
 ciqual_food_code:en: 2054
 ciqual_food_name:en: Pear nectar
 ciqual_food_name:fr: Nectar de poire
-#wikidata:en:
 
 < en: Fruit nectars
 en: Strawberry nectars
@@ -9522,7 +9275,6 @@ lt: Braškių nektarai, braškių nektaras
 nl: Aardbeiennectar
 pl: Nektary truskawkowe
 pt: Néctares de morango
-#wikidata:en:
 
 < en: Fruit nectars
 en: Raspberry nectars
@@ -9534,7 +9286,6 @@ it: Nettare di lamponi
 lt: Aviečių nektarai, aviečių nektaras
 pl: Nektary malinowe
 pt: Néctares de framboesa
-#wikidata:en:
 
 < en: Fruit nectars
 en: Cherry nectars
@@ -9547,7 +9298,6 @@ it: Nettare di ciliegia
 lt: Vyšnių nektarai, vyšnių nektaras
 pl: Nektary wiśniowe
 pt: Néctares de cereja
-#wikidata:en:
 
 < en: Fruit nectars
 en: Pineapple nectars
@@ -9563,7 +9313,6 @@ lt: Ananasų nektarai, ananasų nektaras
 nl: Ananasnectars, Ananasnectar
 pl: Nektary ananasowe
 pt: Néctares de ananás, néctares de abacaxi
-#wikidata:en:
 
 < en: Fruit nectars
 en: Kiwifruit nectars, Kiwi nectars
@@ -9574,7 +9323,6 @@ hr: Nektari kivija
 hu: Kivinektárok
 it: Nettari di kiwi, nettare di kiwi
 pl: Nektary z kiwi
-#wikidata:en:
 
 < en: Fruit nectars
 en: Pomegranate nectars
@@ -9588,7 +9336,6 @@ lt: Granatų vaisių nektarai, granatų vaisių nektaras
 nl: Granaatappelnectars, Granaatappelnectar
 pl: Nektary z granatu
 pt: Néctares de romã
-#wikidata:en:
 
 < en: Fruit nectars
 en: Tangerine nectars
@@ -9600,7 +9347,6 @@ hu: Mandarinnektárok
 it: Nettari di mandarino, nettare di mandarino
 lt: Mandarinų nektarai, mandarinų nektaras
 nl: Mandarijnennectars, Mandarijnennectar
-#wikidata:en:
 
 < en: Plant-based beverages
 < en: Vegetable-based foods and beverages
@@ -12732,70 +12478,60 @@ fr: Grappa de la Vallée d’Aoste
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02479
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Grappa siciliana, Grappa di Sicilia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01955
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Grappa
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01844
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Südtiroler Grappa, Grappa dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01949
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Grappa di Barolo
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01970
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Grappa trentina, Grappa del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01952
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Grappa veneta, Grappa del Veneto
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01950
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Grappa friulana, Grappa del Friuli
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01948
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Grappa piemontese, Grappa del Piemonte
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01956
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian grape marc spirit or grape marc
 it: Grappa lombarda, Grappa della Lombardia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01951
 protected_name_type:en: gi
-#wikidata:en:
 
 < fr: Marc
 en: French grape marc spirit or grape marc
@@ -12805,7 +12541,6 @@ fr: Marc de Champagne, Eau-de-vie de marc de Champagne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02063, PGI-FR-02063-AM01
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French grape marc spirit or grape marc
 fr: Marc du Jura
@@ -13929,7 +13664,6 @@ wikidata:en: Q2826539
 fr: Ain
 origins:en: en:france
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Ajaccio
@@ -13955,13 +13689,11 @@ wikidata:en: Q453673
 fr: Aloxe-Corton premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton
 fr: Aloxe-Corton Clos des Maréchaudes, Aloxe-Corton premier cru Clos des Maréchaudes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Clos des Maréchaudes
 fr: Aloxe-Corton premier cru Clos des Maréchaudes rouge
@@ -13979,7 +13711,6 @@ wikidata:en: Q29640419
 fr: Aloxe-Corton Clos du Chapître, Aloxe-Corton premier cru Clos du Chapître
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Clos du Chapître
 fr: Aloxe-Corton premier cru Clos du Chapitre rouge
@@ -13989,7 +13720,6 @@ wikidata:en: Q29640422
 fr: Aloxe-Corton La Coutière, Aloxe-Corton premier cru La Coutière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton La Coutière
 fr: Aloxe-Corton premier cru La Coutière rouge
@@ -14003,13 +13733,11 @@ wikidata:en: Q29640423
 fr: Aloxe-Corton La Maréchaude, Aloxe-Corton premier cru La Maréchaude
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton
 fr: Aloxe-Corton La Toppe au Vert, Aloxe-Corton premier cru La Toppe au Vert
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton La Toppe au Vert
 fr: Aloxe-Corton premier cru La Toppe au Vert rouge
@@ -14019,7 +13747,6 @@ wikidata:en: Q29640429
 fr: Aloxe-Corton Les Chaillots, Aloxe-Corton premier cru Les Chaillots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Chaillots
 fr: Aloxe-Corton premier cru Les Chaillots rouge
@@ -14029,7 +13756,6 @@ wikidata:en: Q29640431
 fr: Aloxe-Corton Les Fournières, Aloxe-Corton premier cru Les Fournières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Fournières
 fr: Aloxe-Corton premier cru Les Fournières rouge
@@ -14039,7 +13765,6 @@ wikidata:en: Q29640433
 fr: Aloxe-Corton Les Guérets, Aloxe-Corton premier cru Les Guérets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Guérets
 fr: Aloxe-Corton premier cru Les Guérets blanc
@@ -14051,7 +13776,6 @@ wikidata:en: Q29640434
 fr: Aloxe-Corton Les Maréchaudes, Aloxe-Corton premier cru Les Maréchaudes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Maréchaudes
 fr: Aloxe-Corton premier cru Les Maréchaudes rouge
@@ -14065,7 +13789,6 @@ wikidata:en: Q29640438
 fr: Aloxe-Corton Les Moutottes, Aloxe-Corton premier cru Les Moutottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Moutottes
 fr: Aloxe-Corton premier cru Les Moutottes blanc
@@ -14079,7 +13802,6 @@ wikidata:en: Q29640441
 fr: Aloxe-Corton Les Paulands, Aloxe-Corton premier cru Les Paulands
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Paulands
 fr: Aloxe-Corton Les Paulands blanc
@@ -14093,7 +13815,6 @@ wikidata:en: Q29640443
 fr: Aloxe-Corton Les Petites Folières, Aloxe-Corton premier cru Les Petites Folières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Petites Folières
 fr: Aloxe-Corton premier cru Les Petites Folières blanc
@@ -14103,7 +13824,6 @@ wikidata:en: Q29640444
 fr: Aloxe-Corton Les Valozières, Aloxe-Corton premier cru Les Valozières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Valozières
 fr: Aloxe-Corton premier cru Les Valozières rouge
@@ -14117,7 +13837,6 @@ wikidata:en: Q29640446
 fr: Aloxe-Corton Les Vercots, Aloxe-Corton premier cru Les Vercots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Aloxe-Corton Les Vercots
 fr: Aloxe-Corton premier cru Les Vercots rouge
@@ -14156,7 +13875,6 @@ origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0349
 protected_name_type:en: pdo
 wikidata:en: Q436721
-#wikidata:en:
 
 < fr: Alsace Grand Cru
 fr: Alsace Grand Cru Altenberg de Bergheim, Altenberg de Bergheim
@@ -14511,7 +14229,6 @@ wikidata:en: Q3442168
 < en: Wines from France
 fr: Vin d'Alsace
 origins:en: en:france
-#wikidata:en:
 
 < fr: Vin d'Alsace
 fr: Alsace Pinot gris
@@ -14535,12 +14252,10 @@ origins:en: en:france, en:loire-valley
 < en: Wines from France
 fr: Anjou Coteaux de la Loire, Anjou Coteaux de la Loire Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Anjou-Villages Brissac, Anjou-Villages Brissac Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Arbois Pupillin mousseux
@@ -14574,31 +14289,26 @@ origins:en: en:france, en:burgundy
 fr: Auxey-Duresses premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses
 fr: Auxey-Duresses Bas des Duresses, Auxey-Duresses Bas des Duresses premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses
 fr: Auxey-Duresses Climat du Val, Auxey-Duresses premier cru Climat du Val
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses
 fr: Auxey-Duresses Clos du Val, Auxey-Duresses premier cru Clos du Val
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses
 fr: Auxey-Duresses La Chapelle, Auxey-Duresses premier cru La Chapelle
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses La Chapelle
 fr: Auxey-Duresses premier cru La Chapelle blanc
@@ -14618,7 +14328,6 @@ fr: Auxey-Duresses premier cru La Chapelle rouge AOC - AOP
 fr: Auxey-Duresses Les Bréterins, Auxey-Duresses premier cru Les Bréterins
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses Les Bréterins
 fr: Auxey-Duresses premier cru Les Bréterins rouge
@@ -14638,7 +14347,6 @@ fr: Auxey-Duresses premier cru Les Bréterins blanc AOC - AOP
 fr: Auxey-Duresses Les Duresses, Auxey-Duresses premier cru Les Duresses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses Les Duresses
 fr: Auxey-Duresses premier cru Les Duresses blanc
@@ -14658,19 +14366,16 @@ fr: Auxey-Duresses premier cru Les Duresses rouge AOC - AOP
 fr: Auxey-Duresses Les Écusseaux, Auxey-Duresses premier cru Les Écusseaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses
 fr: Auxey-Duresses Les Grands Champs, Auxey-Duresses premier cru Les Grands Champs
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses
 fr: Auxey-Duresses premier cru Reugne, Auxey-Duresses Reugne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Auxey-Duresses premier cru Reugne
 fr: Auxey-Duresses premier cru Reugne blanc
@@ -14694,7 +14399,6 @@ protected_name_type:en: pgi
 < en: Wines from France
 fr: Bandol, Vin de Bandol
 origins:en: en:france
-#wikidata:en:
 
 < en: White wines
 < fr: Bandol
@@ -14720,7 +14424,6 @@ wikidata:en: Q1018887
 < en: Wines from France
 fr: Béarn, Béarn Bellocq
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Beaujolais
@@ -14746,19 +14449,16 @@ origins:en: en:france, en:beaujolais
 fr: Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune A l'Écu, Beaune premier cru A l'Écu
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune premier cru
 fr: Beaune premier cru A l'Ecu rouge
@@ -14766,7 +14466,6 @@ wikidata:en: Q42945923
 
 < fr: Beaune premier cru
 fr: Beaune premier cru A l'Ecu rouge AOC - AOP
-#wikidata:en:
 
 < fr: Beaune premier cru
 fr: Beaune premier cru A l'Ecu blanc
@@ -14779,7 +14478,6 @@ fr: Beaune premier cru A l'Ecu blanc AOC - AOP
 fr: Beaune Aux Coucherias, Beaune premier cru Aux Coucherias
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune premier cru
 fr: Beaune premier cru Aux Coucherias rouge
@@ -14787,7 +14485,6 @@ wikidata:en: Q42945926
 
 < fr: Beaune premier cru
 fr: Beaune premier cru Aux Coucherias rouge AOC - AOP
-#wikidata:en:
 
 < fr: Beaune premier cru
 fr: Beaune premier cru Aux Coucherias blanc
@@ -14795,19 +14492,16 @@ wikidata:en: Q42945925
 
 < fr: Beaune premier cru
 fr: Beaune premier cru Aux Coucherias blanc AOC - AOP
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune Aux Cras, Beaune premier cru Aux Cras
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune Belissand, Beaune premier cru Belissand
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Belissand rouge
@@ -14822,7 +14516,6 @@ wikidata:en: Q43021210
 fr: Beaune Blanches Fleurs, Beaune premier cru Blanches Fleurs
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Blanches Fleurs blanc
@@ -14837,7 +14530,6 @@ wikidata:en: Q42945944
 fr: Beaune Champs Pimont, Beaune premier cru Champs Pimont
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Champs Pimont blanc
@@ -14852,7 +14544,6 @@ wikidata:en: Q42945948
 fr: Beaune Clos de la Féguine, Beaune premier cru Clos de la Féguine
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Clos de la Feguine rouge
@@ -14867,7 +14558,6 @@ wikidata:en: Q42945949
 fr: Beaune Clos de la Mousse, Beaune premier cru Clos de la Mousse
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Clos de la Mousse blanc
@@ -14882,7 +14572,6 @@ wikidata:en: Q42950684
 fr: Beaune Clos de l'Écu, Beaune premier cru Clos de l'Écu
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Clos de l'Ecu rouge
@@ -14897,7 +14586,6 @@ wikidata:en: Q42950683
 fr: Beaune Clos des Avaux, Beaune premier cru Clos des Avaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Clos des Avaux rouge
@@ -14912,7 +14600,6 @@ wikidata:en: Q42950680
 fr: Beaune Clos des Ursules, Beaune premier cru Clos des Ursules
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Clos des Ursules blanc
@@ -14927,7 +14614,6 @@ wikidata:en: Q42950675
 fr: Beaune Clos du Roi, Beaune premier cru Clos du Roi
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Clos du Roi rouge
@@ -14942,7 +14628,6 @@ wikidata:en: Q42950673
 fr: Beaune Clos Saint-Landry, Beaune premier cru Clos Saint-Landry
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Clos Saint-Landry blanc
@@ -14957,7 +14642,6 @@ wikidata:en: Q42950666
 fr: Beaune En Genêt, Beaune premier cru En Genêt
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru En Genêt blanc
@@ -14972,7 +14656,6 @@ wikidata:en: Q42950663
 fr: Beaune En l'Orme, Beaune premier cru En l'Orme
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru En l'Orme rouge
@@ -14987,7 +14670,6 @@ wikidata:en: Q42950661
 fr: Beaune La Mignotte, Beaune premier cru La Mignotte
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru La Mignotte rouge
@@ -15002,7 +14684,6 @@ wikidata:en: Q42950657
 fr: Beaune Le Bas des Teurons, Beaune premier cru Le Bas des Teurons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Le Bas des Teurons rouge
@@ -15017,7 +14698,6 @@ wikidata:en: Q42866159
 fr: Beaune Le Clos des Mouches, Beaune premier cru Le Clos des Mouches
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Le Clos des Mouches blanc
@@ -15032,7 +14712,6 @@ wikidata:en: Q42866163
 fr: Beaune Les Aigrots, Beaune premier cru Les Aigrots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Aigrots rouge
@@ -15047,7 +14726,6 @@ wikidata:en: Q42866165
 fr: Beaune Les Avaux, Beaune premier cru Les Avaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Avaux rouge
@@ -15062,7 +14740,6 @@ wikidata:en: Q42866168
 fr: Beaune Les Boucherottes, Beaune premier cru Les Boucherottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Boucherottes blanc
@@ -15077,7 +14754,6 @@ wikidata:en: Q42866171
 fr: Beaune Les Bressandes, Beaune premier cru Les Bressandes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Bressandes rouge
@@ -15092,7 +14768,6 @@ wikidata:en: Q42866175
 fr: Beaune Les Cent Vignes, Beaune premier cru Les Cent Vignes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Cents Vignes blanc
@@ -15107,7 +14782,6 @@ wikidata:en: Q42866179
 fr: Beaune Les Chouacheux, Beaune premier cru Les Chouacheux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Chouacheux blanc
@@ -15122,7 +14796,6 @@ wikidata:en: Q42866182
 fr: Beaune Les Épenotes, Beaune premier cru Les Épenotes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Epenotes blanc
@@ -15136,7 +14809,6 @@ wikidata:en: Q42866188
 fr: Beaune Les Fèves, Beaune premier cru Les Fèves
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Fèves blanc
@@ -15151,7 +14823,6 @@ wikidata:en: Q42866190
 fr: Beaune Les Grèves, Beaune premier cru Les Grèves
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Grèves blanc
@@ -15166,7 +14837,6 @@ wikidata:en: Q42866193
 fr: Beaune Les Marconnets, Beaune premier cru Les Marconnets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Marconnets blanc
@@ -15180,7 +14850,6 @@ wikidata:en: Q42866197
 fr: Beaune Les Montrevenots, Beaune premier cru Les Montrevenots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Montrevenots rouge
@@ -15195,7 +14864,6 @@ wikidata:en: Q42866198
 fr: Beaune Les Perrières, Beaune premier cru Les Perrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Perrières blanc
@@ -15210,7 +14878,6 @@ wikidata:en: Q42866202
 fr: Beaune Les Reversées, Beaune premier cru Les Reversées
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Reversés blanc
@@ -15225,7 +14892,6 @@ wikidata:en: Q42866206
 fr: Beaune Les Sceaux, Beaune premier cru Les Sceaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Sceaux blanc
@@ -15240,7 +14906,6 @@ wikidata:en: Q42866208
 fr: Beaune Les Seurey, Beaune premier cru Les Seurey
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Seurey rouge
@@ -15255,7 +14920,6 @@ wikidata:en: Q42866209
 fr: Beaune Les Sizies, Beaune premier cru Les Sizies
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Sizies rouge
@@ -15270,7 +14934,6 @@ wikidata:en: Q42866215
 fr: Beaune Les Teurons, Beaune premier cru Les Teurons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Teurons blanc
@@ -15285,7 +14948,6 @@ wikidata:en: Q42866219
 fr: Beaune Les Toussaints, Beaune premier cru Les Toussaints
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Toussaints blanc
@@ -15300,7 +14962,6 @@ wikidata:en: Q42866222
 fr: Beaune Les Tuvilains, Beaune premier cru Les Tuvilains
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Tuvilains blanc
@@ -15314,7 +14975,6 @@ wikidata:en: Q42866225
 fr: Beaune Les Vignes Franches, Beaune premier cru Les Vignes Franches
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Les Vignes Franches blanc
@@ -15329,7 +14989,6 @@ wikidata:en: Q42866228
 fr: Beaune Montée Rouge, Beaune premier cru Montée Rouge
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Montée Rouge blanc
@@ -15344,7 +15003,6 @@ wikidata:en: Q42866231
 fr: Beaune Pertuisots, Beaune premier cru Pertuisots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Pertuisots rouge
@@ -15359,7 +15017,6 @@ wikidata:en: Q42866232
 fr: Beaune Sur les Grèves, Beaune premier cru Sur les Grèves
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Sur les Grèves blanc
@@ -15374,7 +15031,6 @@ wikidata:en: Q42950653
 fr: Beaune Sur les Grèves-Clos Sainte-Anne, Beaune premier cru Sur les Grèves-Clos Sainte-Anne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Beaune
 fr: Beaune premier cru Sur les Grèves - Clos Saint-Anne42866243
@@ -15407,7 +15063,6 @@ wikidata:en: Q857701
 fr: Blagny, Blagny Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Blagny
 fr: Blagny Hameau de Blagny, Blagny premier cru Hameau de Blagny
@@ -15425,7 +15080,6 @@ wikidata:en: Q42866368
 fr: Blagny La Jeunelotte, Blagny premier cru La Jeunelotte
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Blagny
 fr: Blagny La Pièce sous le Bois, Blagny premier cru La Pièce sous le Bois
@@ -15476,7 +15130,6 @@ wikidata:en: Q42866698
 fr: Blaye-Côtes-de-Bordeaux blanc
 origins:en: en:france
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -15494,7 +15147,6 @@ wikidata:en: Q892806
 < en: Bordeaux
 fr: Bordeaux haut-benauge
 origins:en: en:france
-#wikidata:en:
 
 < en: Bordeaux
 < en: rosé wines
@@ -15505,7 +15157,6 @@ wikidata:en: Q1427324
 < en: Bordeaux
 fr: Bordeaux Claret
 origins:en: en:france
-#wikidata:en:
 
 < en: Bordeaux
 < en: rosé wines
@@ -15517,7 +15168,6 @@ wikidata:en: Q5732132
 < en: Bordeaux
 fr: Bordeaux Mousseux
 origins:en: en:france
-#wikidata:en:
 
 < en: Bordeaux
 fr: Bordeaux supérieur
@@ -15530,7 +15180,6 @@ fr: Bouches-du-Rhône
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1223-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Bordeaux
 fr: côtes-de-bourg, côtes de bourg, bourg, bourgeais
@@ -15692,7 +15341,6 @@ origins:en: en:france, en:burgundy
 < fr: Bourgogne Clairet
 fr: Bourgogne Clairet Côtes du Couchois, Bourgogne Rosé Côtes du Couchois
 origins:en: en:france, en:burgundy
-#wikidata:en:
 
 < fr: Bourgogne Clairet
 fr: Bourgogne Clairet Coulanges-la-Vineuse, Bourgogne Rosé Coulanges-la-Vineuse
@@ -15722,17 +15370,14 @@ wikidata:en: Q43015185
 < fr: Bourgogne Clairet
 fr: Bourgogne Clairet Le Chapitre, Bourgogne Rosé Le Chapitre
 origins:en: en:france, en:burgundy
-#wikidata:en:
 
 < fr: Bourgogne Clairet
 fr: Bourgogne Clairet Montrecul, Montre-cul, Bourgogne Rosé Montrecul, Bourgogne Rosé Montre-cul, Bourgogne Rosé En Montre-Cul
 origins:en: en:france, en:burgundy
-#wikidata:en:
 
 < fr: Bourgogne Clairet
 fr: Bourgogne Clairet Vézelay, Bourgogne Rosé Vézelay
 origins:en: en:france, en:burgundy
-#wikidata:en:
 
 < en: Wines from France
 fr: Bourgueil
@@ -15782,7 +15427,6 @@ fr: Cabernet de Saumur, Cabernet de Saumur Val de Loire
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0257
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Bordeaux wines
 < en: Dessert wines
@@ -15801,7 +15445,6 @@ wikidata:en: Q1025792
 #<en:Wines from France
 #fr:Cassis
 #origins:en: en:France
-#wikidata:en:
 
 < en: Bordeaux wines
 < en: Dessert wines
@@ -15830,7 +15473,6 @@ wikidata:en: Q1058259
 fr: Chablis premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis grand cru
@@ -15842,283 +15484,236 @@ wikidata:en: Q2947280
 fr: Chablis grand cru Blanchot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis grand cru Bougros
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis grand cru Grenouilles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis grand cru Les Clos
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis grand cru Preuses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis grand cru Valmur
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis grand cru Vaudésir
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Beauroy
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Berdiot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Beugnons, Chablis Beugnons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Butteaux, Chablis Butteaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Chapelot, Chablis Chapelot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Chatains, Chablis Chatains
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Chaume de Talvat, Chablis Chaume de Talvat
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Côte de Bréchain, Chablis Côte de Bréchain
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Côte de Cuissy, Chablis Côte de Cuissy
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Côte de Fontenay, Chablis Côte de Fontenay
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Côte de Jouan, Chablis Côte de Jouan
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Côte de Léchet, Chablis Côte de Léchet
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Côte de Savant, Chablis Côte de Savant
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Côte de Vaubarousse, Chablis Côte de Vaubarousse
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Côte des Prés, Chablis Côte des Prés Girots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Forêts, Chablis Forêts
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Fourchaume, Chablis Fourchaume
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Les Beauregards, Chablis Les Beauregards
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Les Épinottes, Chablis Les Épinottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Les Fourneaux, Chablis Les Fourneaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Les Lys, Chablis Les Lys
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru L'Homme mort, Chablis L'Homme mort
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Mélinots, Chablis Mélinots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Mont de Milieu, Chablis Mont de Milieu
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Montée de Tonnerre, Chablis Montée de Tonnerre
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Montmains, Chablis Montmains
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Morein, Chablis Morein
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Pied d'Aloup, Chablis Pied d'Aloup
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Roncières, Chablis Roncières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Sécher, Chablis Sécher
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Troesmes, Chablis Troesmes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vaillons, Chablis Vaillons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vau de Vey, Chablis Vau de Vey
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vau Ligneau, Chablis Vau Ligneau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vaucoupin, Chablis Vaucoupin
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vaugiraut, Chablis Vaugiraut
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vaulorent, Chablis Vaulorent
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vaupulent, Chablis Vaupulent
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vaux-Ragons, Chablis Vaux-Ragons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chablis
 fr: Chablis premier cru Vosgros, Chablis Vosgros
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -16144,151 +15739,126 @@ wikidata:en: Q2948108
 fr: Chambolle-Musigny premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Aux Beaux Bruns, Chambolle-Musigny premier cru Aux Beaux Bruns
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Aux Combottes, Chambolle-Musigny premier cru Aux Combottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Aux Echanges, Chambolle-Musigny premier cru Aux Echanges
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Derrière la Grange, Chambolle-Musigny premier cru Derrière la Grange
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny La Combe d'Orveau, Chambolle-Musigny premier cru La Combe d'Orveau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Amoureuses, Chambolle-Musigny premier cru Les Amoureuses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Baudes, Chambolle-Musigny premier cru Les Baudes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Borniques, Chambolle-Musigny premier cru Les Borniques
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Carrières, Chambolle-Musigny premier cru Les Carrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Chabiots, Chambolle-Musigny premier cru Les Chabiots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Charmes, Chambolle-Musigny premier cru Les Charmes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Chatelots, Chambolle-Musigny premier cru Les Chatelots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Combottes, Chambolle-Musigny premier cru Les Combottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Cras, Chambolle-Musigny premier cru Les Cras
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Feusselottes, Chambolle-Musigny premier cru Les Feusselottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Fuées, Chambolle-Musigny premier cru Les Fuées
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Groseilles, Chambolle-Musigny premier cru Les Groseilles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Gruenchers, Chambolle-Musigny premier cru Les Gruenchers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Hauts Doix, Chambolle-Musigny premier cru Les Hauts Doix
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Lavrottes, Chambolle-Musigny premier cru Les Lavrottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Noirots, Chambolle-Musigny premier cru Les Noirots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Plantes, Chambolle-Musigny premier cru Les Plantes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Sentiers, Chambolle-Musigny premier cru Les Sentiers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chambolle-Musigny
 fr: Chambolle-Musigny Les Véroilles, Chambolle-Musigny premier cru Les Véroilles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -16355,19 +15925,16 @@ wikidata:en: Q2364692
 fr: Chassagne-Montrachet Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Abbaye de Morgeot, Chassagne-Montrachet Abbaye de Morgeot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Abbaye de Morgeot rouge
@@ -16377,7 +15944,6 @@ wikidata:en: Q42866476
 fr: Chassagne-Montrachet premier cru Blanchot Dessus, Chassagne-Montrachet Blanchot Dessus
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Blanchot dessus rouge
@@ -16391,7 +15957,6 @@ wikidata:en: Q42866480
 fr: Chassagne-Montrachet premier cru Bois de Chassagne, Chassagne-Montrachet Bois de Chassagne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Bois de Chassagne rouge
@@ -16405,7 +15970,6 @@ wikidata:en: Q42866481
 fr: Chassagne-Montrachet premier cru Cailleret, Chassagne-Montrachet Cailleret
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Cailleret blanc
@@ -16419,7 +15983,6 @@ wikidata:en: Q42866487
 fr: Chassagne-Montrachet premier cru Champs Jendreau, Chassagne-Montrachet Champs Jendreau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Champs Jendreau blanc
@@ -16433,19 +15996,16 @@ wikidata:en: Q42866489
 fr: Chassagne-Montrachet premier cru Chassagne, Chassagne-Montrachet Chassagne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Chassagne du Clos Saint-Jean, Chassagne-Montrachet Chassagne du Clos Saint-Jean
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Clos Chareau, Chassagne-Montrachet Clos Chareau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Clos Chareau rouge
@@ -16459,7 +16019,6 @@ wikidata:en: Q42866499
 fr: Chassagne-Montrachet premier cru Clos Pitois, Chassagne-Montrachet Clos Pitois
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Clos Pitois rouge
@@ -16473,13 +16032,11 @@ wikidata:en: Q42866504
 fr: Chassagne-Montrachet premier cru Clos Saint Jean, Chassagne-Montrachet Clos Saint Jean
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Dent de Chien, Chassagne-Montrachet Dent de Chien
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Dent de Chien rouge
@@ -16489,7 +16046,6 @@ wikidata:en: Q42866512
 fr: Chassagne-Montrachet premier cru En Cailleret, Chassagne-Montrachet En Cailleret
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru En Cailleret rouge
@@ -16503,7 +16059,6 @@ wikidata:en: Q42866513
 fr: Chassagne-Montrachet premier cru En Remilly, Chassagne-Montrachet En Remilly
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru En Remilly blanc
@@ -16517,7 +16072,6 @@ wikidata:en: Q42866517
 fr: Chassagne-Montrachet premier cru En Virondot, Chassagne-Montrachet En Virondot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru En Virondot blanc
@@ -16527,13 +16081,11 @@ wikidata:en: Q42866518
 fr: Chassagne-Montrachet premier cru Ez Cretz, Chassagne-Montrachet Ez Cretz, Chassagne-Montrachet premier cru En Cretz, Chassagne-Montrachet En Cretz
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Ez Crottes, Chassagne-Montrachet Ez Crottes, Chassagne-Montrachet premier cru En Crottes, Chassagne-Montrachet En Crottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Ez Crottes rouge
@@ -16547,7 +16099,6 @@ wikidata:en: Q42866526
 fr: Chassagne-Montrachet premier cru Francemont, Chassagne-Montrachet Francemont
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Francemont rouge
@@ -16561,7 +16112,6 @@ wikidata:en: Q42866528
 fr: Chassagne-Montrachet premier cru Guerchères, Chassagne-Montrachet Guerchères
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Guerchère rouge
@@ -16575,7 +16125,6 @@ wikidata:en: Q42866531
 fr: Chassagne-Montrachet premier cru La Boudriotte, Chassagne-Montrachet La Boudriotte
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru La Boudriotte blanc
@@ -16585,7 +16134,6 @@ wikidata:en: Q42866533
 fr: Chassagne-Montrachet premier cru La Cardeuse, Chassagne-Montrachet La Cardeuse
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru La Cardeuse rouge
@@ -16599,7 +16147,6 @@ wikidata:en: Q42960416
 fr: Chassagne-Montrachet premier cru La Chapelle, Chassagne-Montrachet La Chapelle
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru La Chapelle rouge
@@ -16613,7 +16160,6 @@ wikidata:en: Q42960423
 fr: Chassagne-Montrachet premier cru La Grande Borne, Chassagne-Montrachet La Grande Borne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru La Grande Borne blanc
@@ -16623,7 +16169,6 @@ wikidata:en: Q42960428
 fr: Chassagne-Montrachet premier cru La Grande Montagne, Chassagne-Montrachet La Grande Montagne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru La Grande Montagne blanc
@@ -16633,7 +16178,6 @@ wikidata:en: Q42960433
 fr: Chassagne-Montrachet premier cru La Maltroie, Chassagne-Montrachet La Maltroie
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru La Maltroie blanc
@@ -16643,7 +16187,6 @@ wikidata:en: Q42960436
 fr: Chassagne-Montrachet premier cru La Romanée, Chassagne-Montrachet La Romanée
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru La Romanée rouge
@@ -16657,7 +16200,6 @@ wikidata:en: Q41437312
 fr: Chassagne-Montrachet premier cru La Roquemaure, Chassagne-Montrachet La Roquemaure
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru La Roquemaure blanc
@@ -16671,7 +16213,6 @@ wikidata:en: Q43015654
 fr: Chassagne-Montrachet premier cru Les Baudines, Chassagne-Montrachet Les Baudines
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Baudines rouge
@@ -16685,7 +16226,6 @@ wikidata:en: Q43015657
 fr: Chassagne-Montrachet premier cru Les Boirettes, Chassagne-Montrachet Les Boirettes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Boirettes rouge
@@ -16699,7 +16239,6 @@ wikidata:en: Q42299161
 fr: Chassagne-Montrachet premier cru Les Bondues, Chassagne-Montrachet Les Bondues
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Bondues rouge
@@ -16713,7 +16252,6 @@ wikidata:en: Q43015663
 fr: Chassagne-Montrachet premier cru Les Brussonnes, Chassagne-Montrachet Les Brussonnes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Brussonnes rouge
@@ -16727,13 +16265,11 @@ wikidata:en: Q43015668
 fr: Chassagne-Montrachet premier cru Les Champs-Gains, Chassagne-Montrachet Les Champs-Gains
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Chaumes, Chassagne-Montrachet Les Chaumes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Chaumes rouge
@@ -16747,13 +16283,11 @@ wikidata:en: Q43014297
 fr: Chassagne-Montrachet premier cru Les Chaumets, Chassagne-Montrachet Les Chaumets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Chenevottes, Chassagne-Montrachet Les Chenevottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Chenevottes blanc
@@ -16767,7 +16301,6 @@ wikidata:en: Q43014303
 fr: Chassagne-Montrachet premier cru Les Combards, Chassagne-Montrachet Les Combards
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Combards blanc
@@ -16781,7 +16314,6 @@ wikidata:en: Q43014305
 fr: Chassagne-Montrachet premier cru Les Commes, Chassagne-Montrachet Les Commes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Commes rouge
@@ -16795,7 +16327,6 @@ wikidata:en: Q43014307
 fr: Chassagne-Montrachet premier cru Les Embazées, Chassagne-Montrachet Les Embazées
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Embazées rouge
@@ -16809,7 +16340,6 @@ wikidata:en: Q43014312
 fr: Chassagne-Montrachet premier cru Les Fairendes, Chassagne-Montrachet Les Fairendes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Fairendes blanc
@@ -16823,7 +16353,6 @@ wikidata:en: Q43014316
 fr: Chassagne-Montrachet premier cru Les Grandes Ruchottes, Chassagne-Montrachet Les Grandes Ruchottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Grandes Ruchottes blanc
@@ -16833,7 +16362,6 @@ wikidata:en: Q43014318
 fr: Chassagne-Montrachet premier cru Les Grands Clos, Chassagne-Montrachet Les Grands Clos
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Grands Clos rouge
@@ -16847,7 +16375,6 @@ wikidata:en: Q43014320
 fr: Chassagne-Montrachet premier cru Les Macherelles, Chassagne-Montrachet Les Macherelles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Macherelles rouge
@@ -16861,7 +16388,6 @@ wikidata:en: Q43014323
 fr: Chassagne-Montrachet premier cru Les Murées, Chassagne-Montrachet Les Murées
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Murées rouge
@@ -16875,7 +16401,6 @@ wikidata:en: Q43014330
 fr: Chassagne-Montrachet premier cru Les Pasquelles, Chassagne-Montrachet Les Pasquelles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Pasquelles rouge
@@ -16889,7 +16414,6 @@ wikidata:en: Q43014332
 fr: Chassagne-Montrachet premier cru Les Petites Fairendes, Chassagne-Montrachet Les Petites Fairendes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Petites Fairendes blanc
@@ -16903,7 +16427,6 @@ wikidata:en: Q42866540
 fr: Chassagne-Montrachet premier cru Les Petits Clos, Chassagne-Montrachet Les Petits Clos
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Petits Clos rouge
@@ -16917,7 +16440,6 @@ wikidata:en: Q42866541
 fr: Chassagne-Montrachet premier cru Les Places, Chassagne-Montrachet Les Places
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Places blanc
@@ -16931,7 +16453,6 @@ wikidata:en: Q42866545
 fr: Chassagne-Montrachet premier cru Les Rebichets, Chassagne-Montrachet Les Rebichets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Rebichets blanc
@@ -16945,7 +16466,6 @@ wikidata:en: Q42866548
 fr: Chassagne-Montrachet premier cru Les Vergers, Chassagne-Montrachet Les Vergers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Les Vergers blanc
@@ -16959,7 +16479,6 @@ wikidata:en: Q42866550
 fr: Chassagne-Montrachet premier cru Morgeot, Chassagne-Montrachet Morgeot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Morgeot rouge
@@ -16973,13 +16492,11 @@ wikidata:en: Q42866551
 fr: Chassagne-Montrachet premier cru Petingerets, Chassagne-Montrachet Petingerets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Tête du Clos, Chassagne-Montrachet Tête du Clos
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Tête du Clos rouge
@@ -16993,7 +16510,6 @@ wikidata:en: Q42866560
 fr: Chassagne-Montrachet premier cru Tonton Marcel, Chassagne-Montrachet Tonton Marcel
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Tonton Marcel blanc
@@ -17007,7 +16523,6 @@ wikidata:en: Q42866564
 fr: Chassagne-Montrachet premier cru Vide Bourse, Chassagne-Montrachet Vide Bourse
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Vide Bourse rouge
@@ -17017,7 +16532,6 @@ wikidata:en: Q42866566
 fr: Chassagne-Montrachet premier cru Vigne Blanche, Chassagne-Montrachet Vigne Blanche
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Vigne Blanche blanc
@@ -17031,7 +16545,6 @@ wikidata:en: Q42866568
 fr: Chassagne-Montrachet premier cru Vigne Derrière, Chassagne-Montrachet Vigne Derrière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Chassagne-Montrachet
 fr: Chassagne-Montrachet premier cru Vigne Derrière rouge
@@ -17076,7 +16589,6 @@ origins:en: en:france
 protected_name_type:en: pdo
 region:fr: Bourgogne
 wikidata:en: Q1070885
-#wikidata:en:
 
 < en: Wines from France
 fr: Cheverny
@@ -17117,7 +16629,6 @@ wikidata:en: Q1094843
 < en: Wines from France
 fr: Clairette de Languedoc
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -17163,7 +16674,6 @@ wikidata:en: Q2983452
 < en: Wines from France
 fr: Collioure
 origins:en: en:france
-#wikidata:en:
 
 < fr: Collioure
 fr: Collioure blanc
@@ -17220,17 +16730,14 @@ wikidata:en: Q18214462
 < en: Wines from France
 fr: Corse Calvi, Vin de Corse Calvi, Calvi
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Corse Coteaux du Cap Corse, Vin de Corse Coteaux du Cap Corse, Cap Corse
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Corse Figari, Vin de Corse Figari
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Corse Porto-Vecchio, Vin de Corse Porto-Vecchio, Porto-Vecchio
@@ -17245,7 +16752,6 @@ wikidata:en: Q3473740
 < en: Wines from France
 fr: Corse, Vin de Corse
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -17329,13 +16835,11 @@ wikidata:en: Q2655967
 fr: castillon-côtes-de-bordeaux, castillon côtes de bordeaux, castillon-cotes-de-bordeaux, castillon cotes de bordeaux, côtes-de-castillon
 origins:en: en:france
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: côtes-de-bordeaux
 fr: francs-côtes-de-bordeaux, francs côtes de bordeaux, francs-cotes-de-bordeaux, francs cotes de bordeaux, bordeaux-côtes-de-francs
 origins:en: en:france
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes de la Charité, Cotes de la Charité
@@ -17418,7 +16922,6 @@ wikidata:en: Q1136597
 < en: Wines from France
 fr: Coteaux de Saumur Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux de Tannay
@@ -17454,7 +16957,6 @@ fr: Coteaux du Languedoc Pic-Saint-Loup, Pic-Saint-Loup
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02354
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Coteaux du Languedoc Pic-Saint-Loup
 fr: Pic Saint-Loup rouge
@@ -17467,61 +16969,50 @@ wikidata:en: Q43013303
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Cabrières, Cabrières
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Coteaux de la Méjanelle, Coteaux du Languedoc La Méjanelle, Coteaux de la Méjanelle, La Méjanelle
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Coteaux de Saint-Christol, Coteaux du Languedoc Saint-Christol, Coteaux de Saint-Christol, Saint-Christol
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Coteaux de Vérargues, Coteaux du Languedoc Vérargues, Coteaux de Vérargues, Vérargues
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Montpeyroux, Montpeyroux
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Quatourze, Quatourze
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Saint-Drézéry, Saint-Drézéry
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Saint-Georges-d'Orques, Saint-Georges-d'Orques
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Languedoc
 fr: Coteaux du Languedoc Saint-Saturnin, Saint-Saturnin
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Picpoul de Pinet
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-N1672
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: La Clape
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02113
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux du Layon
@@ -17533,12 +17024,10 @@ wikidata:en: Q1136591
 < fr: Coteaux du Layon
 fr: Coteaux du Layon Chaume Val de Loire, Coteaux du Layon Chaume
 origins:en: en:france
-#wikidata:en:
 
 < fr: Coteaux du Layon
 fr: Coteaux du Layon Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux du Libron
@@ -17556,14 +17045,12 @@ wikidata:en: Q2998551
 < en: Wines from France
 fr: Coteaux du Loir Val de Loire, Coteaux du Loir
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux du Lyonnais
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0202
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux du Pont du Gard
@@ -17619,27 +17106,22 @@ wikidata:en: Q1151017
 < en: Côtes d'Auvergne
 fr: Côtes d'Auvergne Boudes
 origins:en: en:france
-#wikidata:en:
 
 < en: Côtes d'Auvergne
 fr: Côtes d'Auvergne Chanturgue
 origins:en: en:france
-#wikidata:en:
 
 < en: Côtes d'Auvergne
 fr: Côtes d'Auvergne Châteaugay
 origins:en: en:france
-#wikidata:en:
 
 < en: Côtes d'Auvergne
 fr: Côtes d'Auvergne Corent
 origins:en: en:france
-#wikidata:en:
 
 < en: Côtes d'Auvergne
 fr: Côtes d'Auvergne Madargue
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes de Bergerac
@@ -17677,7 +17159,6 @@ fr: Côtes de Millau
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0596
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes de Montravel
@@ -17734,7 +17215,6 @@ wikidata:en: Q1150995
 < en: Wines from France
 fr: Luberon
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes du Marmandais
@@ -17751,7 +17231,6 @@ fr: Côtes du Rhône Villages
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0664
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Châteauneuf-du-Pape
@@ -17769,7 +17248,6 @@ fr: Côtes du Roussillon
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0919-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < fr: Côtes du Roussillon
@@ -17782,7 +17260,6 @@ wikidata:en: Q469048
 < fr: Côtes du Roussillon
 fr: Côtes du Roussillon Les Aspres
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes du Tarn
@@ -17795,7 +17272,6 @@ fr: Ventoux, AOP Ventoux
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0399
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes du Vivarais
@@ -17816,7 +17292,6 @@ fr: Crémant d'Alsace
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0917
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Bordeaux
 < en: sparkling wines
@@ -17824,14 +17299,12 @@ fr: Crémant de Bordeaux
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0488
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Sparkling wines
 fr: Crémant de Bourgogne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Crémant de Die
@@ -17851,7 +17324,6 @@ wikidata:en: Q1142487
 < en: Wines from France
 fr: Crémant du Jura
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: White wines
@@ -17865,7 +17337,6 @@ wikidata:en: Q1140103
 < en: Wines from France
 fr: Crozes-Hermitage, Crozes-Ermitage
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Drôme
@@ -17911,17 +17382,14 @@ origins:en: en:france
 < en: Wines from France
 fr: Fiefs Vendéens Mareuil, Mareuil
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Fiefs Vendéens Pissotte, Pissotte
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Fiefs Vendéens Vix, Vix
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Fitou
@@ -17934,74 +17402,62 @@ wikidata:en: Q470974
 fr: Fixin
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru Clos de la Perrière, Fixin Clos de la Perrière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru Clos Napoléon, Fixin Clos Napoléon
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru En Suchot, Fixin En Suchot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru La Perrière, Fixin La Perrière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru Le Clos du Chapitre, Fixin Le Clos du Chapitre
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru Le Meix Bas, Fixin Le Meix Bas
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru Le Village, Fixin Le Village
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru Les Arvelets, Fixin Les Arvelets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru Les Hervelets, Fixin Les Hervelets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Fixin
 fr: Fixin premier cru Queue de Hareng, Fixin Queue de Hareng
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Fleurie
 origins:en: en:france, en:beaujolais
 protected_name_file_number:en: PDO-FR-A0930
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Franche-Comté
@@ -18020,7 +17476,6 @@ fr: Fronton
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0595
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Gaillac
@@ -18041,12 +17496,10 @@ fr: Gaillac perlé
 < en: Wines from France
 fr: Gaillac premières côtes
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Gaillac mousseux
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Gard
@@ -18071,43 +17524,36 @@ wikidata:en: Q1316029
 fr: Gevrey-Chambertin premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Au Closeau, Gevrey-Chambertin Au Closeau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Aux Combottes, Gevrey-Chambertin Aux Combottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Bel Air, Gevrey-Chambertin Bel Air
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Champeaux, Gevrey-Chambertin Champeaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Champonnet, Gevrey-Chambertin Champonnet
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Cherbaudes, Gevrey-Chambertin Cherbaudes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Clos des Varoilles, Gevrey-Chambertin Clos des Varoilles
@@ -18119,115 +17565,96 @@ protected_name_type:en: pdo
 fr: Gevrey-Chambertin premier cru Clos du Chapitre, Gevrey-Chambertin Clos du Chapitre
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Clos Prieur, Gevrey-Chambertin Clos Prieur
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Clos St Jacques, Gevrey-Chambertin Clos St Jacques
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Combe au Moine, Gevrey-Chambertin Combe au Moine
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Craipillot, Gevrey-Chambertin Craipillot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru En Ergot, Gevrey-Chambertin En Ergot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Estournelles St Jacques, Gevrey-Chambertin Estournelles St Jacques
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Fonteny, Gevrey-Chambertin Fonteny
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Issarts, Gevrey-Chambertin Issarts
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru La Bossière, Gevrey-Chambertin La Bossière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru La Perrière, Gevrey-Chambertin La Perrière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru La Romanée, Gevrey-Chambertin La Romanée
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Lavaut St Jacques, Gevrey-Chambertin Lavaut St Jacques
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Les Cazetiers, Gevrey-Chambertin Les Cazetiers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Les Crobeaux, Gevrey-Chambertin Les Crobeaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Les Goulots, Gevrey-Chambertin Les Goulots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Petite Chapelle, Gevrey-Chambertin Petite Chapelle
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Petits Cazetiers, Gevrey-Chambertin Petits Cazetiers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Gevrey-Chambertin
 fr: Gevrey-Chambertin premier cru Poissenot, Gevrey-Chambertin Poissenot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Gigondas
@@ -18246,13 +17673,11 @@ wikidata:en: Q3108210
 fr: Givry premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry
 fr: Givry premier cru Vigne Rouge, Givry Vigne Rouge
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Vigne Rouge
 fr: Givry premier cru A Vigne Rouge rouge
@@ -18280,7 +17705,6 @@ wikidata:en: Q42867252
 fr: Givry premier cru Clos Charle, Givry Clos Charle
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Clos Charle
 fr: Givry premier cru Clos Charlé rouge
@@ -18294,25 +17718,21 @@ wikidata:en: Q42867246
 fr: Givry premier cru Clos de la Barraude, Givry Clos de la Barraude
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry
 fr: Givry premier cru Clos du Cras Long, Givry Clos du Cras Long
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry
 fr: Givry premier cru Clos du Vernoy, Givry Clos du Vernoy
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry
 fr: Givry premier cru Clos Jus, Givry Clos Jus
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Clos Jus
 fr: Givry premier cru Clos Jus blanc
@@ -18327,7 +17747,6 @@ wikidata:en: Q42867266
 fr: Givry premier cru Clos Marceaux, Givry Clos Marceaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Clos Marceaux
 fr: Givry premier cru Clos Marceaux blanc
@@ -18342,7 +17761,6 @@ wikidata:en: Q42867267
 fr: Givry premier cru Clos Marole, Givry Clos Marole
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Clos Marole
 fr: Givry premier cru Clos Marole rouge
@@ -18356,7 +17774,6 @@ wikidata:en: Q42393730
 fr: Givry premier cru Clos Saint-Paul, Givry Clos Saint-Paul
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Clos-Saint-Paul
 fr: Givry premier cru Clos-Saint-Paul rouge
@@ -18370,7 +17787,6 @@ wikidata:en: Q42867265
 fr: Givry premier cru Clos Saint-Pierre, Givry Clos Saint-Pierre
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Clos Saint-Pierre
 fr: Givry premier cru Clos-Saint-Pierre blanc
@@ -18385,7 +17801,6 @@ wikidata:en: Q42966755
 fr: Givry premier cru Clos Salomon, Givry Clos Salomon
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Clos Salomon
 fr: Givry premier cru Clos Salomon rouge
@@ -18400,13 +17815,11 @@ wikidata:en: Q42867264
 fr: Givry premier cru Crauzot, Givry Crauzot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry
 fr: Givry premier cru Cremillons, Givry Cremillons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Cremillons
 fr: Givry premier cru Crémillons rouge
@@ -18421,7 +17834,6 @@ wikidata:en: Q42966759
 fr: Givry premier cru En Choue, Givry En Choue
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru En Choue
 fr: Givry premier cru En Choué blanc
@@ -18436,7 +17848,6 @@ wikidata:en: Q42966765
 fr: Givry premier cru La grande Berge, Givry La grande Berge
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru La grande Berge
 fr: Givry premier cru La Grande Berge blanc
@@ -18451,7 +17862,6 @@ wikidata:en: Q42966774
 fr: Givry premier cru La Plante, Givry La Plante
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru La Plante
 fr: Givry premier cru La Plante blanc
@@ -18466,7 +17876,6 @@ wikidata:en: Q42300486
 fr: Givry premier cru Le Paradis, Givry Le Paradis
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Le Paradis
 fr: Givry premier cru Le Paradis blanc
@@ -18481,7 +17890,6 @@ wikidata:en: Q42966791
 fr: Givry premier cru Le petit Pretan, Givry Le petit Pretan
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Le petit Pretan
 fr: Givry premier cru Le Petit Prétan rouge
@@ -18496,7 +17904,6 @@ wikidata:en: Q42300632
 fr: Givry premier cru Le Vigron, Givry Le Vigron
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Le Vigron
 fr: Givry premier cru Le Vigron blanc
@@ -18511,7 +17918,6 @@ wikidata:en: Q42966808
 fr: Givry premier cru Les Bois Chevaux, Givry Les Bois Chevaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Les Bois Chevaux
 fr: Givry premier cru Les Bois Chevaux blanc
@@ -18526,7 +17932,6 @@ wikidata:en: Q42966812
 fr: Givry premier cru Les Bois Gautiers, Givry Les Bois Gautiers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Les Bois Gautiers
 fr: Givry premier cru Les Bois Gautiers blanc
@@ -18540,7 +17945,6 @@ wikidata:en: Q42966816
 fr: Givry premier cru Les grandes Vignes, Givry Les grandes Vignes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Les grandes Vignes
 fr: Givry premier cru Les Grandes Vignes blanc
@@ -18555,7 +17959,6 @@ wikidata:en: Q43013770
 fr: Givry premier cru Les grands Pretans, Givry Les grands Pretans
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Les grands Pretans
 fr: Givry premier cru Les Grands Prétans blanc
@@ -18570,7 +17973,6 @@ wikidata:en: Q43013767
 fr: Givry premier cru Petit Marole, Givry Petit Marole
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Petit Marole
 fr: Givry premier cru Petit Marole blanc
@@ -18585,7 +17987,6 @@ wikidata:en: Q43013782
 fr: Givry premier cru Servoisine, Givry Servoisine
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Givry premier cru Servoisine
 fr: Givry premier cru Servoisine rouge
@@ -18599,7 +18000,6 @@ wikidata:en: Q42867275
 < en: Wines from France
 fr: Grand Roussillon Rancio
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 fr: Grand-Échezeaux, Grand-Échezeaux grand cru, Grand Échezeaux, Grand Échezeaux grand cru
@@ -18684,19 +18084,16 @@ fr: Haut-Montravel
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0152
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Haut-Poitou
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0726
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Hermitage, l'Hermitage, Ermitage, l'Ermitage
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Île de Beauté
@@ -18708,12 +18105,10 @@ wikidata:en: Q18332002
 fr: Irancy
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Irouléguy
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Isère
@@ -18726,31 +18121,26 @@ fr: Jasnières
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0393
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Jasnières Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Juliénas
 origins:en: en:france, en:beaujolais
 protected_name_file_number:en: PDO-FR-A1025
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Jurançon
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0827
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Jurançon sec
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -18773,79 +18163,66 @@ wikidata:en: Q3215969
 fr: Ladoix Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru Basses Mourottes, Ladoix Basses Mourottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru Bois Roussot, Ladoix Bois Roussot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru En Naget, Ladoix En Naget
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru Hautes Mourottes, Ladoix Hautes Mourottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru La Corvée, Ladoix La Corvée
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru La Micaude, Ladoix La Micaude
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru Le Clou d'Orge, Ladoix Le Clou d'Orge
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru Le Rognet et Corton, Ladoix Le Rognet et Corton
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru Les Buis, Ladoix Les Buis
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru Les Grêchons et Foutrières, Ladoix Les Grêchons et Foutrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Ladoix
 fr: Ladoix premier cru Les Joyeuses, Ladoix Les Joyeuses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Bordeaux wines
 < en: Red wines
@@ -18853,7 +18230,6 @@ fr: lalande-de-pomerol, lalande de pomerol
 origins:en: en:france
 protected_name_type:en: pdo
 wikidata:en: Q669737
-#wikidata:en:
 
 < en: Wines from France
 fr: Landes
@@ -18865,7 +18241,6 @@ fr: Languedoc
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0922
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -18879,7 +18254,6 @@ fr: Lavilledieu
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1136
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Les Baux de Provence
@@ -18891,14 +18265,12 @@ wikidata:en: Q1820443
 < en: Wines from France
 fr: LÉtoile mousseux
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Limoux
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0921
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Lirac
@@ -18917,7 +18289,6 @@ wikidata:en: Q1516318
 < en: Wines from France
 fr: Lot
 origins:en: en:france
-#wikidata:en:
 
 < en: Bordeaux wines
 < en: Dessert wines
@@ -18966,7 +18337,6 @@ wikidata:en: Q3332006
 fr: Mâcon primeur, Macon primeur, Mâcon nouveau, Macon nouveau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -18975,7 +18345,6 @@ protected_name_type:en: pdo
 fr: Mâcon Azé, Macon Azé
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -18984,7 +18353,6 @@ protected_name_type:en: pdo
 fr: Mâcon Bray, Macon Bray
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -18993,7 +18361,6 @@ protected_name_type:en: pdo
 fr: Mâcon Burgy, Macon Burgy
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19002,7 +18369,6 @@ protected_name_type:en: pdo
 fr: Mâcon Bussières, Macon Bussières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19011,7 +18377,6 @@ protected_name_type:en: pdo
 fr: Mâcon Chaintré, Macon Chaintré
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19020,7 +18385,6 @@ protected_name_type:en: pdo
 fr: Mâcon Chardonnay, Macon Chardonnay
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19029,7 +18393,6 @@ protected_name_type:en: pdo
 fr: Mâcon Charnay-lès Mâcon, Macon Charnay-lès Mâcon
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19038,7 +18401,6 @@ protected_name_type:en: pdo
 fr: Mâcon Cruzille, Macon Cruzille
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19047,7 +18409,6 @@ protected_name_type:en: pdo
 fr: Mâcon Davayé, Macon Davayé
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19056,7 +18417,6 @@ protected_name_type:en: pdo
 fr: Mâcon Igé, Macon Igé
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19065,7 +18425,6 @@ protected_name_type:en: pdo
 fr: Mâcon Lugny, Macon Lugny
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19074,7 +18433,6 @@ protected_name_type:en: pdo
 fr: Mâcon Mancey, Macon Mancey
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19083,7 +18441,6 @@ protected_name_type:en: pdo
 fr: Mâcon Milly-Lamartine, Macon Milly-Lamartine
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19092,7 +18449,6 @@ protected_name_type:en: pdo
 fr: Mâcon Péronne, Macon Péronne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19101,7 +18457,6 @@ protected_name_type:en: pdo
 fr: Mâcon Pierreclos, Macon Pierreclos
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19110,7 +18465,6 @@ protected_name_type:en: pdo
 fr: Mâcon Prissé, Macon Prissé
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19119,7 +18473,6 @@ protected_name_type:en: pdo
 fr: Mâcon La Roche Vineuse, Macon La Roche Vineuse
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19128,7 +18481,6 @@ protected_name_type:en: pdo
 fr: Mâcon Saint-Gengoux-le-National, Macon Saint-Gengoux-le-National, Mâcon Saint Gengoux le National, Macon Saint Gengoux le National
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19137,7 +18489,6 @@ protected_name_type:en: pdo
 fr: Mâcon Verzé, Macon Verzé
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Red wines
 < en: Rosé wines
@@ -19145,68 +18496,58 @@ protected_name_type:en: pdo
 fr: Mâcon Serrières, Macon Serrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: White wines
 < fr: Mâcon
 fr: Mâcon Fuissé, Macon Fuissé
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: White wines
 < fr: Mâcon
 fr: Mâcon Loché, Macon Loché
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: White wines
 < fr: Mâcon
 fr: Mâcon Montbellet, Macon Montbellet
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: White wines
 < fr: Mâcon
 fr: Mâcon Solutré Pouilly, Macon Solutré Pouilly
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: White wines
 < fr: Mâcon
 fr: Mâcon Uchizy, Macon Uchizy
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: White wines
 < fr: Mâcon
 fr: Mâcon Vergisson, Macon Vergisson
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: White wines
 < fr: Mâcon
 fr: Mâcon Vinzelles, Macon Vinzelles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Madiran
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Malepère
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0196
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -19220,62 +18561,52 @@ wikidata:en: Q3287444
 fr: Maranges Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Maranges
 fr: Maranges premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Maranges
 fr: Maranges premier cru Clos de la Boutière, Maranges Clos de la Boutière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Maranges
 fr: Maranges premier cru Clos de la Fussière, Maranges Clos de la Fussière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Maranges
 fr: Maranges premier cru La Fussière, Maranges La Fussière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Maranges
 fr: Maranges premier cru Le Clos des Loyères, Maranges Le Clos des Loyères
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Maranges
 fr: Maranges premier cru Le Clos des Rois, Maranges Le Clos des Rois
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Maranges
 fr: Maranges premier cru Le Croix Moines, Maranges Le Croix Moines
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Maranges
 fr: Maranges premier cru Les Clos Roussots, Maranges Les Clos Roussots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Marcillac
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0818
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Medoc wines
 fr: Margaux
@@ -19347,7 +18678,6 @@ wikidata:en: Q592785
 < en: Wines from France
 fr: Menetou-Salon, Menetou-Salon Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -19362,61 +18692,51 @@ wikidata:en: Q2749134
 fr: Mercurey premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Clos de Paradis, Mercurey Clos de Paradis
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Clos des Barraults, Mercurey Clos des Barraults
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Clos des grands Voyens, Mercurey Clos des grands Voyens
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Clos des Myglands, Mercurey Clos des Myglands
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Clos Marcilly, Mercurey Clos Marcilly
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Clos Tonnerre, Mercurey Clos Tonnerre
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Clos Voyens, Mercurey Clos Voyens
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Grand Clos Fortoul, Mercurey Grand Clos Fortoul
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Griffères, Mercurey Griffères
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey premier cru Griffères
 fr: Mercurey premier cru Griffères blanc
@@ -19426,7 +18746,6 @@ wikidata:en: Q42864116
 fr: Mercurey premier cru La Bondue, Mercurey La Bondue
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru La Cailloute, Mercurey La Cailloute
@@ -19450,25 +18769,21 @@ wikidata:en: Q42880498	Mercurey premier cru La Levrière rouge
 fr: Mercurey premier cru La Mission, Mercurey La Mission
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Le Clos du Roy, Mercurey Le Clos du Roy
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Le Clos L'Evêque, Mercurey Le Clos L'Evêque
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Byots, Mercurey Les Byots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey premier cru Les Byots
 fr: Mercurey premier cru Les Byots blanc
@@ -19482,79 +18797,66 @@ wikidata:en: Q42880510
 fr: Mercurey premier cru Les Champs Martin, Mercurey Les Champs Martin
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Combins, Mercurey Les Combins
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Crêts, Mercurey Les Crêts
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Croichots, Mercurey Les Croichots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Fourneaux, Mercurey Les Fourneaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Montaigus, Mercurey Les Montaigus
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Naugues, Mercurey Les Naugues
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Puillets, Mercurey Les Puillets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Ruelles, Mercurey Les Ruelles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Saumonts, Mercurey Les Saumonts
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Vasées, Mercurey Les Vasées
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Les Velley, Mercurey Les Velley
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Mercurey
 fr: Mercurey premier cru Sazenay, Mercurey Sazenay
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -19563,136 +18865,113 @@ fr: Meursault
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
 wikidata:en: Q7889954
-#wikidata:en:
 
 < en: Red wines
 fr: Meursault Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Charmes, Meursault Charmes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Clos des Perrières, Meursault Clos des Perrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Genevrières, Meursault Genevrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru La Jeunelotte, Meursault La Jeunelotte
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru La Pièce sous le Bois, Meursault La Pièce sous le Bois
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Le Porusot, Meursault Le Porusot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Les Bouchères, Meursault Les Bouchères
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Les Caillerets, Meursault Les Caillerets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Les Cras, Meursault Les Cras
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Les Gouttes d'Or, Meursault Les Gouttes d'Or
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Les Plures, Meursault Les Plures
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Les Ravelles, Meursault Les Ravelles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Les Santenots Blancs, Meursault Les Santenots Blancs
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Les Santenots du Milieu, Meursault Les Santenots du Milieu
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Perrières, Meursault Perrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Sous Blagny, Meursault Sous Blagny
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Meursault
 fr: Meursault premier cru Sous le dos d'Ane, Meursault Sous le dos d'Ane
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Minervois
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Minervois-La-Livinière
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Monbazillac
 origins:en: en:france
-#wikidata:en:
 
 < en: Red wines
 < fr: saint-émilion
@@ -19714,7 +18993,6 @@ wikidata:en: Q3322367
 fr: Montagny premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Montagny
 fr: Montagny premier cru Champ Toizeau, Montagny Champ Toizeau
@@ -19834,7 +19112,6 @@ wikidata:en: Q43014990
 fr: Montagny premier cru Les Charmelottes, Montagny Les Charmelottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Montagny
 fr: Montagny premier cru Les Coères, Montagny Les Coères
@@ -19906,7 +19183,6 @@ wikidata:en: Q42966966
 fr: Montagny premier cru Les Parrières, Montagny Les Parrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Montagny
 fr: Montagny premier cru Les Pidances, Montagny Les Pidances
@@ -19924,7 +19200,6 @@ wikidata:en: Q42966973
 fr: Montagny premier cru Les Resses, Montagny Les Resses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Montagny
 fr: Montagny premier cru Les Treuffères, Montagny Les Treuffères
@@ -19972,7 +19247,6 @@ wikidata:en: Q42966994
 fr: Montagny premier cru Saint-Morille, Montagny Saint-Morille
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Montagny
 fr: Montagny premier cru Saint-Ytages, Montagny Saint-Ytages
@@ -20021,7 +19295,6 @@ fr: Terrasses du Larzac
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02084
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -20035,115 +19308,96 @@ wikidata:en: Q3322760
 fr: Monthelie Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Clos des Toisières, Monthelie Clos des Toisières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru La Taupine, Monthelie La Taupine
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Le Cas Rougeot, Monthelie Le Cas Rougeot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Le Château Gaillard, Monthelie Le Château Gaillard
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Le Clos Gauthey, Monthelie Le Clos Gauthey
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Le Clou des Chênes, Monthelie Le Clou des Chênes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Le Meix Bataille, Monthelie Le Meix Bataille
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Le Village, Monthelie Le Village
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Les Barbières, Monthelie Les Barbières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Les Champs Fulliots, Monthelie Les Champs Fulliots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: White wines
 < fr: Monthelie
 fr: Monthelie premier cru Les Clous, Monthelie Les Clous
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Les Duresses, Monthelie Les Duresses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Les Hauts Brins, Monthelie Les Hauts Brins
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Les Riottes, Monthelie Les Riottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Les Vignes Rondes, Monthelie Les Vignes Rondes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Monthelie
 fr: Monthelie premier cru Sur la Velle, Monthelie Sur la Velle
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Montlouis-sur-Loire, Montlouis-sur-Loire Val de Loire, Montlouis-sur-Loire Val de Loire mousseux, Montlouis-sur-Loire Val de Loire pétillant
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: White wines
@@ -20157,7 +19411,6 @@ wikidata:en: Q1795432
 < en: Wines from France
 fr: Montravel
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -20179,7 +19432,6 @@ wikidata:en: Q42862927
 fr: Morey-Saint-Denis premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru blanc
@@ -20194,7 +19446,6 @@ wikidata:en: Q42862926
 fr: Morey-Saint-Denis premier cru Aux Charmes, Morey-Saint-Denis Aux Charmes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Aux Charmes rouge
@@ -20209,7 +19460,6 @@ wikidata:en: Q42864318
 fr: Morey-Saint-Denis premier cru Aux Cheseaux, Morey-Saint-Denis Aux Cheseaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Aux Cheseaux blanc
@@ -20224,7 +19474,6 @@ wikidata:en: Q42864323
 fr: Morey-Saint-Denis premier cru Clos Baulet, Morey-Saint-Denis Clos Baulet
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Clos Baulet rouge
@@ -20239,7 +19488,6 @@ wikidata:en: Q42864326
 fr: Morey-Saint-Denis premier cru Clos des Ormes, Morey-Saint-Denis Clos des Ormes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Clos des Ormes rouge
@@ -20254,7 +19502,6 @@ wikidata:en: Q42864329
 fr: Morey-Saint-Denis premier cru Clos Sorbè, Morey-Saint-Denis Clos Sorbè
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Clos Sorbè rouge
@@ -20269,7 +19516,6 @@ wikidata:en: Q42863934
 fr: Morey-Saint-Denis premier cru Côte Rotie, Morey-Saint-Denis Côte Rotie
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Côte Rotie blanc
@@ -20284,7 +19530,6 @@ wikidata:en: Q42863940
 fr: Morey-Saint-Denis premier cru La Bussière, Morey-Saint-Denis La Bussière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru La Bussière rouge
@@ -20299,7 +19544,6 @@ wikidata:en: Q42863941
 fr: Morey-Saint-Denis premier cru La Riotte, Morey-Saint-Denis La Riotte
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru La Riotte blanc
@@ -20314,7 +19558,6 @@ wikidata:en: Q42863947
 fr: Morey-Saint-Denis premier cru Le Village, Morey-Saint-Denis Le Village
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Le Village blanc
@@ -20329,7 +19572,6 @@ wikidata:en: Q42863951
 fr: Morey-Saint-Denis premier cru Les Blanchards, Morey-Saint-Denis Les Blanchards
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Les Blanchards rouge
@@ -20344,7 +19586,6 @@ wikidata:en: Q42863953
 fr: Morey-Saint-Denis premier cru Les Chaffots, Morey-Saint-Denis Les Chaffots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Les Chaffots rouge
@@ -20359,7 +19600,6 @@ wikidata:en: Q42863957
 fr: Morey-Saint-Denis premier cru Les Charrières, Morey-Saint-Denis Les Charrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Les Charrières rouge
@@ -20374,7 +19614,6 @@ wikidata:en: Q42863960
 fr: Morey-Saint-Denis premier cru Les Chenevery, Morey-Saint-Denis Les Chenevery
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Les Chenevery rouge
@@ -20389,7 +19628,6 @@ wikidata:en: Q42863964
 fr: Morey-Saint-Denis premier cru Les Faconnières, Morey-Saint-Denis Les Faconnières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Les Faconnières rouge
@@ -20404,7 +19642,6 @@ wikidata:en: Q42863972
 fr: Morey-Saint-Denis premier cru Les Genavrières, Morey-Saint-Denis Les Genavrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Les Genavrières blanc
@@ -20419,7 +19656,6 @@ wikidata:en: Q42863974
 fr: Morey-Saint-Denis premier cru Les Gruenchers, Morey-Saint-Denis Les Gruenchers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis
 fr: Morey-Saint-Denis premier cru Les Gruenchers blanc
@@ -20434,7 +19670,6 @@ wikidata:en: Q42863976
 fr: Morey-Saint-Denis premier cru Les Milandes, Morey-Saint-Denis Les Milandes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis premier cru Les Milandes
 fr: Morey-Saint-Denis premier cru Les Millandes blanc
@@ -20449,7 +19684,6 @@ wikidata:en: Q42862915
 fr: Morey-Saint-Denis premier cru Les Ruchots, Morey-Saint-Denis Les Ruchots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis premier cru Les Ruchots
 fr: Morey-Saint-Denis premier cru Les Ruchots blanc
@@ -20464,7 +19698,6 @@ wikidata:en: Q42862919
 fr: Morey-Saint-Denis premier cru Les Sorbès, Morey-Saint-Denis Les Sorbès
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis premier cru Les Sorbès
 fr: Morey-Saint-Denis premier cru Les Sorbès blanc
@@ -20479,7 +19712,6 @@ wikidata:en: Q42862922
 fr: Morey-Saint-Denis premier cru Monts Luisants, Morey-Saint-Denis Monts Luisants
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Morey-Saint-Denis premier cru Monts Luisants
 fr: Morey-Saint-Denis premier cru Monts Luisants rouge
@@ -20498,7 +19730,6 @@ fr: Moselle
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0669
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Moulin-à-Vent
@@ -20513,22 +19744,18 @@ wikidata:en: Q3325895
 < en: Wines from France
 fr: Muscadet Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Muscadet-Coteaux de la Loire Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Muscadet-Côtes de Grandlieu Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Muscadet-Sèvre et Maine, Muscadet-Sèvre et Maine Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -20561,7 +19788,6 @@ wikidata:en: Q42863101
 fr: Nuits-Saint-Georges premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru blanc
@@ -20575,7 +19801,6 @@ wikidata:en: Q42863169
 fr: Nuits-Saint-Georges premier cru Aux Argillas, Nuits-Saint-Georges Aux Argillas
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Argillas rouge
@@ -20589,7 +19814,6 @@ wikidata:en: Q42863102
 fr: Nuits-Saint-Georges premier cru Aux Boudots, Nuits-Saint-Georges Aux Boudots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Boudots blanc
@@ -20603,7 +19827,6 @@ wikidata:en: Q42863106
 fr: Nuits-Saint-Georges premier cru Aux Bousselots, Nuits-Saint-Georges Aux Bousselots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Bousselots rouge
@@ -20617,7 +19840,6 @@ wikidata:en: Q42863108
 fr: Nuits-Saint-Georges premier cru Aux Chaignots, Nuits-Saint-Georges Aux Chaignots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Chaignots blanc
@@ -20631,7 +19853,6 @@ wikidata:en: Q42863114
 fr: Nuits-Saint-Georges premier cru Aux Champs Perdrix, Nuits-Saint-Georges Aux Champs Perdrix
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Champs Perdrix rouge
@@ -20645,7 +19866,6 @@ wikidata:en: Q42863116
 fr: Nuits-Saint-Georges premier cru Aux Cras, Nuits-Saint-Georges Aux Cras
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Cras blanc
@@ -20659,7 +19879,6 @@ wikidata:en: Q42863121
 fr: Nuits-Saint-Georges premier cru Aux Murgers, Nuits-Saint-Georges Aux Murgers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Murgers rouge
@@ -20673,7 +19892,6 @@ wikidata:en: Q42863123
 fr: Nuits-Saint-Georges premier cru Aux Perdrix, Nuits-Saint-Georges Aux Perdrix
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Perdrix rouge
@@ -20687,7 +19905,6 @@ wikidata:en: Q42863126
 fr: Nuits-Saint-Georges premier cru Aux Thorey, Nuits-Saint-Georges Aux Thorey
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Thorey rouge
@@ -20701,7 +19918,6 @@ wikidata:en: Q42863663
 fr: Nuits-Saint-Georges Aux Vignerondes premier cru Aux Vignerondes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Aux Vignerondes rouge
@@ -20715,7 +19931,6 @@ wikidata:en: Q42863661
 fr: Nuits-Saint-Georges premier cru Chaines Carteaux, Nuits-Saint-Georges Chaines Carteaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Chaines Carteaux blanc
@@ -20729,7 +19944,6 @@ wikidata:en: Q42863670
 fr: Nuits-Saint-Georges premier cru Château Gris, Nuits-Saint-Georges Château Gris
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Château Gris rouge
@@ -20743,7 +19957,6 @@ wikidata:en: Q42863671
 fr: Nuits-Saint-Georges premier cru Clos Arlot, Nuits-Saint-Georges Clos Arlot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos Arlot blanc
@@ -20757,7 +19970,6 @@ wikidata:en: Q42863678
 fr: Nuits-Saint-Georges premier cru Clos de la Maréchale, Nuits-Saint-Georges Clos de la Maréchale
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos de la Maréchale rouge
@@ -20771,7 +19983,6 @@ wikidata:en: Q42863679
 fr: Nuits-Saint-Georges premier cru Clos des Argillières, Nuits-Saint-Georges Clos des Argillières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos des Argillières blanc
@@ -20785,7 +19996,6 @@ wikidata:en: Q42863684
 fr: Nuits-Saint-Georges premier cru Clos des Corvées, Nuits-Saint-Georges Clos des Corvées
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos des Corvées rouge
@@ -20799,7 +20009,6 @@ wikidata:en: Q42863686
 fr: Nuits-Saint-Georges premier cru Clos des Corvées Pagets, Nuits-Saint-Georges Clos des Corvées Pagets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos des Corvées Pagets rouge
@@ -20813,7 +20022,6 @@ wikidata:en: Q42863688
 fr: Nuits-Saint-Georges premier cru Clos des Forêts-St-Georges, Nuits-Saint-Georges Clos des Forêts-St-Georges
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos des Forêts Saint-Georges rouge
@@ -20827,7 +20035,6 @@ wikidata:en: Q42863695
 fr: Nuits-Saint-Georges premier cru Clos des grandes Vignes, Nuits-Saint-Georges Clos des grandes Vignes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos des Grandes Vignes rouge
@@ -20841,7 +20048,6 @@ wikidata:en: Q42863698
 fr: Nuits-Saint-Georges premier cru Clos des Porrets Saint-Georges, Nuits-Saint-Georges Clos des Porrets Saint-Georges
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos des Porrets-Saint-Georges blanc
@@ -20855,7 +20061,6 @@ wikidata:en: Q42863704
 fr: Nuits-Saint-Georges premier cru Clos Saint-Marc, Nuits-Saint-Georges Clos Saint-Marc
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Clos Saint-Marc rouge
@@ -20869,7 +20074,6 @@ wikidata:en: Q42863705
 fr: Nuits-Saint-Georges premier cru En la Perrière Noblot, Nuits-Saint-Georges En la Perrière Noblot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru En la Perrière Noblot rouge
@@ -20883,7 +20087,6 @@ wikidata:en: Q42863707
 fr: Nuits-Saint-Georges premier cru La Richemone, Nuits-Saint-Georges La Richemone
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru La Richemone rouge
@@ -20897,7 +20100,6 @@ wikidata:en: Q42864337
 fr: Nuits-Saint-Georges premier cru Les Argillières, Nuits-Saint-Georges Les Argillières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Argillières rouge
@@ -20911,7 +20113,6 @@ wikidata:en: Q42863715
 fr: Nuits-Saint-Georges premier cru Les Cailles, Nuits-Saint-Georges Les Cailles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Cailles rouge
@@ -20925,7 +20126,6 @@ wikidata:en: Q42299158
 fr: Nuits-Saint-Georges premier cru Les Chabœufs, Nuits-Saint-Georges Les Chabœufs
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Chabœufs blanc
@@ -20939,7 +20139,6 @@ wikidata:en: Q42863720
 fr: Nuits-Saint-Georges premier cru Les Crots, Nuits-Saint-Georges Les Crots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Crots rouge
@@ -20953,7 +20152,6 @@ wikidata:en: Q42863724
 fr: Nuits-Saint-Georges premier cru Les Damodes, Nuits-Saint-Georges Les Damodes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Damodes blanc
@@ -20967,7 +20165,6 @@ wikidata:en: Q42863133
 fr: Nuits-Saint-Georges premier cru Les Didiers, Nuits-Saint-Georges Les Didiers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Didiers rouge
@@ -20981,7 +20178,6 @@ wikidata:en: Q42863134
 fr: Nuits-Saint-Georges premier cru Les Hauts Pruliers, Nuits-Saint-Georges Les Hauts Pruliers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Hauts Pruliers blanc
@@ -20995,7 +20191,6 @@ wikidata:en: Q42863136
 fr: Nuits-Saint-Georges premier cru Les Perrières, Nuits-Saint-Georges Les Perrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Perrières blanc
@@ -21009,13 +20204,11 @@ wikidata:en: Q42863139
 fr: Nuits-Saint-Georges premier cru Les Petits Plets, Nuits-Saint-Georges Les Petits Plets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Porrets Saint-Georges, Nuits-Saint-Georges Les Porrets Saint-Georges
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Porrets-Saint-Georges rouge
@@ -21029,7 +20222,6 @@ wikidata:en: Q42863140
 fr: Nuits-Saint-Georges premier cru Les Poulettes, Nuits-Saint-Georges Les Poulettes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Poulettes rouge
@@ -21044,7 +20236,6 @@ wikidata:en: Q42863143
 fr: Nuits-Saint-Georges premier cru Les Proces, Nuits-Saint-Georges Les Proces
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Procès blanc
@@ -21058,7 +20249,6 @@ wikidata:en: Q42863147
 fr: Nuits-Saint-Georges premier cru Les Pruliers, Nuits-Saint-Georges Les Pruliers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Pruliers rouge
@@ -21072,7 +20262,6 @@ wikidata:en: Q42863149
 fr: Nuits-Saint-Georges premier cru Les Saints-Georges, Nuits-Saint-Georges Les Saints-Georges
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Saints-Georges rouge
@@ -21086,7 +20275,6 @@ wikidata:en: Q42863152
 fr: Nuits-Saint-Georges premier cru Les Terres Blanches, Nuits-Saint-Georges Les Terres Blanches
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Terres Blanches rouge
@@ -21100,7 +20288,6 @@ wikidata:en: Q42863156
 fr: Nuits-Saint-Georges premier cru Les Vallerots, Nuits-Saint-Georges Les Vallerots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Vallerots rouge
@@ -21114,7 +20301,6 @@ wikidata:en: Q42863159
 fr: Nuits-Saint-Georges premier cru Les Vaucrains, Nuits-Saint-Georges Les Vaucrains
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Les Vaucrains rouge
@@ -21128,7 +20314,6 @@ wikidata:en: Q42863162
 fr: Nuits-Saint-Georges premier cru Roncière, Nuits-Saint-Georges Roncière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Roncière rouge
@@ -21142,7 +20327,6 @@ wikidata:en: Q42863164
 fr: Nuits-Saint-Georges premier cru Rue de Chaux, Nuits-Saint-Georges Rue de Chaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Nuits-Saint-Georges
 fr: Nuits-Saint-Georges premier cru Rue de Chaux rouge
@@ -21252,19 +20436,16 @@ wikidata:en: Q42863192
 fr: Pernand-Vergelesses Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Clos Berthet, Pernand-Vergelesses Clos Berthet
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Clos Berthet blanc
@@ -21274,7 +20455,6 @@ wikidata:en: Q42863195
 fr: Pernand-Vergelesses premier cru Creux de la Net, Pernand-Vergelesses Creux de la Net
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Creux de la Net blanc
@@ -21288,7 +20468,6 @@ wikidata:en: Q42863199
 fr: Pernand-Vergelesses premier cru En Caradeux, Pernand-Vergelesses En Caradeux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru En Caradeux blanc
@@ -21302,7 +20481,6 @@ wikidata:en: Q42863203
 fr: Pernand-Vergelesses premier cru Ile des Vergelesses, Pernand-Vergelesses Ile des Vergelesses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Ile des Vergelesses blanc
@@ -21316,13 +20494,11 @@ wikidata:en: Q42863210
 fr: Pernand-Vergelesses premier cru La Morand, Pernand-Vergelesses La Morand
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Les Fichots, Pernand-Vergelesses Les Fichots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Les Fichots rouge
@@ -21336,19 +20512,16 @@ wikidata:en: Q42863211
 fr: Pernand-Vergelesses premier cru Les Plantes des Champs et Combottes, Pernand-Vergelesses Les Plantes des Champs et Combottes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Les Quartiers, Pernand-Vergelesses Les Quartiers
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Sous Frétille, Pernand-Vergelesses Sous Frétille
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Sous Frétille blanc
@@ -21358,13 +20531,11 @@ wikidata:en: Q42864341
 fr: Pernand-Vergelesses premier cru Vergelesses, Pernand-Vergelesses Vergelesses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Village de Pernand, Pernand-Vergelesses Village de Pernand
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Pernand-Vergelesses
 fr: Pernand-Vergelesses premier cru Village de Pernand blanc
@@ -21596,7 +20767,6 @@ wikidata:en: Q3400215
 < en: Wines from France
 fr: Pouilly-sur-Loire Val de Loire, Blanc Fumé de Pouilly, Pouilly-Fumé
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: white wines
@@ -21646,7 +20816,6 @@ protected_name_type:en: pdo
 fr: Puligny-Montrachet premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru rouge
@@ -21656,7 +20825,6 @@ wikidata:en: Q42862521
 fr: Puligny-Montrachet Champ Canet, Puligny-Montrachet premier cru Champ Canet
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Champ Canet rouge
@@ -21670,7 +20838,6 @@ wikidata:en: Q43021771
 fr: Puligny-Montrachet Champ Gain, Puligny-Montrachet premier cru Champ Gain
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Champ Gain blanc
@@ -21684,7 +20851,6 @@ wikidata:en: Q43017278
 fr: Puligny-Montrachet Clavaillon, Puligny-Montrachet premier cru Clavaillon
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Clavaillon blanc
@@ -21698,7 +20864,6 @@ wikidata:en: Q43017281
 fr: Puligny-Montrachet Clos de la Garenne, Puligny-Montrachet premier cru Clos de la Garenne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Clos de la Garenne rouge
@@ -21712,7 +20877,6 @@ wikidata:en: Q43013616
 fr: Puligny-Montrachet Clos de la Mouchère, Puligny-Montrachet premier cru Clos de la Mouchère
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Clos de la Mouchère rouge
@@ -21726,7 +20890,6 @@ wikidata:en: Q42862487
 fr: Puligny-Montrachet Hameau de Blagny, Puligny-Montrachet premier cru Hameau de Blagny
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Hameau de Blagny blanc
@@ -21736,7 +20899,6 @@ wikidata:en: Q42862490
 fr: Puligny-Montrachet La Garenne, Puligny-Montrachet premier cru La Garenne
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru La Garenne blanc
@@ -21746,7 +20908,6 @@ wikidata:en: Q42862492
 fr: Puligny-Montrachet La Truffière, Puligny-Montrachet premier cru La Truffière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru La Truffière blanc
@@ -21760,7 +20921,6 @@ wikidata:en: Q42862494
 fr: Puligny-Montrachet Le Cailleret, Puligny-Montrachet premier cru Le Cailleret
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Le Cailleret blanc
@@ -21774,7 +20934,6 @@ wikidata:en: Q42862500
 fr: Puligny-Montrachet Les Chalumaux, Puligny-Montrachet premier cru Les Chalumaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Les Chalumaux blanc
@@ -21788,7 +20947,6 @@ wikidata:en: Q42862504
 fr: Puligny-Montrachet Les Combettes, Puligny-Montrachet premier cru Les Combettes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Les Combettes rouge
@@ -21802,7 +20960,6 @@ wikidata:en: Q42862505
 fr: Puligny-Montrachet Les Demoiselles, Puligny-Montrachet premier cru Les Demoiselles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Les Demoiselles rouge
@@ -21816,7 +20973,6 @@ wikidata:en: Q42862508
 fr: Puligny-Montrachet Les Folatières, Puligny-Montrachet premier cru Les Folatières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Les Folatières rouge
@@ -21830,7 +20986,6 @@ wikidata:en: Q42862512
 fr: Puligny-Montrachet Les Perrières, Puligny-Montrachet premier cru Les Perrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Les Perrières blanc
@@ -21844,7 +20999,6 @@ wikidata:en: Q42862528
 fr: Puligny-Montrachet Les Pucelles, Puligny-Montrachet premier cru Les Pucelles
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Les Pucelles rouge
@@ -21858,7 +21012,6 @@ wikidata:en: Q42862526
 fr: Puligny-Montrachet Les Referts, Puligny-Montrachet premier cru Les Referts
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Les Referts rouge
@@ -21872,7 +21025,6 @@ wikidata:en: Q42862524
 fr: Puligny-Montrachet Sous le Puits, Puligny-Montrachet premier cru Sous le Puits
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Puligny-Montrachet
 fr: Puligny-Montrachet premier cru Sous le Puits blanc
@@ -21905,7 +21057,6 @@ wikidata:en: Q2123199
 < en: Wines from France
 fr: Rasteau Rancio
 origins:en: en:france
-#wikidata:en:
 
 < fr: Rasteau Rancio
 fr: Rasteau tuilé rancio
@@ -21930,7 +21081,6 @@ wikidata:en: Q42862538
 < en: Wines from France
 fr: Régnié
 origins:en: en:france, en:beaujolais
-#wikidata:en:
 
 < en: Wines from France
 fr: Reuilly Val de Loire, Reuilly
@@ -21993,7 +21143,6 @@ wikidata:en: Q3442913
 < en: Wines from France
 fr: Rosé de Loire Val de Loire, Rosé de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Rosé des Riceys
@@ -22003,7 +21152,6 @@ wikidata:en: Q2167983
 < en: Wines from France
 fr: Vin Rosette
 origins:en: en:france
-#wikidata:en:
 
 < en: White wines
 < en: Wines from France
@@ -22038,7 +21186,6 @@ wikidata:en: Q42319297
 fr: Rully premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully
 fr: Rully premier cru blanc
@@ -22052,7 +21199,6 @@ wikidata:en: Q42319416
 fr: Rully premier cru Agneux, Rully Agneux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully
 fr: Rully premier cru Agneux blanc
@@ -22066,7 +21212,6 @@ wikidata:en: Q42863225
 fr: Rully premier cru Champs Cloux, Rully Champs Cloux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully
 fr: Rully premier cru Champs Cloux rouge
@@ -22080,7 +21225,6 @@ wikidata:en: Q42301233
 fr: Rully premier cru Chapitre, Rully Chapitre
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully
 fr: Rully premier cru Chapitre blanc
@@ -22094,7 +21238,6 @@ wikidata:en: Q42863228
 fr: Rully premier cru Clos du Chaigne à Jean de France, Rully Clos du Chaigne à Jean de France
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully
 fr: Rully premier cru Clos du Chaigne rouge
@@ -22108,7 +21251,6 @@ wikidata:en: Q42319311
 fr: Rully premier cru Clos Saint-Jacques, Rully Clos Saint-Jacques
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Clos Saint-Jacques
 fr: Rully premier cru Clos St Jacques rouge
@@ -22122,7 +21264,6 @@ wikidata:en: Q42319313
 fr: Rully premier cru Cloux, Rully Cloux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Cloux
 fr: Rully premier cru Cloux rouge
@@ -22136,7 +21277,6 @@ wikidata:en: Q42319320
 fr: Rully premier cru Gresigny, Rully Gresigny
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Gresigny
 fr: Rully premier cru Grésigny blanc
@@ -22150,7 +21290,6 @@ wikidata:en: Q42863236
 fr: Rully premier cru La Bressande, Rully La Bressande
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru La Bressande
 fr: Rully premier cru La Bressande rouge
@@ -22164,7 +21303,6 @@ wikidata:en: Q42319330
 fr: Rully premier cru La Fosse, Rully La Fosse
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru La Fosse
 fr: Rully premier cru La Fosse blanc
@@ -22178,7 +21316,6 @@ wikidata:en: Q42863239
 fr: Rully premier cru La Pucelle, Rully La Pucelle
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru La Pucelle
 fr: Rully premier cru La Pucelle rouge
@@ -22192,7 +21329,6 @@ wikidata:en: Q42319341
 fr: Rully premier cru La Renarde, Rully La Renarde
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru La Renarde
 fr: Rully premier cru La Renarde rouge
@@ -22206,7 +21342,6 @@ wikidata:en: Q42319344
 fr: Rully premier cru Le Meix Cadot, Rully Le Meix Cadot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Le Meix Cadot
 fr: Rully premier cru Le Meix Cadot blanc
@@ -22220,7 +21355,6 @@ wikidata:en: Q42863245
 fr: Rully premier cru Le Meix Caillet, Rully Le Meix Caillet
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Le Meix Caillet
 fr: Rully premier cru Le Meix Caillet rouge
@@ -22234,7 +21368,6 @@ wikidata:en: Q42319347
 fr: Rully premier cru Les Pierres, Rully Les Pierres
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Les Pierres
 fr: Rully premier cru Les Pierres rouge
@@ -22248,7 +21381,6 @@ wikidata:en: Q42319351
 fr: Rully premier cru Margotés, Rully Margotés
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Margotés
 fr: Rully premier cru Margotés rouge
@@ -22262,7 +21394,6 @@ wikidata:en: Q42863249
 fr: Rully premier cru Marissou, Rully Marissou
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Marissou
 fr: Rully premier cru Marissou blanc
@@ -22276,7 +21407,6 @@ wikidata:en: Q42863253
 fr: Rully premier cru Molesme, Rully Molesme
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Molesme
 fr: Rully premier cru Molesme blanc
@@ -22290,7 +21420,6 @@ wikidata:en: Q42863257
 fr: Rully premier cru Montpalais, Rully Montpalais
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Montpalais
 fr: Rully premier cru Montpalais rouge
@@ -22304,7 +21433,6 @@ wikidata:en: Q42319392
 fr: Rully premier cru Pillot, Rully Pillot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Pillot
 fr: Rully premier cru Pillot rouge
@@ -22318,7 +21446,6 @@ wikidata:en: Q42319393
 fr: Rully premier cru Preaux, Rully Preaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Preaux
 fr: Rully premier cru Préaux blanc
@@ -22332,7 +21459,6 @@ wikidata:en: Q42863261
 fr: Rully premier cru Rabourcé, Rully Rabourcé
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Rabourcé
 fr: Rully premier cru Rabourcé blanc
@@ -22346,7 +21472,6 @@ wikidata:en: Q42863262
 fr: Rully premier cru Raclot, Rully Raclot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Raclot
 fr: Rully premier cru Raclot rouge
@@ -22360,7 +21485,6 @@ wikidata:en: Q42319401
 fr: Rully premier cru Vauvry, Rully Vauvry
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Rully premier cru Vauvry
 fr: Rully premier cru Vauvry blanc
@@ -22394,7 +21518,6 @@ wikidata:en: Q3463541
 fr: Saint-Aubin premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru blanc
@@ -22408,31 +21531,26 @@ wikidata:en: Q42863612
 fr: Saint-Aubin Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Bas de Vermarain à l'est, Saint-Aubin Bas de Vermarain à l'est
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Derrière chez Edouard, Saint-Aubin Derrière chez Edouard
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Derrière la Tour, Saint-Aubin Derrière la Tour
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Echaille, Saint-Aubin Echaille
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Echaille rouge
@@ -22446,7 +21564,6 @@ wikidata:en: Q42863293
 fr: Saint-Aubin premier cru En Créot, Saint-Aubin En Créot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin premier cru En Créot
 fr: Saint-Aubin premier cru En Créot blanc
@@ -22460,7 +21577,6 @@ wikidata:en: Q42863290
 fr: Saint-Aubin premier cru En la Ranché, Saint-Aubin En la Ranché
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin premier cru En la Ranché
 fr: Saint-Aubin premier cru En la Ranché blanc
@@ -22474,7 +21590,6 @@ wikidata:en: Q42863286
 fr: Saint-Aubin premier cru En Montceau, Saint-Aubin En Montceau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin premier cru En Montceau
 fr: Saint-Aubin premier cru En Montceau rouge
@@ -22488,7 +21603,6 @@ wikidata:en: Q42863284
 fr: Saint-Aubin premier cru En Remilly, Saint-Aubin En Remilly
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin premier cru En Remilly
 fr: Saint-Aubin premier cru En Remilly blanc
@@ -22502,7 +21616,6 @@ wikidata:en: Q42863279
 fr: Saint-Aubin premier cru En Vollon à l'Est, Saint-Aubin En Vollon à l'Est
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin premier cru En Vollon à l'Est
 fr: Saint-Aubin premier cru En Vollon à l'Est rouge
@@ -22516,7 +21629,6 @@ wikidata:en: Q42863544
 fr: Saint-Aubin premier cru Es Champs, Saint-Aubin Es Champs
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin premier cru Es Champs
 fr: Saint-Aubin premier cru Es Champs rouge
@@ -22530,7 +21642,6 @@ wikidata:en: Q42863550
 fr: Saint-Aubin premier cru La Chatenière, Saint-Aubin La Chatenière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin premier cru La Chatenière
 fr: Saint-Aubin premier cru La Chatenière blanc
@@ -22544,7 +21655,6 @@ wikidata:en: Q42863557
 fr: Saint-Aubin premier cru Le Bas de Gamay à l'Est, Saint-Aubin Le Bas de Gamay à l'Est
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin premier cru Le Bas de Gamay à l'Est
 fr: Saint-Aubin premier cru Le Bas de Gamay à l'Est blanc
@@ -22558,7 +21668,6 @@ wikidata:en: Q42863559
 fr: Saint-Aubin premier cru Le Charmois, Saint-Aubin Le Charmois
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Le Charmois rouge
@@ -22572,7 +21681,6 @@ wikidata:en: Q42863562
 fr: Saint-Aubin premier cru Le Puits, Saint-Aubin Le Puits
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Le Puits blanc
@@ -22586,7 +21694,6 @@ wikidata:en: Q42863568
 fr: Saint-Aubin premier cru Les Castets, Saint-Aubin Les Castets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Castets rouge
@@ -22600,7 +21707,6 @@ wikidata:en: Q42863569
 fr: Saint-Aubin premier cru Les Champlots, Saint-Aubin Les Champlots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Champlots rouge
@@ -22614,7 +21720,6 @@ wikidata:en: Q42863574
 fr: Saint-Aubin premier cru Les Combes, Saint-Aubin Les Combes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Combes rouge
@@ -22628,7 +21733,6 @@ wikidata:en: Q42863581
 fr: Saint-Aubin premier cru Les Combes au Sud, Saint-Aubin Les Combes au Sud
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Combes au Sud blanc
@@ -22642,7 +21746,6 @@ wikidata:en: Q42863579
 fr: Saint-Aubin premier cru Les Cortons, Saint-Aubin Les Cortons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Cortons blanc
@@ -22656,7 +21759,6 @@ wikidata:en: Q42863584
 fr: Saint-Aubin premier cru Les Frionnes, Saint-Aubin Les Frionnes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Frionnes rouge
@@ -22670,7 +21772,6 @@ wikidata:en: Q42863586
 fr: Saint-Aubin premier cru Les Murgers des Dents de Chien, Saint-Aubin Les Murgers des Dents de Chien
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Murgers des dents de chien blanc
@@ -22684,7 +21785,6 @@ wikidata:en: Q42863592
 fr: Saint-Aubin premier cru Les Perrières, Saint-Aubin Les Perrières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Perrières rouge
@@ -22698,7 +21798,6 @@ wikidata:en: Q42863595
 fr: Saint-Aubin premier cru Les Travers de Marinot, Saint-Aubin Les Travers de Marinot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Les Travers de Marinot rouge
@@ -22712,7 +21811,6 @@ wikidata:en: Q42863599
 fr: Saint-Aubin premier cru Marinot, Saint-Aubin Marinot
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Marinot blanc
@@ -22726,7 +21824,6 @@ wikidata:en: Q42863608
 fr: Saint-Aubin premier cru Pitangeret, Saint-Aubin Pitangeret
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Pitangeret rouge
@@ -22740,7 +21837,6 @@ wikidata:en: Q42863610
 fr: Saint-Aubin premier cru Sous Roche Dumay, Saint-Aubin Sous Roche Dumay
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Sous Roche Dumay rouge
@@ -22754,7 +21850,6 @@ wikidata:en: Q42863616
 fr: Saint-Aubin premier cru Sur Gamay, Saint-Aubin Sur Gamay
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Sur Gamay blanc
@@ -22768,7 +21863,6 @@ wikidata:en: Q42863621
 fr: Saint-Aubin premier cru Sur le Sentier du Clou, Saint-Aubin Sur le Sentier du Clou
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Sur le sentier du Clou rouge
@@ -22782,7 +21876,6 @@ wikidata:en: Q42863622
 fr: Saint-Aubin premier cru Vignes Moingeon, Saint-Aubin Vignes Moingeon
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Vignes Moingeon rouge
@@ -22796,7 +21889,6 @@ wikidata:en: Q42863631
 fr: Saint-Aubin premier cru Village, Saint-Aubin Village
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Saint-Aubin
 fr: Saint-Aubin premier cru Village blanc
@@ -22862,7 +21954,6 @@ fr: Saint-Estèphe, Saint Estèphe
 origins:en: en:france
 protected_name_type:en: pdo
 wikidata:en: Q1640145
-#wikidata:en:
 
 < en: Red wines
 < fr: saint-émilion
@@ -22877,12 +21968,10 @@ fr: Saint-Guilhem-le-Désert
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1143
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Saint-Joseph
 origins:en: en:france
-#wikidata:en:
 
 < en: White wines
 < fr: Saint-Joseph
@@ -22897,17 +21986,14 @@ wikidata:en: Q382471
 < en: Wines from France
 fr: Saint-Mont
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Saint-Nicolas-de-Bourgueil Val de Loire, Saint-Nicolas-de-Bourgueil
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Saint-Péray mousseux, Saint-Péray
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Saint-Pourçain
@@ -22927,7 +22013,6 @@ wikidata:en: Q3463558
 fr: Saint-Romain côte-de-beaune, Saint Romain Côte de Beaune
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Saint-Sardos
@@ -22980,7 +22065,6 @@ fr: Santenay rouge ou Santenay Côte de Beaune (Q42863352
 fr: Santenay premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay premier cru
 fr: Santenay premier cru rouge
@@ -22996,7 +22080,6 @@ protected_name_type:en: pdo
 fr: Santenay premier cru Beauregard, Santenay Beauregard
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Beauregard rouge
@@ -23010,7 +22093,6 @@ wikidata:en: Q42301020
 fr: Santenay premier cru Beaurepaire, Santenay Beaurepaire
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Beaurepaire blanc
@@ -23024,7 +22106,6 @@ wikidata:en: Q42301024
 fr: Santenay premier cru Clos de Tavannes, Santenay Clos de Tavannes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Clos de Tavannes blanc
@@ -23038,7 +22119,6 @@ wikidata:en: Q42863325
 fr: Santenay premier cru Clos des Mouches, Santenay Clos des Mouches
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Clos des Mouches rouge
@@ -23052,7 +22132,6 @@ wikidata:en: Q42301049
 fr: Santenay premier cru Clos Faubard, Santenay Clos Faubard
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Clos Faubard blanc
@@ -23066,13 +22145,11 @@ wikidata:en: Q42863327
 fr: Santenay premier cru Clos Rousseau, Santenay Clos Rousseau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Grand Clos Rousseau, Santenay Grand Clos Rousseau
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Grand Clos Rousseau rouge
@@ -23086,7 +22163,6 @@ wikidata:en: Q42301052
 fr: Santenay premier cru La Comme, Santenay La Comme
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru La Comme rouge
@@ -23100,7 +22176,6 @@ wikidata:en: Q42863331
 fr: Santenay premier cru La Maladière, Santenay La Maladière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru La Maladière blanc
@@ -23114,7 +22189,6 @@ wikidata:en: Q42863336
 fr: Santenay premier cru Les Gravières, Santenay Les Gravières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Les Gravières rouge
@@ -23128,7 +22202,6 @@ wikidata:en: Q42863337
 fr: Santenay premier cru Les Gravières - Clos de Tavannes, Santenay Les Gravières - Clos de Tavannes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Les Gravières-Clos de Tavannes rouge
@@ -23142,7 +22215,6 @@ wikidata:en: Q42863341
 fr: Santenay premier cru Passetemps, Santenay Passetemps
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Santenay
 fr: Santenay premier cru Passetemps rouge
@@ -23163,12 +22235,10 @@ fr: Saumur
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0260-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Saumur Val de Loire mousseux or pétillant, Saumur Val de Loire mousseux, Saumur Val de Loire pétillant
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Saumur-Champigny, Saumur-Champigny Val de Loire
@@ -23187,26 +22257,22 @@ fr: Sauternes
 origins:en: en:france
 protected_name_type:en: pdo
 wikidata:en: Q771636
-#wikidata:en:
 
 < en: Wines from France
 fr: Savennières, Savennières Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Savennières-Coulée de Serrant, Savennières-Coulée de Serrant Val de Loire
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0983-AM01, en:PDO-FR-A0983
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Savennières-Roche-aux-Moines, Savennières-Roche-aux-Moines Val de Loire, Savennières Roche aux Moines
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0982
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -23228,7 +22294,6 @@ wikidata:en: Q42319266
 fr: Savigny-lès-Beaune premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru rouge
@@ -23248,7 +22313,6 @@ protected_name_type:en: pdo
 fr: Savigny-lès-Beaune premier cru Aux Clous, Savigny-lès-Beaune Aux Clous
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Aux Clous rouge
@@ -23262,7 +22326,6 @@ wikidata:en: Q42365208
 fr: Savigny-lès-Beaune premier cru Aux Fourneaux, Savigny-lès-Beaune Aux Fourneaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Aux Fourneaux blanc
@@ -23276,7 +22339,6 @@ wikidata:en: Q42863364
 fr: Savigny-lès-Beaune premier cru Aux Gravains, Savigny-lès-Beaune Aux Gravains
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Aux Gravains blanc
@@ -23290,7 +22352,6 @@ wikidata:en: Q42863367
 fr: Savigny-lès-Beaune premier cru Aux Guettes, Savigny-lès-Beaune Aux Guettes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Aux Guettes rouge
@@ -23304,7 +22365,6 @@ wikidata:en: Q42863369
 fr: Savigny-lès-Beaune premier cru Aux Serpentières, Savigny-lès-Beaune Aux Serpentières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Aux Serpentières blanc
@@ -23318,7 +22378,6 @@ wikidata:en: Q42863844
 fr: Savigny-lès-Beaune premier cru Basses Vergelesses, Savigny-lès-Beaune Basses Vergelesses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Basses Vergelesses blanc
@@ -23332,7 +22391,6 @@ wikidata:en: Q42863847
 fr: Savigny-lès-Beaune premier cru Bataillière, Savigny-lès-Beaune Bataillière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Bataillère rouge
@@ -23346,7 +22404,6 @@ wikidata:en: Q42863849
 fr: Savigny-lès-Beaune premier cru Champ Chevrey, Savigny-lès-Beaune Champ Chevrey
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Champ Chevrey blanc
@@ -23360,7 +22417,6 @@ wikidata:en: Q42863855
 fr: Savigny-lès-Beaune premier cru La Dominode, Savigny-lès-Beaune La Dominode
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru La Dominode rouge
@@ -23374,7 +22430,6 @@ wikidata:en: Q42864391
 fr: Savigny-lès-Beaune premier cru Les Charnières, Savigny-lès-Beaune Les Charnières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Charnières blanc
@@ -23388,7 +22443,6 @@ wikidata:en: Q42864394
 fr: Savigny-lès-Beaune premier cru Les Haut Jarrons, Savigny-lès-Beaune Les Haut Jarrons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Hauts Jarrons blanc
@@ -23402,7 +22456,6 @@ wikidata:en: Q42864398
 fr: Savigny-lès-Beaune premier cru Les Hauts Marconnets, Savigny-lès-Beaune Les Hauts Marconnets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Hauts Marconnets blanc
@@ -23416,7 +22469,6 @@ wikidata:en: Q42864400
 fr: Savigny-lès-Beaune premier cru Les Jarrons, Savigny-lès-Beaune Les Jarrons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Jarrons rouge
@@ -23430,7 +22482,6 @@ wikidata:en: Q42864403
 fr: Savigny-lès-Beaune premier cru Les Lavières, Savigny-lès-Beaune Les Lavières
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Lavières blanc
@@ -23444,7 +22495,6 @@ wikidata:en: Q42863861
 fr: Savigny-lès-Beaune premier cru Les Marconnets, Savigny-lès-Beaune Les Marconnets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Marconnets rouge
@@ -23458,7 +22508,6 @@ wikidata:en: Q42863863
 fr: Savigny-lès-Beaune premier cru Les Narbantons, Savigny-lès-Beaune Les Narbantons
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Narbantons rouge
@@ -23472,7 +22521,6 @@ wikidata:en: Q42863648
 fr: Savigny-lès-Beaune premier cru Les Peuillets, Savigny-lès-Beaune Les Peuillets
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Peuillets rouge
@@ -23486,7 +22534,6 @@ wikidata:en: Q42863651
 fr: Savigny-lès-Beaune premier cru Les Rouvrettes, Savigny-lès-Beaune Les Rouvrettes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Rouvrettes blanc
@@ -23500,7 +22547,6 @@ wikidata:en: Q42863374
 fr: Savigny-lès-Beaune premier cru Les Talmettes, Savigny-lès-Beaune Les Talmettes
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Talmettes blanc
@@ -23514,7 +22560,6 @@ wikidata:en: Q42863378
 fr: Savigny-lès-Beaune premier cru Les Vergelesses, Savigny-lès-Beaune Les Vergelesses
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Les Vergelesses rouge
@@ -23528,7 +22573,6 @@ wikidata:en: Q42863379
 fr: Savigny-lès-Beaune premier cru Petits Godeaux, Savigny-lès-Beaune Petits Godeaux
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Petits Godeaux blanc
@@ -23542,7 +22586,6 @@ wikidata:en: Q42863382
 fr: Savigny-lès-Beaune premier cru Redrescul, Savigny-lès-Beaune Redrescul
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Savigny-lès-Beaune
 fr: Savigny-lès-Beaune premier cru Redrescul blanc
@@ -23555,7 +22598,6 @@ wikidata:en: Q42863385
 < en: Wines from France
 fr: Seyssel, Seyssel mousseux
 origins:en: en:france
-#wikidata:en:
 
 < en: Burgundy wines
 < en: Red wines
@@ -23569,7 +22611,6 @@ wikidata:en: Q923449
 < en: Wines from France
 fr: Tavel
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Thézac-Perricard
@@ -23585,12 +22626,10 @@ protected_name_type:en: pgi
 < en: Wines from France
 fr: Touraine Noble Joué, Touraine Noble Joué Val de Loire
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Touraine, Touraine Val de Loire, Touraine Val de Loire mousseux, Touraine Val de Loire pétillant
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Tursan
@@ -23646,17 +22685,14 @@ protected_name_type:en: pgi
 < en: Wines from France
 fr: Vin de Savoie
 origins:en: en:france
-#wikidata:en:
 
 < fr: Vin de Savoie
 fr: Vin de Savoie mousseux, Vin de Savoie pétillant
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Vin d'Entraygues et du Fel
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Estaing
@@ -23773,7 +22809,6 @@ wikidata:en: Q42303115
 fr: Volnay premier cru Fremiets - Clos de la Rougeotte, Volnay Fremiets - Clos de la Rougeotte
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Volnay
 fr: Volnay premier cru La Gigotte, Volnay La Gigotte
@@ -23974,7 +23009,6 @@ wikidata:en: Q42300930
 fr: Vougeot premier cru
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Vougeot
 fr: Vougeot premier cru blanc
@@ -23988,7 +23022,6 @@ wikidata:en: Q42300929
 fr: Vougeot premier cru Clos de la Perrière, Vougeot Clos de la Perrière
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Vougeot
 fr: Vougeot premier cru Clos de la Perrière blanc
@@ -24002,7 +23035,6 @@ wikidata:en: Q42300922
 fr: Vougeot premier cru Le Clos Blanc, Vougeot Le Clos Blanc
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Vougeot
 fr: Vougeot premier cru Le Clos Blanc blanc
@@ -24016,7 +23048,6 @@ wikidata:en: Q42300924
 fr: Vougeot premier cru Les Crâs, Vougeot Les Crâs
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Vougeot
 fr: Vougeot premier cru Les Crâs rouge
@@ -24030,7 +23061,6 @@ wikidata:en: Q42300925
 fr: Vougeot premier cru Les Petits Vougeots, Vougeot Les Petits Vougeots
 origins:en: en:france, en:burgundy
 protected_name_type:en: pdo
-#wikidata:en:
 
 < fr: Vougeot
 fr: Vougeot premier cru Les Petits Vougeots blanc
@@ -24043,7 +23073,6 @@ wikidata:en: Q42300928
 < en: Wines from France
 fr: Vouvray, Vouvray Val de Loire, Vouvray Val de Loire mousseux, Vouvray Val de Loire pétillant
 origins:en: en:france
-#wikidata:en:
 
 < en: Wines from France
 fr: Yonne
@@ -24128,119 +23157,102 @@ sl: Štajerska Slovenija
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0639
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Metliška črnina
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A1579
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Slovenska Istra
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0609
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Bizeljčan
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A1520
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Prekmurje
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0769
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Bizeljsko Sremič
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0772
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Vipavska dolina
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0448
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Kras
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0616
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Bela krajina
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0878
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Belokranjec
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A1576
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Dolenjska
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0871
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Goriška Brda
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A0270
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Cviček
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A1561
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Teran
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-A1581
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Posavje
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-A1061
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Primorska
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-A1094
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian wines
 sl: Podravje
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-A0995
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines
 en: Wines from Algeria
@@ -24356,42 +23368,36 @@ en: Sussex
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-02365
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British wines
 en: Darnibole
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-N1636
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British wines
 en: English
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-A1585
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British wines
 en: Welsh
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-A1587
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British wines
 en: English Regional
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-A1589
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British wines
 en: Welsh Regional
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-A1590
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines
 en: Swiss wines
@@ -24420,224 +23426,192 @@ it: Vini austriaci
 nl: Oostenrijkse wijnen
 origins:en: en:austria
 wikidata:en: Q23237
-#wikidata:en:
 
 < en: Wines from Austria
 de: Carnuntum
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0217, PDO-AT-A0217-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Neusiedlersee
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0219, PDO-AT-A0219-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Weststeiermark
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0234, PDO-AT-A0234-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Südsteiermark
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0228, PDO-AT-A0228-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Süd-Oststeiermark
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0226, PDO-AT-A0226-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Rosalia
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-02594
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Wiener Gemischter Satz
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-02593
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Südburgenland
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0227, PDO-AT-A0227-CANCEL
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Neusiedlersee-Hügelland
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0220, PDO-AT-A0220-CANCEL
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Eisenberg
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0215
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Leithaberg
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0216
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Wagram
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0233
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Steirerland
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-A0213
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Austria
 de: Bergland
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-A0211
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Austria
 de: Weinland
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-A0212
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Austria
 de: Salzburg
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0224
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Kärnten
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0218
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Oberösterreich
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0223
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Burgenland
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0207
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Niederösterreich
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0221
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Steiermark
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0225
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Tirol
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0230
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Vorarlberg
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0231
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Wachau
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0205
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Weinviertel
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0206
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Kremstal
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0208
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Kamptal
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0209
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Traisental
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0210
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Mittelburgenland
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0214
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Wien
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0235
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Austria
 de: Thermenregion
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-A0229
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines
 en: Wines from Brazil, Brazilian Wines
@@ -24673,35 +23647,30 @@ da: Dons
 origins:en: en:denmark
 protected_name_file_number:en: PDO-DK-N1635
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Danish wines
 da: Sjælland
 origins:en: en:denmark
 protected_name_file_number:en: PGI-DK-A1245
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Danish wines
 da: Fyn
 origins:en: en:denmark
 protected_name_file_number:en: PGI-DK-A1248
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Danish wines
 da: Jylland
 origins:en: en:denmark
 protected_name_file_number:en: PGI-DK-A1247
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Danish wines
 da: Bornholm
 origins:en: en:denmark
 protected_name_file_number:en: PGI-DK-A1249
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines
 en: Dutch wines
@@ -24718,119 +23687,102 @@ nl: Wijnen uit Ambt Delden
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-02169
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Vijlen
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-02168
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Oolde
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-02230
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Mergelland
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-02114
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit de Achterhoek - Winterswijk
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-02402
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Noord-Brabant
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0964
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Zuid-Holland
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0965
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Noord-Holland
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0966
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Limburg
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0961
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Gelderland
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0962
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Zeeland
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0963
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Utrecht
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0967
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Overijssel
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0968
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Flevoland
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0380
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Drenthe
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0969
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Groningen
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0970
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch wines
 nl: Wijnen uit Friesland
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-A0972
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines
 en: Wines from Belgium, Belgian Wines
@@ -24854,14 +23806,12 @@ nl: Vlaamse mousserende kwaliteitswijn, Vlaamse mousserende kwaliteitswijnen
 origins:en: en:belgium
 protected_name_file_number:en: PDO-BE-A1430
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Belgium
 fr: Vin mousseux de qualité de Wallonie
 origins:en: en:belgium
 protected_name_file_number:en: PDO-BE-A0011
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Belgium
 fr: Crémant de Wallonie
@@ -24875,7 +23825,6 @@ nl: Vlaamse landwijn, Vlaamse landwijnen
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-A1429
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Belgium
 fr: Côtes de Sambre et Meuse
@@ -24889,28 +23838,24 @@ fr: Vin de pays des jardins de Wallonie
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-A0010
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Belgium
 nl: Haspengouwse wijn, Haspengouwse Wijnen
 origins:en: en:belgium
 protected_name_file_number:en: PDO-BE-A1492
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Belgium
 nl: Hagelandse wijn, Hagelandse wijnen
 origins:en: en:belgium
 protected_name_file_number:en: PDO-BE-A1499
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Belgium
 nl: Heuvellandse wijn
 origins:en: en:belgium
 protected_name_file_number:en: PDO-BE-A1426
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines
 en: Wines from Bulgaria, Bulgarian Wines
@@ -24927,315 +23872,270 @@ bg: Болярово
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0985
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Лозица
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0360
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Върбица, Varbitsa
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0370
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Ново село, Novo Selo
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0382
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Павликени, Pavlikeni
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0420
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Поморие, Pomorie
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0430
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Брестник, Brestnik
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0944
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Евксиноград, Evksinograd
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0881
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Варна, Varna
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1032
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Видин, Vidin
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1346
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Враца, Vratsa
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0955
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Долината на Струма, Struma valley
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1473
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Ивайловград, Ivaylovgrad
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1047
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Карлово, Karlovo
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1044
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Ловеч, Lovech
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0956
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Лом, Lom
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1441
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Любимец, Lyubimets
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1177
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Лясковец, Lyaskovets
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0951
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Мелник, Melnik
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1472
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Монтана, Montana
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1314
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Нова Загора, Nova Zagora
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1494
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Оряховица, Oryahovitsa
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1344
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Пазарджик, Pazardjik
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1182
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Перущица, Perushtitsa
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1474
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Плевен, Pleven
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1477
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Пловдив, Plovdiv
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1297
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Русе, Ruse
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1425
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Свищов, Svishtov
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0957
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Септември, Septemvri
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1185
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Славянци, Slavyantsi
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1008
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Сливен, Sliven
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1190
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Стамболово, Stambolovo
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1487
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Стара Загора, Stara Zagora
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1394
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Сунгурларе, Sungurlare
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1489
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Сухиндол, Suhindol
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1018
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Търговище, Targovishte
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1439
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Хан Крум, Han Krum
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1030
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Хасково, Haskovo
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1043
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Хисаря, Hisarya
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1393
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Хърсово, Harsovo
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0946
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Черноморски район
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1392
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Шумен, Shumen
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0997
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Южно Черноморие, Southern Black Sea Coast
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1347
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Ямбол, Yambol
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1179
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Cakap
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0013
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Асеновград
@@ -25243,73 +24143,62 @@ en: Asenovgrad
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0877
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Велики Преслав, Veliki Preslav
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0885
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Карнобат, Karnobat
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1175
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Сандански, Sandanski
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1006
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Шивачево, Shivachevo
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1391
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Драгоево, Dragoevo
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A0952
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Нови Пазар, Novi Pazar
 origins:en: en:bulgaria
 protected_name_file_number:en: PDO-BG-A1031
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Дунавска равнина, Danube Plain
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-A1538
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Тракийска низина, Thracian Lowlands
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-A1552
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Лозицa, Lozitsa
 origins:en: en:bulgaria
-#wikidata:en:
 
 < en: Wines from Bulgaria
 bg: Сакар, Sakar
 origins:en: en:bulgaria
-#wikidata:en:
 
 < en: Wines
 en: Wines from Canada, Canadian Wines
@@ -25364,126 +24253,108 @@ hr: Muškat momjanski, Moscato di Momiano
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-02109
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Ponikve
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-02087
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Dingač
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1649
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Dalmatinske zagore, Dalmatinska zagora
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1648
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Hrvatsko Podunavlje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1655
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Hrvatsko primorje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1650
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Istočna kontinentalna Hrvatska
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1651
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Moslavina
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1653
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Plešivica
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1654
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Prigorje-Bilogora
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1657
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Sjeverna Dalmacija
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1659
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Slavonija
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1660
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Srednja i Južna Dalmacija
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1661
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Zagorje – Međimurje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1662
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Zapadna kontinentalna Hrvatska
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1663
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Pokuplje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1656
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Hrvatska Istra
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1652
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Croatia
 hr: Primorska Hrvatska
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-A1658
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines
 en: Wines from Cyprus, Cypriot wines
@@ -25497,115 +24368,96 @@ el: Κουμανδαρία
 origins:en: en:cyprus
 protected_name_file_number:en: PDO-CY-A1622
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Krasohoria Lemesou, Krasohoria Lemesou Afames, Κρασοχώρια Λεμεσού, Κρασοχώρια Λεμεσού Αφάμης
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Krasohoria Lemesou Laona, Κρασοχώρια Λεμεσού Λαόνα
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Laona Akama, Λαόνα Ακάμα
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Larnaka, Λάρνακα
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Lefkosia, Λευκωσία
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Lemesos, Λεμεσός
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Pafos, Πάφος
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Pitsilia, Πιτσιλιά
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 cy: Vouni Panayia - Ampelitis, Βουνί Παναγιάς – Αμπελίτη
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Κρασοχώρια Λεμεσού - Λαόνα
 origins:en: en:cyprus
 protected_name_file_number:en: PDO-CY-A1624
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Βουνί Παναγιάς – Αμπελίτης
 origins:en: en:cyprus
 protected_name_file_number:en: PDO-CY-A1625
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Λαόνα Ακάμα
 origins:en: en:cyprus
 protected_name_file_number:en: PDO-CY-A1626
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Πιτσιλιά
 origins:en: en:cyprus
 protected_name_file_number:en: PDO-CY-A1627
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Κρασοχώρια Λεμεσού
 origins:en: en:cyprus
 protected_name_file_number:en: PDO-CY-A1628
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Πάφος
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-A1618
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Λεμεσός
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-A1619
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Λάρνακα
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-A1620
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Cyprus
 el: Λευκωσία
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-A1621
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines
 en: Wines from Czech Republic
@@ -25618,133 +24470,112 @@ wikidata:en: Q695626
 < en: Wines from Czech Republic
 cz: Čechy Litoměřická
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cz: Čechy Mělnická
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cz: české
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cz: Morava Mikulovská
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cz: Morava Slovácká
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cz: Morava Velkopavlovická
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cz: Morava Znojemská
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cz: moravské
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Novosedelské Slámové víno
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A1321
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Šobes, Šobeské víno
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A1089
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Znojmo
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A1086
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Čechy
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A0888
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Litoměřická
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A0894
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Velkopavlovická
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A0896
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Morava
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A0899
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Znojemská
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A0892
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Mělnická
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A0895
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Mikulovská
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A0897
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: Slovácká
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-A0890
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: české
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-A0900
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Czech Republic
 cs: moravské
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-A0902
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines
 en: Wines from Georgia, Georgian wines
@@ -25810,22 +24641,18 @@ origins:en: en:georgia
 < en: Wines from Georgia
 ge: Tibaani
 origins:en: en:georgia
-#wikidata:en:
 
 < en: Wines from Georgia
 ge: Tsinandali, winandali
 origins:en: en:georgia
-#wikidata:en:
 
 < en: Wines from Georgia
 ge: Tvishi, tviSi
 origins:en: en:georgia
-#wikidata:en:
 
 < en: Wines from Georgia
 ge: Vazisubani
 origins:en: en:georgia
-#wikidata:en:
 
 < en: Wines
 en: Wines from Germany, German wines
@@ -25841,430 +24668,362 @@ de: Ahr
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A0867
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Ahrtaler
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Baden
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1264
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Badischer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Bayerischer Bodensee
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Brandenburger
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Brandenburger Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1281
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Bürgstadter Berg
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-N1822
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Franken
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1267
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Hessische Bergstraße
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1268
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Landwein Neckar
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1284
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Main
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Mecklenburger
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Mitteldeutscher, Mitteldeutscher Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1291
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Mittelrhein
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1269
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Mosel
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1270
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Monzinger Niederberg
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-02363
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Nahe
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1271
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Nahegauer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Neckar
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Oberrhein
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Landwein Oberrhein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1285
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Pfalz
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1272
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Pfälzer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Regensburger
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rhein
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rheinburgen
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rheingau
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1273
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rheingauer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rheinhessen
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1274
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rheinischer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rhein-Neckar, Landwein Rhein-Neckar
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1287
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Ruwer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Saale-Unstrut
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1275
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Saar
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Saarländischer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Sächsischer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Schleswig-Holsteinischer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Schwäbischer
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Starkenburger
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Taubertäler
 origins:en: en:germany
-#wikidata:en:
 
 < en: Wines from Germany
 de: Uhlen Roth Lay
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-02083
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Uhlen Laubach
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-02082
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Uhlen Blaufüsser Lay, Uhlen Blaufüßer Lay
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-02081
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Württemberg
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1276
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Würzburger Stein-Berg
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-02403
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Schleswig-Holsteinischer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1304
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Landwein Rhein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1286
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Landwein Main
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1282
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Mecklenburger Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1290
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Badischer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1279
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Landwein der Ruwer
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1288
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rheingauer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1299
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Saarländischer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1302
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Sächsischer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1303
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Taubertäler Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1307
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Sachsen
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-A1277
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Germany
 de: Ahrtaler Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1278
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Bayerischer Bodensee-Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1280
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Landwein der Mosel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1283
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Landwein der Saar
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1289
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Nahegauer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1293
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Pfälzer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1294
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Regensburger Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1296
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rheinburgen-Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1298
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Rheinischer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1301
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Schwäbischer Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1305
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Germany
 de: Starkenburger Landwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-A1306
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines
 en: Wines from Greece, Greek wines
@@ -26278,566 +25037,459 @@ wikidata:en: Q1779616
 < en: Wines from Greece
 el: Achaia, Αχαϊα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Aegean Sea, Αιγαίο Πέλαγος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Agora, Αγορά
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Amynteo
 el: Amynteo, Αμύνταιο
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Anavyssos
 el: Anavyssos, Ανάβυσσος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Anchialos
 el: Anchialos, Αγχίαλος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Archanes
 el: Αρχάνες, Archanes
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Argolida
 el: Αργολίδα, Argolida
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Arkadia, Αρκαδία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Atalanti, Αταλάντη
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Attiki, Αττική
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Avdira, Άβδηρα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Cephalonia Muscatel, Μοσχάτος Κεφαλληνίας
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Corfu, Κέρκυρα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Cotes de Meliton, Πλαγιές Μελίτωνα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Crete, Κρήτη
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Cyclades, Κυκλάδες
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Dafnes, Δαφνές
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Dodekanese, Δωδεκάνησος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Drama, Δράμα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Epanomi, Επανομή
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Epirus, Ήπειρος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: anda, Εύβοια
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Florina, Φλώρινα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Gerania, Γεράνεια
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Goumenissa, Γουμένισσα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Grevena, Γρεβενά
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Halikouna, Χαλικούνα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Halkidiki, Χαλκιδική
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Heraklion, Ηράκλειο
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Ikaria, Ικαρία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Ilia, Ηλεία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Ilion, Ίλιον
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Imathia, Ημαθία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Ioannina, Ιωάννινα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Ismaros, Ίσμαρος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Karditsa, Καρδίτσα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Karystos, Κάρυστος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Kastoria, Καστοριά
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Kissamos, Κίσαμος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Kitherona, Κιθαιρώνας
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Klimenti, Κλημέντι
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Knimida, Κνημίδα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Korinthos, Κόρινθος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Kos, Κω
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Kozani, Κοζάνη
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Krania, Κρανιά
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Krannona, Κραννώνα
 origins:en: en:greece
-#wikidata:en:
 
 # conflicts with Greek oil
 #<en:Wines from Greece
 #el:Lakonia, Λακωνία
 #origins:en: en:Greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Lasithi, Λασίθι
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Lefkada, Λευκάδας
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Lemnos, Λήμνος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Lemnos Muscatel, Μοσχάτος Λήμνου
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Letrines, Λετρίνα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Lilantio Pedio, Ληλάντιο Πεδίο
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Macedonia, Μακεδονία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Magnissia, Μαγνησία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Mantinia, Μαντινεία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Mantzavinata, Μαντζαβινάτα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Markopoulo, Μαρκόπουλο
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Martino, Μαρτίνο
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Mavrodaphne of Cephalonia, Μαυροδάφνη Κεφαλληνίας
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Mavrodaphne of Patras, Μαυροδάφνη Πατρών
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Messenikola, Μεσενικόλα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Messinia, Μεσσηνία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Metaxata, Μεταξάτα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Meteora, Μετέωρα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Metsovo, Μέτσοβο
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Mount Athos - Holly Mountain, Άγιο Όρος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Muscat of Rio Patras, Μοσχάτος Ρίου Πατρών
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Naoussa, Νάουσα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Nea Messimvria, Νέα Μεσήμβρια
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Nemea, Νεμέα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Opountia Lokridos, Οπούντια Λοκρίδος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Παλλήνη, Pallini
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Παγγαίο, Pangeon
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Παρνασσός, Parnasos
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Πάρος, Paros
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Πάτρα, Patras
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Μοσχάτος Πατρών, Patras Muscatel
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Πέλλα, Pella
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Πελοπόννησος, Peloponnese
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Πεζά, Peza
 en: Peza
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Πιερία, Pieria
 en: Pieria
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Πισάτιδα, Pisatis
 en: Pisatis
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Πυλία, Pylia
 en: Pylia
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Ραψάνη, Rapsani
 en: Rapsani
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsaina of Megara, Retsaina of Megara Attika
 el: Ρετσίνα Μεγάρων, Ρετσίνα Μεγάρων Αττική, Retsaina of Megara, Retsaina of Megara Attika
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Retsina of Attiki, Ρετσίνα Αττικής
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Ewia
 el: Ρετσίνα Ευβοίας, Retsina of Ewia
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Gialtra, Retsina of Gialtra Ewia
 el: Ρετσίνα Γιάλτρων Εύβοια, Ρετσίνα Γιάλτρων, Retsina of Gialtra, Retsina of Gialtra Ewia
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Halkida, Retsina of Halkida Ewia
 el: Ρετσίνα Χαλκίδας, Ρετσίνα Χαλκίδας Εύβοια, Retsina of Halkida, Retsina of Halkida Ewia
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Karystos, Retsina of Karystos Ewia
 el: Ρετσίνα Καρύστου, Ρετσίνα Καρύστου Εύβοια, Retsina of Karystos, Retsina of Karystos Ewia
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Kropia, Retsina of Koropi, Retsina of Koropi Attika
 el: Retsina of Kropia, Retsina of Koropi, Retsina of Koropi Attika, Ρετσίνα Κρωπίας, Ρετσίνα Κορωπίου, Ρετσίνα Κορωπίου Αττική
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Markopoulo, Retsina of Markopoulo Attika
 el: Retsina of Markopoulo, Retsina of Markopoulo Attika, Ρετσίνα Μαρκοπούλου, Ρετσίνα Μαρκοπούλου Αττική
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Mesogia, Retsina of Mesogia Attika
 el: Retsina of Mesogia, Retsina of Mesogia Attika, Ρετσίνα Μεσογείων, Ρετσίνα Μεσογείων Αττική
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Pallini, Retsina of Pallini Attika
 el: Retsina of Pallini, Retsina of Pallini Attika, Ρετσίνα Παλλήνης, Ρετσίνα Παλλήνης Αττική
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Peania, Retsina of Liopesi, Retsina of Liopesi Attika
 el: Ρετσίνα Παιανίας Αττική, Ρετσίνα Λιοπεσίου Αττική, Ρετσίνα Παιανίας, Ρετσίνα Λιοπεσίου, Retsina of Peania, Retsina of Liopesi, Retsina of Liopesi Attika
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Pikermi, Retsina of Pikermi Attika
 el: Ρετσίνα Πικερμίου, Ρετσίνα Πικερμίου Αττική, Retsina of Pikermi, Retsina of Pikermi Attika
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Spata, Retsina of Spata Attika
 el: Ρετσίνα Σπάτων, Ρετσίνα Σπάτων Αττική, Retsina of Spata, Retsina of Spata Attika
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Thebes, Retsina of Thebes Viotia
 el: Ρετσίνα Θηβών, Ρετσίνα Θηβών Βοιωτία, Retsina of Thebes, Retsina of Thebes Viotia
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Retsina of Viotia
 el: Ρετσίνα Βοιωτίας, Retsina of Viotia
 origins:en: en:greece
-#wikidata:en:
 
 # conflicts with greek oil
 #<en:Wines from Greece
 #el:Rhodes, Ρόδος
 #origins:en: en:Greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Rhodes Muscatel
 el: Rhodes Muscatel, Μοσχάτος Ρόδου
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 en: Ritsona
 el: Ritsona, Ριτσώνα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Robola of Cephalonia, Ρομπόλα Κεφαλληνίας
 origins:en: en:greece
-#wikidata:en:
 
 # conflicts with the Samos cheese
 #<en:Wines from Greece
 #el:Samos, Σάμος
 #origins:en: en:Greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Santorini, Σαντορίνη
@@ -26847,122 +25499,98 @@ wikidata:en: Q2223717
 < en: Wines from Greece
 el: Serres, Σέρρες
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Siatista, Σιάτιστα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Sithonia, Σιθωνία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Sitia, Σητεία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Slopes of Ambelos, Πλαγιές Αμπέλου
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Slopes of Egialia, Πλαγίες Αιγιαλείας
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Slopes of Enos, Πλαγιές του Αίνου
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Slopes of Paiko, Πλαγίες Πάικου
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Slopes of Parnitha, Πλαγιές Πάρνηθας
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Slopes of Pendeliko, Πλαγιές Πεντελικού
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Slopes of Vertiskos, Πλαγιές Βερτίσκου
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Spata, Σπάτα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Sterea Ellada, Στερεά Ελλάδα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Tegea, Τεγέα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Thapsana, Θαψανά
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Thebes, Θήβα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Thessalia, Θεσσαλία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Thessaloniki, Θεσσαλονίκη
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Thrace, Θράκη
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Trifilia, Τριφυλία
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Tyrnavos, Τύρναβος
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Velventos, Βελβεντός
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Verdea Onomasia kata paradosi Zakinthou, Βερντέα Ονομασία κατά παράδοση Ζακύνθου
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines from Greece
 el: Zitsa, Ζίτσα
 origins:en: en:greece
-#wikidata:en:
 
 < en: Wines
 en: Wines from Hungary, Hungarian Wines
@@ -26979,21 +25607,18 @@ hu: Csopaki borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-02378
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Egri borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1328, PDO-HU-A1328-AM05
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Móri borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1333, PDO-HU-A1333-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Hajós-Bajai borok
@@ -27007,56 +25632,48 @@ hu: Mátrai borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1368, PDO-HU-A1368-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Kunsági borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1332, PDO-HU-A1332-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Tokaji borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1254, PDO-HU-A1254-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Monori borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-N1638
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Szekszárdi borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1349, PDO-HU-A1349-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Villányi borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1381, PDO-HU-A1381-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Pécsi borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1385, PDO-HU-A1385-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Tolnai borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1353, PDO-HU-A1353-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 # Includes Villányi, Szekszárdi, Pécsi and Tolnai wine regions
 < en: Wines from Hungary
@@ -27071,140 +25688,120 @@ hu: Balatoni borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1507, PGI-HU-A1507-AM04
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Balaton-felvidéki borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1509, PDO-HU-A1509-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Felső-magyarországi borok
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-A1329, PGI-HU-A1329-AM02
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Soltvadkerti borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-02171
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Dunai borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1345
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Káli borok, Káli-medencei borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1505
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Tihanyi borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1503
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Bükki borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1500
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Debrői Hárslevelű
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1373
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Nagy-Somlói borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1501
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Zalai borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1502
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Izsáki Arany Sárfehér
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1341
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Balatonmelléki borok
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-A1508
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Dunántúli borok
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-A1351
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Badacsonyi borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1506
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Balatonboglári borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1378
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Balatonfüred-Csopaki borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1516
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Somlói borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1376
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Neszmélyi borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1335
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Pannonhalmi borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1338
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Etyek-Budai borok
@@ -27225,21 +25822,18 @@ hu: Soproni borok
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-A1504
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Zempléni borok
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-A1375
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Hungary
 hu: Duna-Tisza-közi borok
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-A1342
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines
 en: Wines from Italy, Italian wines
@@ -27253,7 +25847,6 @@ it: Vini italiani
 nl: Italiaanse wijnen, Italiaanse wijn, Wijn uit Italië
 origins:en: en:italy
 wikidata:en: Q1125341
-#wikidata:en:
 
 < en: Wines from Italy
 it: Aglianico del Taburno, Taburno
@@ -27261,7 +25854,6 @@ origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0277
 protected_name_type:en: pdo
 wikidata:en: Q374645
-#wikidata:en:
 
 < en: Wines from Italy
 it: Aglianico del Vulture
@@ -27294,14 +25886,12 @@ it: Venezia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0517, PDO-IT-A0517-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Romagna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0507
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Primitivo di Manduria Dolce Naturale
@@ -27322,7 +25912,6 @@ it: Castel del Monte Nero di Troia Riserva
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0538
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Castel del Monte Rosso Riserva
@@ -27343,12 +25932,10 @@ it: Barletta
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0542
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rosso Barletta
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Negroamaro di Terra d'Otranto
@@ -27391,7 +25978,6 @@ it: Offida
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0477
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre di Offida
@@ -27461,70 +26047,60 @@ it: Portofino, Golfo del Tigullio - Portofino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0355
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terrazze dell'Imperiese
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0364
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rosazzo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0367
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Liguria di Levante
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0363
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Gutturnio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0327
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ortrugo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0350
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Falanghina del Sannio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0248
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Catalanesca del Monte Somma
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0254
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Casavecchia di Pontelatone
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0241
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre Aquilane, Terre de L'Aquila
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0898
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Albugnano
@@ -27559,38 +26135,32 @@ it: Alghero
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0904
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Allerona
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0852
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Alta Langa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1252
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Alto Adige, dell'Alto Adige, Südtirol, Südtiroler
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0293
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Alto Adige
 it: Alto Adige Colli di Bolzano, Alto Adige Südtiroler Bozner Leiten
 origins:en: en:italy
-#wikidata:en:
 
 < it: Alto Adige
 it: Alto Adige Meranese di collina, Alto Adige Meranese, Alto Adige Südtirol Meraner Hügel, Alto Adige Südtirol Meraner
 origins:en: en:italy
-#wikidata:en:
 
 < it: Alto Adige
 it: Alto Adige Santa Maddalena, Südtiroler St.Magdalener
@@ -27600,17 +26170,14 @@ wikidata:en: Q3613242
 < it: Alto Adige
 it: Alto Adige Terlano, Alto Adige Südtirol Terlaner
 origins:en: en:italy
-#wikidata:en:
 
 < it: Alto Adige
 it: Alto Adige Valle Isarco, Alto Adige Südtiroler Eisacktal, Alto Adige Eisacktaler
 origins:en: en:italy
-#wikidata:en:
 
 < it: Alto Adige
 it: Alto Adige Valle Venosta, Alto Adige Südtirol Vinschgau
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ansonica Costa dell'Argentario
@@ -27624,28 +26191,24 @@ it: Arborea
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0906
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Arcole
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0438
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Atina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0692
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Aversa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0238
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bagnoli di Sopra, Bagnoli
@@ -27666,7 +26229,6 @@ it: Barbera d'Asti, Barbera d'Asti Colli Astiani, Barbera d'Asti Colli Astiano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1398
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Barbera d'Asti
 it: Barbera d'Asti Nizza
@@ -27676,7 +26238,6 @@ wikidata:en: Q3634742
 < it: Barbera d'Asti
 it: Barbera d'Asti Tinella
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Barbera del Monferrato
@@ -27705,7 +26266,6 @@ xx: Bardolino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0436
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bardolino Superiore
@@ -27719,35 +26279,30 @@ it: Barolo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1389
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Basilicata
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0531
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Benaco Bresciano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1205
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bergamasca
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1369
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bettona
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0853
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bianchello del Metauro
@@ -27770,28 +26325,24 @@ wikidata:en: Q2900839
 < en: Wines from Italy
 it: Bianco della Valdinievole
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bianco dell'Empolese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1337
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Biferno
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0674
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bolgheri
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1348
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bolgheri Sassicaia
@@ -27812,42 +26363,36 @@ it: Bramaterra
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1075
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Breganze
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0439
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Brindisi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0543
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Camarro
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0805
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Campania
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0253
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Campi Flegrei
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0239
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Campi Flegrei
 it: Campi Flegrei Piedirosso riserva
@@ -27884,71 +26429,60 @@ it: Cannonau di Sardegna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1099
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cannonau di Sardegna Capo Ferrato
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cannonau di Sardegna Jerzu
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cannonau di Sardegna Oliena, Cannonau di Sardegna Nepente di Oliena
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Capalbio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1379
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Capriano del Colle
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1124
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Carignano del Sulcis
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1172
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Castel del Monte
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0545
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Castel San Lorenzo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0242
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Castelli Romani
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0695
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cellatica
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1108
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cerasuolo di Vittoria
@@ -27962,14 +26496,12 @@ it: Rosso Conero
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0428
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Chianti Classico
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1235
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 en: Chianti
@@ -28015,12 +26547,10 @@ it: Cilento
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0243
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cinque Terre Costa da Posa, Cinque Terre Sciacchetrà Costa da Posa
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cinque Terre Costa de Campu, Cinque Terre Sciacchetrà Costa de Campu
@@ -28037,14 +26567,12 @@ it: Circeo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0700
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cirò
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0610
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cisterna d'Asti
@@ -28058,7 +26586,6 @@ it: Civitella d'Agliano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0766
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Albani
@@ -28100,77 +26627,64 @@ wikidata:en: Q2983030
 < en: Wines from Italy
 it: Colli Amerini
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Aprutini
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0884
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Berici
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0450, PDO-IT-A0450-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Pignoletto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-N1877
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Bolognesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0289
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli Bolognesi
 it: Colli Bolognesi Colline di Oliveto
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Bolognesi
 it: Colli Bolognesi Colline di Riosto
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Bolognesi
 it: Colli Bolognesi Colline Marconiane
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Bolognesi
 it: Colli Bolognesi Monte San Pietro
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Bolognesi
 it: Colli Bolognesi Serravalle
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Bolognesi
 it: Colli Bolognesi Terre di Montebudello
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Bolognesi
 it: Colli Bolognesi Zola Predosa
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli del Trasimeno, Trasimeno
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0839
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli del Trasimeno
 it: Colli del Trasimeno Cabernet Sauvignon
@@ -28229,7 +26743,6 @@ it: Colli della Sabina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0702
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli della Sabina
 it: Colli della Sabina bianco frizzante
@@ -28272,7 +26785,6 @@ it: Colli della Toscana centrale
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1436
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli dell'Etruria Centrale
@@ -28323,7 +26835,6 @@ it: Colli di Faenza
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0291
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli di Faenza
 it: Colli di Faenza Sangiovese
@@ -28360,7 +26871,6 @@ it: Colli di Luni
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0353
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli di Luni
 it: Colli di Luni rosso
@@ -28415,7 +26925,6 @@ it: Colli di Rimini
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0297
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli di Rimini
 it: Colli di Rimini Cabernet Sauvignon
@@ -28460,14 +26969,12 @@ it: Colli di Salerno
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0255
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli di Scandiano e di Canossa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0305
 protected_name_type:en: pdo
-#wikidata:en:
 wikidata:en: Q2983331
 
 < it: Colli di Scandiano e di Canossa
@@ -28595,7 +27102,6 @@ it: Colli d'Imola
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0290
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Etruschi Viterbesi
@@ -28665,28 +27171,24 @@ it: Colli Euganei
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0454
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Lanuvini
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0704
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Maceratesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0443
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Martani
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0842
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Orientali del Friuli
@@ -28694,92 +27196,76 @@ it: Colli Orientali del Friuli
 < it: Colli Orientali del Friuli
 it: Colli Orientali del Friuli Picolit Cialla
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Orientali del Friuli
 it: Colli Orientali del Friuli Cialla
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Orientali del Friuli
 it: Colli Orientali del Friuli Rosazzo
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Orientali del Friuli
 it: Colli Orientali del Friuli Schiopettino di Prepotto
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Perugini
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0843
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Pesaresi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0458
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli Pesaresi
 it: Colli Pesaresi Focara
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Pesaresi
 it: Colli Pesaresi Roncaglia
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Piacentini
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0312
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli Piacentini
 it: Colli Piacentini Gutturnio
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Piacentini
 it: Colli Piacentini Monterosso Val d'Arda
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Piacentini
 it: Colli Piacentini Val Trebbia
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Piacentini
 it: Colli Piacentini Valnure
 origins:en: en:italy
-#wikidata:en:
 
 < it: Colli Piacentini
 it: Colli Piacentini Vigoleno
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Romagna centrale
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0318
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Tortonesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1097
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Colli Tortonesi
 it: Colli Tortonesi Barbera
@@ -28808,267 +27294,226 @@ it: Collina del Milanese
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1053
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Collina Torinese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1098
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline di Genovesato
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline di Levanto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0354
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Joniche Taratine
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Lucchesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1387
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Novaresi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1100
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Pescaresi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0887
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Saluzzesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1106
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Savonesi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0362
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Contea di Sclafani, Valledolmo-Contea di Sclafani
 origins:en: en:italy
-#wikidata:en:
 protected_name_file_number:en: PDO-IT-A0775
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Controguerra
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0879
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Copertino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0547
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Corti Benedettine del Padovano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0456
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cortona
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1518
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Costa d'Amalfi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0278
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Costa d'Amalfi
 it: Costa d'Amalfi Furore
 origins:en: en:italy
-#wikidata:en:
 
 < it: Costa d'Amalfi
 it: Costa d'Amalfi Ravello
 origins:en: en:italy
-#wikidata:en:
 
 < it: Costa d'Amalfi
 it: Costa d'Amalfi Tramonti
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Costa Viola
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0640
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Coste della Sesia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1138
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Curtefranca
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1042
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Daunia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0599
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Delia Nivolelli
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0777
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dolcetto d'Acqui
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1139
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dolcetto d'Alba
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1142
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dolcetto d'Asti
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1174
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dolcetto di Ovada, Dolcetto d'Ovada
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1176
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dolcetto di Ovada Superiore o Ovada
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dugenta
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0256
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Elba
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1519
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Epomeo
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0258
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Erice
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0779
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Esino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0434
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Etna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0780
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Falerio dei Colli Ascolani
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Falerio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0433
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Falerno del Massico
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0249
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Fara
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1178
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Faro
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0781
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Fiano di Avellino
@@ -29082,14 +27527,12 @@ it: Fontanarossa di Cerda
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0806
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Forlì
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0512-AM03, PGI-IT-A0512
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Fortana del Taro
@@ -29103,28 +27546,24 @@ it: Franciacorta
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1034
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Frascati
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0750
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Frascati Superiore
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0682
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Freisa d'Asti
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1180
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Freisa di Chieri
@@ -29138,91 +27577,78 @@ it: Friuli Annia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0905
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Friuli Aquileia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0950
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Friuli Grave
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0954
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Friuli Latisana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0976
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Gabiano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1183
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Galatina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0548
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Galluccio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0250
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Gambellara
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0469
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Garda Colli Mantovani
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1070
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Gattinara
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1311
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Genazzano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0751
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ghemme
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1263
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Gioia del Colle
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0549
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Girò di Cagliari
@@ -29299,38 +27725,32 @@ it: Grignolino del Monferrato Casalese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1187
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Monferrato Casalese
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Grottino di Roccanova
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0528
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: I Terreni di San Severino
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Irpinia, Irpina Campi Taurasini
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0279
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Isola dei Nuraghi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1140
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lago di Corbara
@@ -29391,19 +27811,16 @@ wikidata:en: Q3826414
 < en: Wines from Italy
 it: Lambrusco Mantovano Oltre Po Mantovano
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lambrusco Mantovano Viadanese-Sabbionetano
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lambrusco Salamino di Santa Croce
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0342
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Lambrusco Salamino di Santa Croce
 it: Lambrusco Salamino di Santa Croce rosso
@@ -29418,7 +27835,6 @@ it: Lamezia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0618
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Lamezia
 it: Lamezia rosso riserva
@@ -29433,98 +27849,84 @@ it: Lessona
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1191
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Leverano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0563
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lison-Pramaggiore
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0459
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lizzano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0551
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Loazzolo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1192
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Locorotondo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0552
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Locride
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0644
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lugana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1322
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Malvasia delle Lipari
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0782
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Malvasia di Bosa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0907
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Mandrolisai
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1171
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Marca Trevigiana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0520
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Maremma toscana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1413
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Marmilla
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0789
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 hr: Vino marsala
@@ -29551,33 +27953,28 @@ it: Martina, Martina Franca
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0553
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Matino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0554
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Melissa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0619
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Menfi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0786, PDO-IT-A0786-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Menfi
 it: Menfi Bonera
 origins:en: en:italy
-#wikidata:en:
 
 < it: Menfi
 it: Menfi Feudo dei Fiori
@@ -29589,41 +27986,35 @@ it: Mitterberg
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0295
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Mitterberg tra Cauria e Tel
 de: Mitterberg zwischen Gfrill und Toll
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Monferrato
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1210
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Monreale
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0787
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Montecastelli
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1438
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Montecucco
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1433
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Montefalco
@@ -29658,14 +28049,12 @@ it: Montello - Colli Asolani, Montello e Colli Asolani
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0460, en: PDO-IT-A0460-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Montenetto di Brescia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1256
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Montepulciano d'Abruzzo
@@ -29679,17 +28068,14 @@ it: Colline Teramane Montepulciano d'Abruzzo, Montepulciano d'Abruzzo Colline Te
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0876-AM04, PDO-IT-A0876
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Montepulciano d'Abruzzo
 it: Montepulciano d'Abruzzo Casauria, Montepulciano d'Abruzzo Terre di Casauria
 origins:en: en:italy
-#wikidata:en:
 
 < it: Montepulciano d'Abruzzo
 it: Montepulciano d'Abruzzo Terre dei Vestini
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Monteregio di Massa Marittima
@@ -29740,7 +28126,6 @@ it: Montescudaio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1437
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Montescudaio
 it: Montescudaio bianco
@@ -29782,7 +28167,6 @@ it: Morellino di Scansano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1260
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Moscadello di Montalcino
@@ -29811,7 +28195,6 @@ it: Pantelleria, Moscato di Pantelleria, Passito di Pantelleria
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0792
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Moscato di Sardegna
@@ -29823,17 +28206,14 @@ wikidata:en: Q1948895
 < it: Moscato di Sardegna
 it: Moscato di Sardegna Gallura
 origins:en: en:italy
-#wikidata:en:
 
 < it: Moscato di Sardegna
 it: Moscato di Sardegna Tempio Pausania
 origins:en: en:italy
-#wikidata:en:
 
 < it: Moscato di Sardegna
 it: Moscato di Sardegna Tempo
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Moscato di Siracusa
@@ -29898,50 +28278,42 @@ it: Orcia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1442
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Palizzi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0645
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Pellaro
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0648
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Penisola Sorrentina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0280
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Penisola Sorrentina
 it: Penisola Sorrentina Gragnano
 origins:en: en:italy
-#wikidata:en:
 
 < it: Penisola Sorrentina
 it: Penisola Sorrentina Lettere
 origins:en: en:italy
-#wikidata:en:
 
 < it: Penisola Sorrentina
 it: Penisola Sorrentina Sorrento
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Piemonte
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1224
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Pinerolese
@@ -29985,148 +28357,126 @@ it: Pornassio, Ormeasco di Pornassio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0356
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Primitivo di Manduria
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0565
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Provincia di Mantova
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1078
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Provincia di Nuoro
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0808
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Provincia di Pavia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1015
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Verona, Veronese, Provincia di Verona
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0524
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Quistello
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1081
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ramandolo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0939
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Recioto di Gambellara
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0470
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Recioto di Soave
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0465
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Riesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0793
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Riviera del Brenta
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0471
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Riviera ligure di Ponente
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0357
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Riviera ligure di ponente
 it: Riviera ligure di ponente Albenga, Riviera ligure di ponente Albengalese
 origins:en: en:italy
-#wikidata:en:
 
 < it: Riviera ligure di ponente
 it: Riviera ligure di ponente Finale, Riviera ligure di ponente Finalese
 origins:en: en:italy
-#wikidata:en:
 
 < it: Riviera ligure di ponente
 it: Riviera ligure di ponente Riviera dei Fiori
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Roccamonfina
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0263
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Roero
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1261, PDO-IT-A1261-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Romangia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0812
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ronchi di Brescia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1265
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ronchi Varesini
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1037
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rosso di Cerignola
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0566
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rosso di Montalcino
@@ -30145,7 +28495,6 @@ it: Rosso Orvietano, Orvietano Rosso
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0847
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rubino di Cantavenna
@@ -30166,28 +28515,24 @@ it: Sabbioneta
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1082
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Salaparuta
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0795
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Salemi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0807
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Salento
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0602
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Salice Salentino
@@ -30256,96 +28601,82 @@ it: Salina
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0809
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sambuca di Sicilia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0797
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: San Gimignano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1464
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sannio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0281
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Santa Margherita di Belice
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0798
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sant'Anna di Isola Capo Rizzuto
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sant'Antimo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1486
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sardegna Semidano, Sardegna Semidano Mogoro
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1046
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sebino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1041
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Serrapetrona
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0451
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sibiola
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0813
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sicilia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0801, PDO-IT-A0801-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sizzano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1236
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Soave Superiore
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0473
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Soave, Soave Colli Scaligeri
@@ -30359,21 +28690,18 @@ it: Sovana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1490
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Spello
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0856
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Squinzano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0569
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Teroldego Rotaliano
@@ -30414,7 +28742,6 @@ it: Terre del Volturno
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0264
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre di Casole
@@ -30428,42 +28755,36 @@ it: Terre di Chieti
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0901
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre di Veleja
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0529
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre Lariane
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1069
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Tharros
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0814
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Torgiano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0851
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Torgiano Rosso Riserva
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0834
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Trebbiano d'Abruzzo
@@ -30475,36 +28796,30 @@ wikidata:en: Q502082
 < en: Wines from Italy
 it: Trentino Ziresi, Trentino dei Ziresi
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Trentino Isera, Trentino d'Isera
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Trentino Sorni
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Trento
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0752
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Trexenta
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0815
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: égbria
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Val d'Arbia
@@ -30522,117 +28837,98 @@ it: Val di Cornia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1498
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Val di Cornia
 it: Val di Cornia Suvereto
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Val di Magra
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1431
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Val di Neto
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0655
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Val Tidone
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0532
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valcalepio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1366
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valdadige Terradeiforti, Terradeiforti Valdadige, Terradeiforti
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0475
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valdadige, Etschtaler, Valdadige Terra dei Forti
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0474
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valdamato
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0658
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle Belice
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0811
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Aosta Arnad-Montjovet, Vallée d'Aoste Arnad-Montjovet
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Aosta Blanc de Morgex et de la Salle, Vallée d'Aoste Blanc de Morgex et de la Salle
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Aosta Chambave, Vallée d'Aoste Chambave
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Aosta Donnas, Vallée d'Aoste Donnas
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Aosta Enfer d'Arvier, Vallée d'Aoste Enfer d'Arvier
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Aosta Nus, Vallée d'Aoste Nus
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Aosta Torrette, Vallée d'Aoste Torrette
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valsusa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1243
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valtellina Superiore
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1036
 protected_name_type:en: pdo
-#wikidata:en:
 
 < it: Valtellina Superiore
 it: Valtellina Superiore Grumello
@@ -30689,21 +28985,18 @@ it: Veneto
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0521
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Veneto Orientale
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0522
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Venezia Giulia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0977
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Verdicchio dei Castelli di Jesi
@@ -30749,70 +29042,60 @@ it: Amelia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0835
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Todi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0849
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Spoleto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0848
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Anagni
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0765
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre Siciliane
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0810
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Avola
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0804
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Costa Etrusco Romana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0768
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Roma
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0759
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cerasuolo d'Abruzzo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0743
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre di Cosenza
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0627
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Tintilia del Molise
@@ -30851,28 +29134,24 @@ it: Verduno Pelaverga, Verduno
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1244
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vin Santo del Chianti
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1513
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vin Santo del Chianti Classico
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1514
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vin Santo di Carmignano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1669
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vin Santo di Montepulciano
@@ -30886,348 +29165,298 @@ it: delle Venezie, Beneških okolišev
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-02360, PGI-IT-A0862-AM03, PGI-IT-A0862
 protected_name_type:en: pdo, pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre Tollesi, Tullum
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0742-AM04, PDO-IT-A0742
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bianco di Custoza, Custoza
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0468-AM03, PDO-IT-A0468
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Nizza
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-01896
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: dell'Emilia, Emilia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0509-AM06, PGI-IT-A0509
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bianco di Castelfranco Emilia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0508-AM04, PGI-IT-A0508
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vini di Chianti
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1228-AM04
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vesuvio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0252-AM02, en: PDO-IT-A0252
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Garda
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1320-AM02, PDO-IT-A1320, PDO-IT-1516
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Riviera del Garda Bresciano, Garda Bresciano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1137-AM02, PDO-IT-A1137
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ravenna
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0523-AM03, PGI-IT-A0523
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rubicone
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0525-AM04, PGI-IT-A0525
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Friuli, Friuli Venezia Giulia, Furlanija, Furlanija Julijska krajina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-02176
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Asolani - Prosecco, Asolo - Prosecco
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0514-AM02, PDO-IT-A0514
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Bolognesi Classico Pignoletto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0284-AM02, PDO-IT-A0284
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valdichiana toscana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1510
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valdichiana
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valdinievole
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1512
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre di Pisa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1495
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Val d'Arno di Sopra, Valdarno di Sopra
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1497
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Grance Senesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1400
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Costa Toscana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1434
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ortona
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1184
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Elba Aleatico Passito, Aleatico Passito dell'Elba
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1237
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cagliari
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1313
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre del Colleoni, Colleoni
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1358
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Montecucco Sangiovese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1246
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre Alfieri
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1241
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Val di Cornia Rosso, Rosso della Val di Cornia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1262
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Suvereto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1266
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valli Ossolane
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1242
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valtènesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1188
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valtellina rosso, Rosso di Valtellina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1323
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Alba
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1063
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Calosso
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1118
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Oltrepò Pavese metodo classico
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0958
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Casteggio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0974
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bonarda dell'Oltrepò Pavese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0973
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Buttafuoco dell'Oltrepò Pavese, Buttafuoco
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0978
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Oltrepò Pavese Pinot grigio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1010
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Pinot nero dell'Oltrepò Pavese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1001
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sangue di Giuda, Sangue di Giuda dell'Oltrepò Pavese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0979
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Abruzzo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0880
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Villamagna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0883
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Noto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0790
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Joniche Tarantine
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0546
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vittoria
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0803
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terracina, Moscato di Terracina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0761
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dolcetto di Ovada Superiore, Ovada
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1319
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: San Ginesio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0426
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 en: Prosecco
@@ -31235,259 +29464,222 @@ xx: Prosecco
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0516
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dogliani
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1330
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cònero
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0449
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Pergola
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0429
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Mamertino, Mamertino di Milazzo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0783
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Tarquinia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0760
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Strevi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1238
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: I Terreni di Sanseverino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0432
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Benevento, Beneventano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0283
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline del Genovesato
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0361
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Narni
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0855
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valcamonica
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1317
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ogliastra
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0794
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vigneti delle Dolomiti, Weinberg Dolomiten
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0755
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Teatine
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0891
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terre dell'Alta Val d'Agri
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0530
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Merlara
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0440
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Scanzo, Moscato di Scanzo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0949
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sforzato di Valtellina, Sfursat di Valtellina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1035
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vicenza
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0476, PDO-IT-A0476-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Reggiano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0351
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Reno
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0506
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Canavese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1083
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Cimini
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0767
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Frusinate, del Frusinate
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0770
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lazio
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0771
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli del Sangro
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0744
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colline Frentane
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0745
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Aosta, Vallée d'Aoste
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0296
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: del Vastese, Histonium
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0893
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Marche
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0484
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Toscano, Toscana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1517
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli del Limbara
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0788
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Modena, Provincia di Modena, di Modena
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0347
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vallagarina
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0756
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bivongi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0605
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bianco del Sillaro, Sillaro
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0526
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Arghillà
@@ -31501,224 +29693,192 @@ it: Calabria
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0637
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lipuda
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0665
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Molise, del Molise
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0575
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Pentro di Isernia, Pentro
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0684
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Murgia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0600
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Puglia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0601
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Tarantino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0603
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle d'Itria
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0604
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Osco, Terre degli Osci
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0693
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: San Colombano al Lambro, San Colombano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1054
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Alto Mincio
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1076
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Terrazze Retiche di Sondrio
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1352, PGI-IT-A1352-AM02
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Barbagia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0784
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Nurra
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0791
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Parteolla
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0796
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Planargia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0799
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Assisi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0837
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valle del Tirso
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0816
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valli di Porto Pino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0817
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Val Polcèvera, Val Polcèvera Coronata
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0359
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Paestum
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0261
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Pompeiano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0262
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Alto Livenza
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0864
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Trevigiani
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0518
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Conselvano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0519
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cannara
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0854
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Umbria
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0857
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Sciacca
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0800
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Carso, Carso - Kras
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0910
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Nettuno
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0758
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Friuli Isonzo, Isonzo del Friuli
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0959
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Alta Valle della Greve
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A1443
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lacrima di Morro, Lacrima di Morro d'Alba
@@ -31732,77 +29892,66 @@ it: Scilla
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0651
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rotae
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-A0688
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vermentino di Sardegna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1169
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Scavigna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0621
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: San Martino della Battaglia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1318
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Orta Nova
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0558
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Contessa Entellina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0776
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Eloro, Eloro Pachino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0778
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Nardò
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0556
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Langhe
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1189
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vignanello
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0763
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rosso di Montepulciano
@@ -31816,7 +29965,6 @@ it: Pomino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1453
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Alezio
@@ -31830,112 +29978,96 @@ it: Capri
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0240
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Campidano di Terralba, Terralba
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1167
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Candia dei Colli Apuani
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1377
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cacc'e mmitte di Lucera
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0544
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: S. Anna di Isola Capo Rizzuto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0629
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cortese dell'Alto Monferrato
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1111
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: San Torpè
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1488
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cesanese di Olevano Romano, Olevano Romano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0699
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Casteller
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0748
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Dolcetto di Diano d'Alba, Diano d'Alba
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1324
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Gavi, Cortese di Gavi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1310
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vermentino di Gallura
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0903
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Savuto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0620
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Carmignano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1220
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cerveteri
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0696
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Malvasia di Castelnuovo Don Bosco
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1201
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Nuragus di Cagliari
@@ -31956,19 +30088,16 @@ it: Aprilia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0691
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bianco Pisano di San Torpè
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Conegliano Valdobbiadene - Prosecco, Valdobbiadene - Prosecco, Conegliano - Prosecco
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0515
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Valpolicella
@@ -31989,35 +30118,30 @@ wikidata:en: Q3902111
 < en: Wines from Italy
 it: Vini del Piave
 origins:en: en:italy
-#wikidata:en:
 
 < en: Wines from Italy
 it: Chianti
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1228
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Romagna Albana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0285
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Oltrepò Pavese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0971
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Botticino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1104
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Lago di Caldaro, Kalterersee, Caldaro, Kalterer
@@ -32045,56 +30169,48 @@ it: Vernaccia di San Gimignano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1292
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Trentino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0754
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rosso Piceno, Piceno
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0427
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Erbaluce di Caluso, Caluso
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1315
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Verdicchio di Matelica
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0481
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vernaccia di Serrapetrona
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0445
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Boca
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1074
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Barbaresco
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1399
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Monica di Sardegna
@@ -32108,91 +30224,78 @@ it: Moscato di Sorso, Moscato di Sennori, Moscato di Sorso - Sennori
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0909
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vernaccia di Oristano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1170
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ischia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0251
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: San Severo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0568
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Taurasi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0237
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cinque Terre, Cinque Terre Sciacchetrà
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0352
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Ostuni
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0561
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Rossese di Dolceacqua, Dolceacqua
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0358
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Orvieto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0846
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Carema
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1084
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Siracusa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0802
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Montecarlo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1421
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Colli Orientali del Friuli Picolit
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0938
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cesanese di Affile, Affile
@@ -32206,35 +30309,30 @@ it: Collio Goriziano, Collio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0908
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Marino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0753
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Cori
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0706
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Est! Est!! Est!!! di Montefiascone
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0705
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Montecompatri Colonna, Montecompatri, Colonna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0757
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Vino Nobile di Montepulciano
@@ -32248,49 +30346,42 @@ it: Velletri
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0762
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Zagarolo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0764
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Friuli Colli Orientali
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A0953
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Malvasia di Casorzo d'Asti, Malvasia di Casorzo, Casorzo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1194
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Parrina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1451
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Asti, Asti spumante, Moscato di Asti, Moscato di Asti spumante
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1396
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Italy
 it: Bianco di Pitigliano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-A1339
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines
 en: Wines from Luxembourg
@@ -32436,42 +30527,34 @@ wikidata:en: Q2832668
 < pt: Alentejo
 pt: Alentejo Borba
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Alentejo
 pt: Alentejo Évora
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Alentejo
 pt: Alentejo Granja-Amareleja
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Alentejo
 pt: Alentejo Moura
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Alentejo
 pt: Alentejo Portalegre
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Alentejo
 pt: Alentejo Redondo
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Alentejo
 pt: Alentejo Reguengos
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Alentejo
 pt: Alentejo Vidigueira
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Arruda
@@ -32495,29 +30578,24 @@ wikidata:en: Q2894017
 < pt: Beira Interior
 pt: Beira Interior Castelo Rodrigo
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Beira Interior
 pt: Beira Interior Cova da Beira
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Beira Interior
 pt: Beira Interior Pinhel
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Wine Biscoitos
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1444
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Bucelas
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Carcavelos
@@ -32534,86 +30612,70 @@ pt: Dão
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1534
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Dão Nobre
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Dão Alva
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Dão Besteiros
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Dão Castendo
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Dão Serra da Estrela
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Dão Silgueiros
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Dão Terras de Azurara
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Dão Terras de Senhorim
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Douro Baixo Corgo, Vinho do Douro Baixo Corgo
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Douro Cima Corgo, Vinho do Douro Cima Corgo
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Douro Douro Superior, Vinho do Douro Douro Superior
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Encostas d’Aire Alcobaça
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Encostas d’Aire Ourém
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Graciosa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1446, PDO-PT-A1446-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Lafões
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1455
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Lagoa
@@ -32628,17 +30690,14 @@ wikidata:en: Q3216201
 < en: Wines from Portugal
 pt: Lisboa
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Lisboa Alta Estremadura
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Lisboa Estremadura
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 en: Madeira Wine
@@ -32650,249 +30709,202 @@ it: Vino di Madera
 nl: Madeira Wijn
 pt: Madeira, Vinho da Madeira
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Madeirense
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Moscatel do Douro
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Óbidos
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Palmela
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Península de Setúbal
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Pico
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1445
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Portimão
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Porto
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Ribatejo
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Ribatejo Almeirim
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Ribatejo Cartaxo
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Ribatejo Chamusca
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Ribatejo Coruche
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Ribatejo Santarém
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Ribatejo Tomar
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Setúbal
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Setúbal Roxo
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Tavira
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Távora-Varosa
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Tejo
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Torres Vedras
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1465
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Trás-os-Montes
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1466
 protected_name_type:en: pdo
-#wikidata:en:
 
 < pt: Trás-os-Montes
 pt: Trás-os-Montes Chaves
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Trás-os-Montes
 pt: Trás-os-Montes Planalto Mirandês
 origins:en: en:portugal
-#wikidata:en:
 
 < pt: Trás-os-Montes
 pt: Trás-os-Montes Valpaços
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Licoroso Algarve
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Açores, Vinho Regional Açores
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1447-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Regional Alentejano
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Regional Algarve
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Wines from the Algarve, Algarve
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1448-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Regional Duriense
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Regional Minho
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Regional Terras Madeirenses
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Regional Transmontano
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1545, PDO-PT-A1545-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Alvarinho
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Alvarinho Espumante
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Amarante
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Ave
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Baião
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Basto
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Cávado
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Lima
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Monção e Melgaço
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Paiva
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines from Portugal
 pt: Vinho Verde Sousa
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Wines
 en: Romanian wines
@@ -32904,7 +30916,6 @@ ro: Adamclisi
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-N0037
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealu Mare
@@ -32925,294 +30936,252 @@ ro: Recaş
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0027, PDO-RO-A0027-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Miniş
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0029, PDO-RO-A0029-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Însurăţei
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-N1588
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Cotnari
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0135, PDO-RO-A0135-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Iaşi
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0139, PDO-RO-A0139-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Pietroasa
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0134
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealu Bujorului
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0132
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Nicoreşti
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0133
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Sâmbureşti
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0282
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Drăgăşani
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0286
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Bohotin
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0138
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Târnave
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0365, PDO-RO-A1064
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Banat
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0028
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Aiud
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0366
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Alba Iulia
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0368
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Lechinţa
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0369
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Sebeş-Apold
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0371
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Oltina
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0611
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Mehedinţi
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1072
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Segarcea
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1214
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Panciu
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1093, PDO-RO-A1193, PDO-RO-A1584
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Babadag
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1424
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Ştefăneşti
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1309
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Odobeşti
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1586
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Coteşti
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1577
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Banu Mărăcine
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1558
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Huşi
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1583
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Murfatlar
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0030, PDO-RO-A0624
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Iana
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0136
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Sarica Niculiţel
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A1575
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Crişana
 origins:en: en:romania
 protected_name_file_number:en: PDO-RO-A0105
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealurile Crişanei
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A0106
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Viile Timişului
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A0108
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealurile Transilvaniei
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A0288
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealurile Zarandului
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A0031
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Viile Caraşului
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A0032
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Colinele Dobrogei
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A0612
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Terasele Dunării
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A1077, PGI-RO-A1077-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealurile Olteniei
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A1095
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealurile Munteniei
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A1085, PGI-RO-A1427
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealurile Vrancei
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A1582
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian wines
 ro: Dealurile Moldovei
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-A1591
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Eaux de vie
 en: Romanian wines spirit
@@ -33222,35 +31191,30 @@ ro: Vinars Segarcea
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02006
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Romanian wines spirit
 ro: Vinars Târnave
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02007
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Romanian wines spirit
 ro: Vinars Vrancea
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02011
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Romanian wines spirit
 ro: Vinars Murfatlar
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02000
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Romanian wines spirit
 ro: Vinars Vaslui
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02012
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Wines
 en: Wines from Spain, Spanish wines
@@ -33268,14 +31232,12 @@ es: Chozas Carrascal
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-N1637
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Dehesa Peñalba
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-02592
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Vera de Estenas
@@ -33305,7 +31267,6 @@ es: Urbezo
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-02585
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: El Vicario
@@ -33319,7 +31280,6 @@ es: Los Cerrillos
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-02228
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Vallegarcía
@@ -33347,7 +31307,6 @@ es: Urueña
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-02485
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Rioja
@@ -33403,14 +31362,12 @@ es: Bolandin
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-N1876
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Larrainzar
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-N1875
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Islas Canarias
@@ -33431,7 +31388,6 @@ es: Los Balagueses
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-A0941
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Sierra de Salamanca
@@ -33536,7 +31492,6 @@ es: Murcia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-A0608
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Spain
 es: Cumbres del Guadalfeo
@@ -33564,7 +31519,6 @@ es: Granada
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-A1475
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Empordà
@@ -33662,7 +31616,6 @@ es: Córdoba
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-A1406
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Spain
 es: Ribera del Jiloca
@@ -33676,7 +31629,6 @@ es: Ibiza, Eivissa
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-A0110
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Spain
 es: Valles de Sadacia
@@ -33704,7 +31656,6 @@ es: Los Palacios
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-A1411
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Spain
 es: Ribera del Andarax
@@ -33732,7 +31683,6 @@ es: Cangas
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-A0119
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Valle del Cinca
@@ -33760,7 +31710,6 @@ es: León
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-A0882
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Valles de Benavente
@@ -33788,7 +31737,6 @@ es: Castelló
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-A1173
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Spain
 es: Castilla y León
@@ -33830,7 +31778,6 @@ es: Castilla
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-A0059
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Spain
 es: Ribera del Guadiana
@@ -33858,7 +31805,6 @@ es: Cataluña, Catalunya
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-A1549
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Sierras de Málaga
@@ -33928,14 +31874,12 @@ es: Cádiz
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-A1405
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Spain
 es: Mallorca
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-A0960
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from Spain
 es: Valle de Güímar
@@ -33998,7 +31942,6 @@ es: La Palma
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-A0510
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Tierra del Vino de Zamora
@@ -34103,7 +32046,6 @@ es: Toro
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-A0886
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Rías Baixas
@@ -34278,7 +32220,6 @@ es: Valencia
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-A0872
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from Spain
 es: Cava
@@ -34325,7 +32266,6 @@ fr: Champagnes français, champagne français
 hr: Francuski šampanjci
 nl: Franse champagnes, Franse Champagne, Champagne uit Frankrijk
 origins:en: en:france
-#wikidata:en:
 
 < en: Champagnes
 fr: Champagnes extra bruts
@@ -34540,7 +32480,6 @@ wikidata:en: Q807022
 < en: Wines from France
 fr: Maury, Maury Rancio
 origins:en: en:france
-#wikidata:en:
 
 < fr: Maury
 fr: Maury tuilé rancio
@@ -34581,7 +32520,6 @@ wikidata:en: Q474278
 < fr: Muscats
 fr: Rivesaltes Rancio, Muscat de Rivesaltes Rancio
 origins:en: en:france
-#wikidata:en:
 
 < en: Fortified wines such as natural sweet wines
 fr: Rivesaltes
@@ -35846,7 +33784,6 @@ it: Cantucci Toscani, Cantuccini Toscani
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01290
 protected_name_type:en: pgi
-#wikidata:en:
 
 #Biscuits from Italy
 < en: Biscuits
@@ -36204,19 +34141,16 @@ hr: Rudarska greblica
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-02383
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian bakery products
 hr: Poljički soparnik, Poljički zeljanik, Poljički uljenjak
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-01224
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Bakery products
 en: Cypriot bakery products
 origins:en: en:cyprus
-#wikidata:en:
 
 < en: Cypriot bakery products
 en: Glyko Triantafyllo Agrou
@@ -36224,7 +34158,6 @@ el: Γλυκό Τριαντάφυλλο Αγρού, Glyko Triantafyllo Agrou
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-01310
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cypriot bakery products
 en: Koufeta Amygdalou Geroskipou
@@ -36232,7 +34165,6 @@ el: Κουφέτα Αμυγδάλου Γεροσκήπου, Koufeta Amygdalou Ge
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-0800
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cypriot bakery products
 en: Loukoumi Geroskipou
@@ -36240,7 +34172,6 @@ el: Λουκούμι Γεροσκήπου, Loukoumi Geroskipou
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-0454
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Bakery products
 en: Czech bakery products
@@ -36251,7 +34182,6 @@ cs: Valašský frgál
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0805
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Czech bakery products
 cs: Karlovarské oplatky
@@ -36265,21 +34195,18 @@ cs: Karlovarské trojhránky
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0397
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Czech bakery products
 cs: Mariánskolázeňské oplatky
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0407
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Czech bakery products
 cs: Pardubický perník
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0408
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Czech bakery products
 cs: Lomnické suchary
@@ -36300,7 +34227,6 @@ cs: Karlovarský suchar
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0404
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Czech bakery products
 cs: Štramberské uši
@@ -36317,7 +34243,6 @@ fi: Kainuun rönttönen
 origins:en: en:finland
 protected_name_file_number:en: PGI-FI-0099
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Finnish bakery products
 fi: Karjalanpiirakka
@@ -36366,14 +34291,12 @@ de: Westfälischer Pumpernickel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1095
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German bakery products
 de: Bayerische Breze, Bayerische Brezn, Bayerische Brez'n, Bayerische Brezel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0971
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Baumkuchen
 < en: German bakery products
@@ -36381,7 +34304,6 @@ de: Salzwedeler Baumkuchen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0733
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German bakery products
 < en: Stollen
@@ -36389,7 +34311,6 @@ de: Dresdner Christstollen, Dresdner Stollen, Dresdner Weihnachtsstollen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0704
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German bakery products
 de: Bremer Klaben
@@ -36444,7 +34365,6 @@ wikidata:en: Q139881211
 en: Hungarian bakery products
 fr: Produits de boulangerie hongrois
 origins:en: en:hungary
-#wikidata:en:
 
 < en: Hungarian bakery products
 hu: Tepertős pogácsa
@@ -36461,14 +34381,12 @@ de: Südtiroler Schüttelbrot, Schüttelbrot Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02392
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian bakery products
 it: Pampepato di Terni, Panpepato di Terni
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02467
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian bakery products
 it: Pizza Napoletana
@@ -36503,7 +34421,6 @@ it: Torrone di Bagnara
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1101
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian bakery products
 it: Pagnotta del Dittaino
@@ -36549,7 +34466,6 @@ pl: Cebularz lubelski
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-1092
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish bakery products
 pl: Kołocz śląski, kołacz śląski
@@ -36602,14 +34518,12 @@ pt: Amêndoa Coberta de Moncorvo
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02235
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese bakery products
 pt: Folar de Valpaços
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01392
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese bakery products
 pt: Pão de Ló de Ovar
@@ -36648,28 +34562,24 @@ es: Mollete de Antequera
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-02393
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish bakery products
 es: Polvorones de Estepa
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01218
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish bakery products
 es: Pan de Alfacar
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0890
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish bakery products
 es: Tortas de Aceite de Castilleja de la Cuesta
 origins:en: en:spain
 protected_name_file_number:en: TSG-ES-0058
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Spanish bakery products
 es: Pa de Pagès Català
@@ -36718,7 +34628,6 @@ es: Alfajor de Medina Sidonia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0346
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish bakery products
 es: Pan de Cea
@@ -38646,7 +36555,6 @@ hr: Kolačići od badema
 nl: Amandelcake
 ciqual_food_code:en: 24665
 ciqual_food_name:en: Almond cake
-#wikidata:en:
 
 < en: Almond cakes
 it: tortionata
@@ -38680,7 +36588,6 @@ agribalyse_food_code:en: 23941
 ciqual_food_code:en: 23941
 ciqual_food_name:en: Soft cake filled with fruits, mini sponge roll type
 ciqual_food_name:fr: Gâteau moelleux fourré aux fruits type mini-roulé ou mini-cake fourré
-#wikidata:en:
 # Note: en:dessert-mixes is a category that changes the computation of the Nutri-Score, the canonical name should not be changed without corresponding code changes
 
 < en: Cooking helpers
@@ -39016,7 +36923,6 @@ it: Panforte di Siena
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0795
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cakes
 en: Marble cakes, Marble cake
@@ -39995,7 +37901,6 @@ wikidata:en: Q534126
 
 < en: Confectioneries
 fr: Bonbons dragéifiés
-#wikidata:en:
 
 < en: Confectioneries
 en: Fudge
@@ -40277,7 +38182,6 @@ hr: Kalupi za mliječnu čokoladu
 it: Stampi di cioccolato al latte
 lt: Pieniški šokolado formos
 nl: Melkchocoladevormen, Melkchocolade figuren
-#wikidata:en:
 
 < en: Milk chocolates
 en: Milk chocolate bar
@@ -40324,7 +38228,6 @@ hr: Liker čokolade
 hu: Likőrös csokoládék
 lt: Šokoladai su likeriu
 nl: Chocola met likeur
-#wikidata:en:
 
 < en: Milk chocolates
 en: Chocolates with extra fine milk
@@ -40343,7 +38246,6 @@ hr: Čokolade od rižinog mlijeka
 it: Cioccolato al latte con riso
 lt: Ryžių pieno šokoladai
 nl: Chocolade-rijstmelk
-#wikidata:en:
 
 < en: Cereal chocolates
 < en: Milk chocolates
@@ -40375,7 +38277,6 @@ pt: Chocolates com amêndoas
 ru: Шоколад с миндалём
 sv: Choklad med mandlar, choklad med mandel
 tr: Bademli çikolata
-#wikidata:en:
 
 < en: Chocolates
 en: Milk chocolate bar with nougat, Toblerone
@@ -40406,7 +38307,6 @@ lt: Šokoladai su lazdynais
 nl: Chocola met hazelnoten
 pt: Chocolates com avelãs
 tr: Fındıklı çikolata
-#wikidata:en:
 
 < en: Chocolates
 en: Chocolates with raisins
@@ -40417,14 +38317,12 @@ hr: Čokolade s grožđicama
 ja: レーズンチョコレート
 lt: Šokoladai su razinomis
 sv: Choklader med russin
-#wikidata:en:
 
 < en: Chocolates
 en: Chocolates with praline
 fr: Chocolats à la praline
 hr: Čokolade s pralinama
 ja: プラリネチョコレート
-#wikidata:en:
 
 < en: Chocolates
 en: Rice chocolates
@@ -40433,7 +38331,6 @@ hr: Rižine čokolade
 it: Cioccolato con riso
 lt: Šokoladai su pūstais ryžiais
 nl: Chocola met gepofte rijst
-#wikidata:en:
 
 < en: Chocolates
 en: Cereal chocolates
@@ -40599,7 +38496,6 @@ hr: Čokolade sa zaslađivačima
 it: Cioccolato con edulcorante
 lt: Šokoladai su saldikliais
 nl: Chocola met zoetstoffen
-#wikidata:en:
 
 < en: Chocolates
 en: Flavoured chocolates
@@ -40706,7 +38602,6 @@ fr: Chocolats fourrés à la mousse au chocolat au lait
 
 < en: Chocolates
 fr: Chocolats au speculoos
-#wikidata:en:
 
 < en: Milk chocolates
 < fr: Chocolats au speculoos
@@ -41181,7 +39076,6 @@ it: Forme di cioccolato
 ja: 象ったチョコレート
 lt: Šokoladinės formelės
 nl: Chocolade traktaties
-#wikidata:en:
 
 < en: Chocolate molds
 en: Chocolate Sculptures, Chocolate Scupltures
@@ -41473,7 +39367,6 @@ en: Cremini
 xx: Cremini
 fr: Cremini
 it: Cremini
-#wikidata:en:
 
 < en: Bonbons
 de: Dominosteine
@@ -41506,7 +39399,6 @@ fr: Rochers au chocolat
 agribalyse_proxy_food_code:en: 31066
 agribalyse_proxy_food_name:en: Chocolate and nut confectionery filled with praline
 agribalyse_proxy_food_name:fr: Rocher chocolat fourré praliné
-#wikidata:en:
 
 < fr: Rochers au chocolat
 fr: Rochers au chocolat au lait
@@ -41986,7 +39878,6 @@ hr: Francuske praline
 it: Praline francesi
 nl: Franse praliné
 wikidata:en: Q851428
-#wikidata:en:
 
 # Almonds coated with a thick layer of sugar, often colored
 < en: Nut confectioneries
@@ -42041,7 +39932,6 @@ ja: カラメル
 lt: Skysta karamelė
 nl: Vloeibare caramels
 tr: Sıvı karamel
-#wikidata:en:
 
 < en: Caramels
 en: Soft caramel candy
@@ -42115,7 +40005,6 @@ agribalyse_food_code:en: 31054
 ciqual_food_code:en: 31054
 ciqual_food_name:en: Chewing gum, without sugar
 ciqual_food_name:fr: Chewing-gum, sans sucre
-#wikidata:en:
 
 < en: Chewing gum
 en: Chewing gum with sugar
@@ -42230,7 +40119,6 @@ hr: Čokoladni nugati
 lt: Šokoladinės nugos
 nl: Noga met chocola
 zh: 巧克力牛扎糖
-#wikidata:en:
 
 < en: nougats
 en: White nougat
@@ -42252,7 +40140,6 @@ hr: Kineski nugati
 lt: Kinietiškos nugos
 nl: Chinese noga
 zh: 中国牛扎糖, 中式牛扎糖
-#wikidata:en:
 
 < en: French confectioneries
 < en: nougats
@@ -42292,7 +40179,6 @@ hr: Crni nugat
 lt: Juodos nugos
 nl: Donkere noga
 zh: 黑牛扎糖
-#wikidata:en:
 
 < en: Candies
 < en: Confectioneries
@@ -42551,7 +40437,6 @@ nl: Adventskalender
 pl: Kalendarz adwentowy
 pt: Calendário do Advento
 ru: Рождественский календарь
-#wikidata:en:
 
 < en: Advent calendars
 < en: Christmas chocolates
@@ -42832,7 +40717,6 @@ hr: Čokoladni turrón
 it: Torrone al cioccolato, torrone di cioccolato
 lt: Šokoladinis turrón
 nl: Chocolade turrón
-#wikidata:en:
 
 < en: Chocolate turrón
 en: Chocolate turrón with almonds, Black chocolate turrón with almonds
@@ -42858,7 +40742,6 @@ es: Turrones de coco
 fr: Touron à la noix de coco
 hr: Kokos turron
 lt: Kokosų turrón
-#wikidata:en:
 
 < en: Turrón
 en: Almond turrón
@@ -42870,7 +40753,6 @@ hr: Badem turrón
 it: Torrone alle mandorle
 lt: Migdolų turrón
 nl: Amandelturrón
-#wikidata:en:
 
 < en: Almond turrón
 en: Creamy almond turrón, Soft almond turrón, Jijona turrón
@@ -42914,7 +40796,6 @@ fr: Tourons aux cacahuètes
 hr: Kikiriki turrón
 lt: Žemės riešutų turrón
 nl: Pindanturrón
-#wikidata:en:
 
 < en: Peanut turrón
 en: Creamy peanut turrón
@@ -42939,7 +40820,6 @@ es: Turrones de frutas
 fr: Turrón aux fruits
 hr: Voće turrón
 lt: Vaisių turrón
-#wikidata:en:
 
 < en: Turrón
 en: Guirlache turrón, Turrón de guirlache
@@ -42957,7 +40837,6 @@ hr: Prepečeni žumanjak turrón
 
 < en: Turrón
 es: Turrones a la piedra
-#wikidata:en:
 
 < en: Turrón
 es: Turrones de mazapán de cabello de ángel
@@ -43001,7 +40880,6 @@ fr: Pâtes de pommes
 hr: Paste od jabuka
 lt: Obuolių pasta
 nl: Appelpastas
-#wikidata:en:
 
 < en: Fruit pastes
 en: Guava pastes
@@ -43011,7 +40889,6 @@ fr: Pâtes de goyaves, Pâte de goyave
 hr: Paste od guave
 lt: Gvajavų pasta
 nl: Guavepastas
-#wikidata:en:
 
 < en: Fruit pastes
 en: Multifruit pastes
@@ -43412,7 +41289,6 @@ hr: Galete
 it: Gallette
 ja: ガレット
 nl: Galettes
-#wikidata:en:
 
 < en: Crêpes and galettes
 en: Ham and mushroom pancake in cheese sauce
@@ -43422,7 +41298,6 @@ nl: Ham-kaas pannenkoeken in kaassaus
 agribalyse_food_code:en: 26256
 ciqual_food_code:en: 26256
 ciqual_food_name:en: Ham and mushroom pancake in cheese sauce
-#wikidata:en:
 
 < en: Meals
 en: Filled buckwheat crepes
@@ -43630,14 +41505,12 @@ en: Hackeleback caviars
 de: Hackleback Kaviar
 fr: Caviar de hackeleback
 hr: Hackleback kavijar
-#wikidata:en:
 
 < en: Wild caviars
 en: Paddlefish caviars
 de: Paddlefish Kaviar, Kaviar vom Löffelstör
 fr: Caviar de paddlefish
 hr: Kavijar veslonoša
-#wikidata:en:
 
 < en: Wild caviars
 en: Ossetra caviar
@@ -43645,21 +41518,18 @@ de: Ossietra Kaviar
 fr: Caviar osciètre, Caviar d'osciètre, Caviar ossiètre, Caviar d'ossiètre, Acipenser Gueldenstaedtii, Acipenser Persicus
 hr: Ossetra kavijar
 nl: Ossetra kaviaar
-#wikidata:en:
 
 < en: Wild caviars
 en: Sevruga caviar
 de: Sevruga Kaviar
 fr: Caviar sevruga, Caviar de sevruga, Acipenser stellatus, Caviar d'esturgeon étoilé
 hr: Sevruga kavijar
-#wikidata:en:
 
 < en: Wild caviars
 en: Sterlet caviar
 de: Sterlet Kaviar
 fr: Caviar sterlet, Acipenser ruthenus
 hr: Kavijar od sterleta
-#wikidata:en:
 
 < en: Plant-based foods
 en: Nut and seed mixes, nuts and seeds mixes, Mixes of nuts and seeds
@@ -43721,7 +41591,6 @@ agribalyse_food_code:en: 53502
 ciqual_food_code:en: 53502
 ciqual_food_name:en: Yam or Indian potato, peeled, raw
 ciqual_food_name:fr: Igname, épluchée, crue
-#wikidata:en:
 
 < en: Yam potatoes
 en: Fresh yam potatoes
@@ -44444,7 +42313,6 @@ es: Quinoa roja
 fr: Quinoa rouge
 hr: Crvena kvinoja
 nl: Rode quinoa
-#wikidata:en:
 
 < en: quinoa
 en: Raw quinoa from France, Quinoa from France (raw)
@@ -44729,7 +42597,6 @@ es: Arroces para paella
 fr: Riz pour paellas
 hr: Riže za paellu
 nl: Paellarijst
-#wikidata:en:
 
 < en: Short grain rices
 en: Rices for porridge, porridge rices
@@ -44883,7 +42750,6 @@ it: Riso Basmati integrale
 lt: Rudieji Basmati ryžiai
 nl: Zilvervlies basmatirijsten, Zilvervlies basmatirijst
 sales_format:en: weight, package
-#wikidata:en:
 
 < en: Basmati rices
 < en: Semi-milled rices
@@ -44903,7 +42769,6 @@ it: Riso Basmati bianco
 lt: Baltieji Basmati ryžiai
 nl: Witte basmatirijsten, Witte basmatirijst
 sales_format:en: weight, package
-#wikidata:en:
 
 < en: Japonica rices
 < en: Rices for paella
@@ -45031,7 +42896,6 @@ es: Arroces de Surinam
 fr: Riz Surinam
 hr: Surinamske riže
 nl: Surinaamse rijsten, Surinaamse rijst
-#wikidata:en:
 
 < en: Indica rices
 < en: Long grain rices
@@ -45040,7 +42904,6 @@ es: Arroces Tahibonet
 fr: Riz Tahibonet
 hr: Tahibonet riže
 nl: Tahibonetrijsten, Tahibonetrijst, Tahibonet-rijst, Tahibonet rijst
-#wikidata:en:
 
 < en: Indica rices
 < en: Long grain rices
@@ -45080,7 +42943,6 @@ en: Roma rices
 fr: Riz Roma
 hr: Romske riže
 it: Riso Roma
-#wikidata:en:
 
 < en: Rices
 en: Originario rices
@@ -45093,7 +42955,6 @@ en: Ribe rices
 fr: Riz Ribe
 hr: Ribana riža
 it: Riso Ribe
-#wikidata:en:
 
 < en: Rices
 en: Mixed rices, Mix of rice species
@@ -45146,7 +43007,6 @@ agribalyse_food_code:en: 9390
 ciqual_food_code:en: 9390
 ciqual_food_name:en: Rye, whole, raw
 ciqual_food_name:fr: Seigle entier, cru
-#wikidata:en:
 
 < en: Seeds
 en: Sesame, raw sesame, sesame seeds
@@ -45543,7 +43403,6 @@ fr: Moules feuilletés pour vol-au-vent ou bouchées la reine
 
 < en: White beans
 fr: Lingots blancs
-#wikidata:en:
 
 < en: White beans
 fr: Lingot du Nord
@@ -45714,7 +43573,6 @@ pl: Chipsy z manioku, Czipsy z manioku
 agribalyse_proxy_food_code:en: 38104
 agribalyse_proxy_food_name:en: Prawn crackers
 agribalyse_proxy_food_name:fr: Chips de crevette
-#wikidata:en:
 
 < en: Cassava crisps
 en: Prawn crackers, Prawn cocktail crisps
@@ -46739,7 +44597,6 @@ hr: Konzervirani sirevi
 hu: Konzerv sajtok, Konzerves sajtok
 lt: Konservuoti sūriai
 nl: Kazen in blik/pot
-#wikidata:en:
 
 < en: Cheeses
 en: Cheeses (perishable)
@@ -46804,7 +44661,6 @@ hr: Sirevi iz norveške
 nl: Noorse Kazen, Kazen uit Noorwegen
 no: Norske Oster
 origins:en: en:norway
-#wikidata:en:
 
 < en: Cheeses from Norway
 < en: Cow cheeses
@@ -47146,7 +45002,6 @@ wikidata:en: Q5016036
 
 < en: Cheeses
 it: Robiolino
-#wikidata:en:
 
 < en: Italian cheeses
 fr: gorgonzola et mascarpone
@@ -47195,7 +45050,6 @@ agribalyse_food_code:en: 12716
 ciqual_food_code:en: 12716
 ciqual_food_name:en: Provolone cheese, from cow's milk
 ciqual_food_name:fr: Provolone
-#wikidata:en:
 
 < en: Provolone
 it: Provolone del Monaco
@@ -48051,14 +45905,12 @@ el: Κρασοτύρι Κω, Krasotiri Ko, Τυρί της Πόσιας, Tiri ti
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-02387
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek cheeses
 el: Ξύγαλο Σητείας, Ξίγαλο Σητείας, Xygalo Siteias, Xigalo Siteias
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0731
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek cheeses
 el: Πηχτόγαλο Χανίων, Pichtogalo Chanion
@@ -48213,7 +46065,6 @@ de: Ennstaler Steirerkas
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-02588
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Austrian cheeses
 de: Tiroler Almkäse, Tiroler Alpkäse
@@ -48271,7 +46122,6 @@ es: Quesos de Bélgica, Quesos Belgas
 fr: Fromages belges, Fromages de Belgique
 hr: Belgijski sirevi
 lt: Belgiški sūriai, sūriai iš Belgijos
-#wikidata:en:
 
 < en: Belgian cheeses
 fr: Bètchéye, Boulette de Huy, Boulette de Namur, Boulette de Nivelles, Boulette de Romedenne, Boulette de Surice, Cassette de Beaumont, Crau Stofé
@@ -48336,7 +46186,6 @@ wikidata:en: Q1283428
 < en: Cheeses
 en: Czech cheeses
 lt: Čekiški sūriai, sūriai iš Čekijos
-#wikidata:en:
 
 < en: Czech cheeses
 cs: Olomoucké tvarůžky
@@ -48350,7 +46199,6 @@ cs: Jihočeská Zlatá Niva
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0406
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Czech cheeses
 cs: Jihočeská Niva
@@ -48510,7 +46358,6 @@ ciqual_food_name:en: Abondance cheese, from cow's milk
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0105
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French cheeses
 < en: Goat cheeses
@@ -48573,7 +46420,6 @@ fr: Brocciu Corse, Brocciu
 origins:en: en:corsica, en:france
 protected_name_file_number:en: PDO-FR-0136
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cow cheeses
 < en: French cheeses
@@ -48649,7 +46495,6 @@ origins:en: en:france
 protected_name_file_number:en: PDO-FR-0115-AM01
 protected_name_type:en: pdo
 # protected_name_file_number:en: PDO-FR-0115
-#wikidata:en:
 
 < en: Cow cheeses
 < en: French cheeses
@@ -48662,7 +46507,6 @@ ciqual_food_name:en: Chaource cheese, from cow's milk
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0114
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French cheeses
 < en: Goat cheeses
@@ -48684,7 +46528,6 @@ origins:en: en:france
 #ciqual_food_name:fr:Chevrot (fromage de chèvre)
 protected_name_file_number:en: PDO-FR-0246
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Goat cheeses
 en: Crottin cheese from goat's milk
@@ -48793,7 +46636,6 @@ ciqual_food_name:en: Neufchâtel cheese, from cow's milk
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0126
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French cheeses
 < en: Sheep Cheeses
@@ -48828,7 +46670,6 @@ oqali_family:en: fr:Fromages - Crottin de chevre
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-9140
 wikidata:en: Q965981
-#wikidata:en:
 
 < en: French cheeses
 < en: Goat cheeses
@@ -48843,7 +46684,6 @@ origins:en: en:france
 protected_name_file_number:en: PDO-FR-0298
 protected_name_type:en: pdo
 wikidata:en: Q1245576
-#wikidata:en:
 
 < en: French cheeses
 < en: Goat cheeses
@@ -49291,7 +47131,6 @@ hr: Gauda s kuminom
 it: Gouda con cumino
 lt: Gouda sūriai su kmynais
 nl: Goudse Komijnenkazen, Komijnenkaas, Komijnenkazen
-#wikidata:en:
 
 < en: Gouda
 en: Young Goudas, Young Gouda
@@ -49400,7 +47239,6 @@ agribalyse_food_code:en: 12748
 ciqual_food_code:en: 12748
 ciqual_food_name:en: Saint-Nectaire cheese, from cow's milk, milks collected in many farms
 origins:en: en:france
-#wikidata:en:
 
 < en: Saint-Nectaire
 en: Saint-Nectaire cheese from milk collected in an unique farm, Saint-Nectaire cheese from cow's milk milk collected in an unique farm
@@ -49409,7 +47247,6 @@ agribalyse_food_code:en: 12751
 ciqual_food_code:en: 12751
 ciqual_food_name:en: Saint-Nectaire cheese, from cow's milk, milk collected in an unique farm
 origins:en: en:france
-#wikidata:en:
 
 < en: Cheeses
 < en: Unpasteurised products
@@ -49975,7 +47812,6 @@ en: Orkney Scottish Island Cheddar
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0908
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cheeses from England
 < en: Cow cheeses
@@ -50232,7 +48068,6 @@ en: Staffordshire Cheese
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0354
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cheeses from the United Kingdom
 en: Cheeses from Scotland
@@ -50358,7 +48193,6 @@ de: Holsteiner Tilsiter
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0807
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German cheeses
 de: Hessischer Handkäse, Hessischer Handkäs
@@ -50716,7 +48550,6 @@ wikidata:en: Q14088
 #protected_name_file_number:en: TSG-IT-0001-AM01
 #protected_name_type:en: tsg
 #origins:en: en:Italy
-#wikidata:en:
 
 < en: Grated cheese
 en: Grated Mozzarella
@@ -50738,7 +48571,6 @@ it: Mozzarella di Gioia del Colle
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-02384
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Buffalo cheeses
 < en: Mozzarella
@@ -50872,7 +48704,6 @@ it: Pecorino delle Balze Volterrane
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1166
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian cheeses
 < en: Pecorino
@@ -51139,14 +48970,12 @@ hu: Győr-Moson-Sopron megyei Csemege sajt
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02303
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian cheeses
 hu: Rögös túró
 origins:en: en:hungary
 protected_name_file_number:en: TSG-HU-1113
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Cheeses
 en: Lithuanian cheeses, cheeses from Lithuania
@@ -51169,7 +48998,6 @@ lt: Liliputas
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-0868
 protected_name_type:en: pgi
-#wikidata:en:
 #Q11689160 PB also Polish
 
 < en: Lithuanian cheeses
@@ -51353,14 +49181,12 @@ ro: Caşcaval de Săveni
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02361
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian cheeses
 ro: Telemea de Sibiu, Telemea
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02473
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian cheeses
 ro: Telemea de Ibăneşti
@@ -51384,14 +49210,12 @@ sk: Klenovecký syrec
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-1008
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovakian cheeses
 sk: Zázrivské vojky
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-1026
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovakian cheeses
 sk: Zázrivský korbáčik
@@ -51405,35 +49229,30 @@ sk: Tekovský salámový syr
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-0693
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovakian cheeses
 sk: Oravský korbáčik
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-0774
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovakian cheeses
 sk: Ovčí hrudkový syr – salašnícky
 origins:en: en:slovakia
 protected_name_file_number:en: TSG-SK-0046
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Slovakian cheeses
 sk: Ovčí salašnícky údený syr
 origins:en: en:slovakia
 protected_name_file_number:en: TSG-SK-0045
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Slovakian cheeses
 sk: Slovenský oštiepok
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-0549
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Feta-type cheese
 < en: Slovakian cheeses
@@ -51441,14 +49260,12 @@ sk: Slovenská bryndza
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-0427
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovakian cheeses
 sk: Slovenská parenica
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-0485
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cheeses
 en: Slovenian cheeses, cheeses from Slovenia
@@ -51457,7 +49274,6 @@ fr: Fromages slovènes, Fromages de Slovénie
 hr: Slovenskih sireva
 nl: Sloveense kazen
 origins:en: en:slovenia
-#wikidata:en:
 
 < en: Slovenian cheeses
 sl: Mohant
@@ -51747,7 +49563,6 @@ es: Queso Castellano
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-02307
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish cheeses
 es: Queso Los Beyos
@@ -51791,28 +49606,24 @@ sv: Vrigstad Hemost
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-02488
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Swedish cheeses
 sv: Wrångebäcksost
 origins:en: en:sweden
 protected_name_file_number:en: PDO-SE-02413
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Swedish cheeses
 sv: Hushållsost
 origins:en: en:sweden
 protected_name_file_number:en: TSG-SE-0022
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Swedish cheeses
 sv: Svecia
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-1561
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 nl: Boeren-Leidse kazen
@@ -51822,14 +49633,12 @@ wikidata:en: Q5731192
 < en: Cheeses of the Netherlands
 nl: Nagelkazen
 origins:en: en:netherlands
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 nl: Hollandse geitenkaas
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-1176
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 < en: Edam
@@ -51837,7 +49646,6 @@ nl: Edam Holland
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-0329
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 < en: Gouda
@@ -51846,28 +49654,24 @@ xx: Gouda Holland
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-0328
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 nl: Boerenkazen, Boerenkaas
 origins:en: en:netherlands
 protected_name_file_number:en: TSG-NL-0023
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 nl: Kanterkaas, Kanternagelkaas, Kanterkomijnekaas
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-0059
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 nl: Boeren-Leidse met sleutels
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-0316
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 < en: Gouda
@@ -51875,7 +49679,6 @@ nl: Noord-Hollandse Gouda
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-0314
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cheeses of the Netherlands
 bg: Едамер
@@ -51883,7 +49686,6 @@ nl: Noord-Hollandse Edammer
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-0315
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cheeses
 < en: Pasteurised products
@@ -51978,7 +49780,6 @@ fr: Raclette de Savoie
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02095, PGI-FR-02095-AM02
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Goat cheeses
 < en: Raclette
@@ -51987,7 +49788,6 @@ fr: Raclettes au lait de chèvre
 
 < en: Cheeses
 en: Argentine cheeses, cheeses from Argentina
-#wikidata:en:
 
 < en: Argentine cheeses
 es: Pategrás
@@ -52657,7 +50457,6 @@ bg: Овче масло
 fr: Beurres au lait de brebis
 hr: Ovčji maslaci
 pl: Masło owcze
-#wikidata:en:
 incompatible_with:en: categories:en:Goat butters, Butters
 
 < en: Animal fats
@@ -52668,7 +50467,6 @@ bg: Козе масло
 fr: Beurres au lait de chèvre
 hr: Kozji maslaci
 pl: Masło kozie
-#wikidata:en:
 incompatible_with:en: categories:en:Sheep butters, Butters
 
 < en: Animal fats
@@ -52881,7 +50679,6 @@ fr: Beurres belges
 hr: Belgijski maslaci
 lt: Belgiški sviestai
 origins:en: en:belgium
-#wikidata:en:
 
 < en: Belgian butters
 fr: Beurre d'Ardenne
@@ -52898,7 +50695,6 @@ hr: Francuski maslaci
 lt: Prancūziški sviestai
 pt: Manteigas francesas
 origins:en: en:france
-#wikidata:en:
 
 < en: French butters
 fr: Beurre de Bresse
@@ -53329,7 +51125,6 @@ it: Latte fieno
 #protected_name_file_number:en: TSG-AT-1035
 #protected_name_type:en: tsg
 #origins:en: en:Austria
-#wikidata:en:
 
 < en: Milks
 en: Spanish milks, Milks from Spain
@@ -53343,7 +51138,6 @@ es: Leche certificada de Granja
 origins:en: en:spain
 protected_name_file_number:en: TSG-ES-0003
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Beverages
 < en: Dairies
@@ -53663,7 +51457,6 @@ it: Latte fieno di capra
 #protected_name_file_number:en: TSG-AT-2290
 #protected_name_type:en: tsg
 #origins:en: en:Austria
-#wikidata:en:
 
 < en: Milks
 en: Sheep milks, Sheep milk, Ewe milk, Ewes milk, Sheep's milks, Sheep's milk, Whole sheep milk
@@ -53693,7 +51486,6 @@ it: Latte fieno di pecora
 #protected_name_file_number:en: TSG-AT-2289
 #protected_name_type:en: tsg
 #origins:en: en:Austria
-#wikidata:en:
 
 < en: Milks
 en: Mare's milk
@@ -54561,7 +52353,6 @@ fr: Boissons végétales de riz à la vanille, Laits de riz à la vanille
 hr: Pića na bazi riže vanilije
 nl: Vanillerijstdranken
 pt: Bebidas de arroz com baunilha
-#wikidata:en:
 
 < en: Rice-based drinks
 en: Cocoa rice-based drinks, Cocoa rice milks, Chocolate rice milks, Cocoa rice drinks, Chocolate rice drinks
@@ -54570,7 +52361,6 @@ fr: Boissons végétales de riz au cacao, Boissons végétales de riz au chocola
 hr: Pića na bazi riže i kakaa
 nl: Chocoladerijstdranken
 pt: Bebidas de arroz com cacau
-#wikidata:en:
 
 < en: Rice-based drinks
 en: UHT rice based drinks
@@ -54583,7 +52373,6 @@ fr: Boissons végétales de sésame, Laits de sésame
 hr: Pića na bazi sezama
 lt: Sezamų pienas
 nl: Sesamzaaddranken
-#wikidata:en:
 
 < en: Beverages
 en: Basil seeds drinks
@@ -54593,7 +52382,6 @@ fr: Boissons aux graines de basilic
 hr: Pića od sjemenki bosiljka
 nl: Basilicumzaaddranken
 pt: Bebidas de sementes de manjericão
-#wikidata:en:
 
 < en: Cereal-based drinks
 en: Teff-based drinks, Teff milks, Teff drinks
@@ -54602,7 +52390,6 @@ es: Bebidas de teff, Leches de teff
 fr: Boissons végétales de teff, Laits de teff
 hr: Pića na bazi tefa
 nl: Teffdranken
-#wikidata:en:
 
 < en: Cereal-based drinks
 en: Wheat-based drinks, Wheat milks, Wheat drinks
@@ -54615,7 +52402,6 @@ it: Latti di grano
 lt: Kviečių pienas
 nl: Tarwedranken
 pt: Bebidas de trigo
-#wikidata:en:
 
 < en: Wheat-based drinks
 en: Khorasan wheat-based drinks, Khorasan wheat milks, Kamut milks, Khorasan wheat drinks, Kamut drinks
@@ -54624,7 +52410,6 @@ es: Bebidas de trigo de Jorasán, Leches de trigo de Jorasán, Leches de Kamut, 
 fr: Boissons végétales de blé khorasan, Boissons végétales de blé de Khorasan, Boissons végétales de Kamut, Laits de blé de Khorasan, Laits de Kamut
 hr: Khorasan pića na bazi pšenice
 nl: Kamutdranken
-#wikidata:en:
 
 < en: Wheat-based drinks
 en: Spelt-based drinks, Spelt milks, Spelt drinks
@@ -54695,7 +52480,6 @@ it: Latte di legumi
 nl: Bonendranken
 pl: Mleka ze strączków
 pt: Leites de legumes
-#wikidata:en:
 
 < en: Legume-based drinks
 en: Soy-based drinks, Soy milks, Soya milks, Soya drinks, Soy drinks
@@ -54840,7 +52624,6 @@ ciqual_proxy_food_name:en: Almond drink
 ciqual_proxy_food_name:fr: Boisson à l'amande
 intake24_category_code:en: 19NMLK
 intake24_category_code:fr: 19NMLK
-#wikidata:en:
 
 < en: Nut-based drinks
 en: Almond-based drinks, Almond milks, Almond drinks
@@ -55171,7 +52954,6 @@ hr: Planinska mlijeka
 it: Latti di montagna
 lt: Kalnų pienas
 nl: Melk van bergkoeien
-#wikidata:en:
 
 < en: Cheeses
 < en: Salted spreads
@@ -55317,7 +53099,6 @@ lt: Jogurtai be laktozės
 nl: Lactose-vrije yoghurt, Lactose-vrije yoghurts, Yoghurt zonder lactose, Yoghurts zonder lactose
 pl: Jogurty bez laktozy
 pt: Iogurtes sem lactose
-#wikidata:en:
 
 < en: Plain yogurts
 < en: Sweetened yogurts
@@ -55429,7 +53210,6 @@ agribalyse_food_code:en: 19575
 ciqual_food_code:en: 19575
 ciqual_food_name:en: Yogurt, fermented milk or dairy specialty, flavoured, with sugar
 ciqual_food_name:fr: Yaourt, lait fermenté ou spécialité laitière, aromatisé, sucré
-#wikidata:en:
 
 < en: Flavoured yogurts
 en: Thermised milk flavoured yogurts
@@ -55470,7 +53250,6 @@ agribalyse_proxy_food_name:fr: Yaourt, lait fermenté ou spécialité laitière,
 ciqual_food_code:en: 19682
 ciqual_food_name:en: Yogurt, fermented milk or dairy specialty, w fruits or flavoured (average)
 ciqual_food_name:fr: Yaourt, lait fermenté ou spécialité laitière, aromatisé ou aux fruits (aliment moyen)
-#wikidata:en:
 intake24_category_code:en: FTYG
 intake24_category_code:fr: FTYG
 
@@ -55527,7 +53306,6 @@ it: Yogurt alla frutta con pezzi di frutta, Yogurt con frutta a pezzi
 lt: Jogurtai su vaisių gabaliukais
 nl: Vruchtenyoghurt met stukjes
 pl: Jogurty owocowe z kawałkami owoców
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Multifruit yoghurts
@@ -55576,7 +53354,6 @@ nl: Aardbeienyoghurts, Aardbeienyoghurt, Yoghurt met aardbeien, Yoghurts met aar
 pl: Jogurty truskawkowe, Jogurt truskawkowy
 pt: Iogurtes de morango
 ro: Iaurturi cu căpșune
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Blueberry yogurts
@@ -55592,7 +53369,6 @@ nl: Bosbessenyoghurt, Bosbessenyoghurts, Yoghurt met bosbessen, Yoghurts met bos
 pl: Jogurty jagodowe, Jogurt jagodowe
 pt: Iogurtes de mirtilo
 ro: Iaurturi cu afine
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Blackberry yogurts
@@ -55603,7 +53379,6 @@ it: Yogurt al more
 lt: Gervuogių jogurtai, Jogurtai su gervuogėmis
 pt: Iogurtes de amora
 ro: Iaurturi cu mure
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Mango yogurts
@@ -55618,7 +53393,6 @@ lt: Mangų jogurtai, Jogurtai su mangais
 nl: Mangoyoghurts, Mangoyoghurt, Yoghurt met mango, Yoghurts met mango
 pt: Iogurtes de manga
 ro: Iaurturi cu mango
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Peach yogurts
@@ -55637,7 +53411,6 @@ pt: Iogurtes de pêssego
 ro: Iaurturi cu piersici
 tr: Şeftalili yoğurt
 zh: 桃子酸奶
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Pineapple yogurts
@@ -55650,7 +53423,6 @@ it: Yogurt all'ananas
 lt: Ananasų jogurtai, Jogurtai su ananasais
 nl: Ananasyoghurt, Ananasyoghurts, Yoghurt met ananas, Yoghurts met ananas
 pt: Iogurtes de ananás
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Cherry yogurts
@@ -55666,7 +53438,6 @@ nl: Kersenyoghurts, Kersenyoghurt
 pt: Iogurtes de cereja
 ro: Iaurturi cu cireșe
 tr: Kirazlı yoğurt
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Raspberry yogurts
@@ -55682,7 +53453,6 @@ lt: Aviečių jogurtai, Jogurtai su avietėmis
 nl: Frambozenyoghurt, Frambozenyoghurts, Yoghurt met framboos, Yoghurt met frambozen, Yoghurts met framboos, Yoghurts met frambozen
 pt: Iogurtes de framboesa
 ro: Iaurturi cu zmeură
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Apricot yogurts
@@ -55697,7 +53467,6 @@ lt: Abrikosų jogurtai, Jogurtai su abrikosais
 nl: abrikozenyoghurt, Abrikozenyoghurts, Yoghurt met abrikoos, Yoghurt met abrikozen, Yoghurts met abrikoos, Yoghurts met abrikozen
 pt: Iogurtes de damasco
 ro: Iaurturi cu caise
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Pear yogurts
@@ -55711,7 +53480,6 @@ lt: Kriaušių jogurtai, Jogurtai su kriaušėmis
 nl: Perenyoghurt, Perenyoghurts, Yoghurt met peer, Yoghurt met peren
 pt: Iogurtes de pera
 ro: Iaurturi cu pere
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Apple yogurts
@@ -55722,7 +53490,6 @@ it: Yogurt alla mela
 lt: Obuolių jogurtai, Jogurtai su obuoliais
 nl: Appelyoghurt, Appelyoghurts, Yoghurt met appel
 pt: Iogurtes de maçã
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Plum yogurts
@@ -55732,7 +53499,6 @@ hr: Jogurti od šljiva
 it: Yogurt alla prugna, yogurt alla susina
 lt: Slyvų jogurtai, Jogurtai su slyvomis
 nl: Pruimenyoghurt, Pruimenyoghurts, Yoghurt met pruimen
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Prune yogurts
@@ -55742,7 +53508,6 @@ hr: Jogurti od suhih šljiva
 it: Yogurt alla prugna secca
 lt: Džiovintų slyvų jogurtai, Jogurtai su džiovintomis slyvomis
 nl: Gedroogde pruimenyoghurt, Gedroogde pruimenyoghurts, Yoghurt met gedroogde pruimen
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Rhubarb yogurts
@@ -55756,7 +53521,6 @@ lt: Rabarbarų jogurtai, Jogurtai su rabarbariaus
 nl: Rabarberyogurt, Rabarberyogurts
 pt: Iogurtes de ruibarbo
 ro: Iaurturi cu rubarbă
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Banana yogurts
@@ -55771,7 +53535,6 @@ lt: Bananiniai jogurtai, Jogurtai su bananais
 nl: Yoghurt met banaan
 pt: Iogurtes de banana
 ro: Iaurturi cu banane
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Fig yogurts, Figs yogurts
@@ -55783,7 +53546,6 @@ lt: Figų jogurtai, Jogurtai su figomis
 nl: Yoghurt met vijg
 pt: Iogurtes de figo
 ro: Iaurturi cu smochine
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Grapefruit yogurts
@@ -55791,7 +53553,6 @@ fr: Yaourts au pamplemousse
 hr: Jogurti od grejpa
 lt: Greipfrutų jogurtai, Jogurtai su greipfrutais
 pt: Iogurtes de toranja
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Kiwifruit yogurts, Kiwi yogurts
@@ -55820,7 +53581,6 @@ lt: Kokosiniai jogurtai, Jogurtai su kokosais
 nl: Yoghurt met kokos
 pt: Iogurtes de coco
 ro: Iaurturi cu nucă de cocos
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Hazelnut yogurts
@@ -55832,7 +53592,6 @@ lt: Lazdyno riešutų jogurtai, Jogurtai su lazdynais
 nl: Hazelnootyoghurt, Hazelnootyoghurts, Yoghurt met hazelnoot
 pt: Iogurtes de avelã
 tr: Fındıklı yoğurt
-#wikidata:en:
 
 < en: Fruit yogurts
 en: Chestnut yogurts
@@ -55846,7 +53605,6 @@ lt: Kaštonų jogurtai, Jogurtai su kaštonais
 nl: Kastanjeyoghurts, Kastanjeyoghurt
 pt: Iogurtes de castanha
 ro: Iaurturi cu castane
-#wikidata:en:
 
 < en: Yogurts
 en: Chocolate chunks yogurts, Chocolate yogurts, Fermented milk yogurt with chocolate shavings and cream and sugar, Dairy specialty with chocolate shavings and cream and sugar, straciatella yogurts, stracciatella yogurts
@@ -55863,7 +53621,6 @@ agribalyse_food_code:en: 19580
 ciqual_food_code:en: 19580
 ciqual_food_name:en: Yogurt, fermented milk or dairy specialty, with chocolate shavings, with cream, with sugar
 ciqual_food_name:fr: Yaourt, lait fermenté ou spécialité laitière, aux copeaux de chocolat, à la crème, sucré
-#wikidata:en:
 
 < en: Yogurts
 en: Caramel yogurts
@@ -56082,7 +53839,6 @@ fi: sekoitetut jugurtit
 fr: Yaourts brassés, Yaourt brassé
 hr: Razmućeni jogurti
 nl: Roeryoghurts
-#wikidata:en:
 
 < en: Yogurts
 ru: Биойогурт, Биойогурты
@@ -56108,7 +53864,6 @@ fi: Sekoitetut hedelmäjogurtit
 fr: Yaourts brassés aux fruits, Yaourt brassé aux fruits
 hr: Voćni miješani jogurti
 nl: Vruchtenroeryoghurts, Vruchtenroeryoghurt
-#wikidata:en:
 
 < en: Stirred yogurts
 < en: Vanilla yogurt
@@ -56128,7 +53883,6 @@ it: Yogurt dolcificati
 lt: Saldinti jogurtai
 nl: Yoghurts met suiker
 pt: Iogurtes açucarados
-#wikidata:en:
 
 < en: Yogurts
 en: Vanilla yogurt, vanilla yogurts
@@ -56312,7 +54066,6 @@ agribalyse_food_code:en: 39220
 ciqual_food_code:en: 39220
 ciqual_food_name:en: Fruit liegeois
 ciqual_food_name:fr: Liégeois aux fruits
-#wikidata:en:
 
 < en: Compotes
 < en: Snacks and desserts for babies
@@ -56409,7 +54162,6 @@ it: Dessert al caffè
 lt: Kavos desertai, Desertai iš kavos
 nl: Koffietoetjes, koffiedesserts
 zh: 咖啡甜品, 咖啡甜点
-#wikidata:en:
 
 < en: Plant-based spreads
 en: Relish
@@ -56580,12 +54332,10 @@ hr: Malina coulis
 hu: Málna öntet
 nl: Frambozencoulis
 agribalyse_food_code:en: 0004
-#wikidata:en:
 
 < en: Fruits coulis
 en: Blackcurrant coulis
 fr: Coulis de cassis
-#wikidata:en:
 
 < en: Fruits coulis
 en: Bilberry coulis
@@ -56596,7 +54346,6 @@ hr: Borovnica coulis
 it: Coulis di mirtillo
 lt: Mėlynės čatnis
 nl: Bosbessencoulis
-#wikidata:en:
 
 < en: Fruits coulis
 fr: Coulis de fruits rouges
@@ -56607,7 +54356,6 @@ fr: Coulis d'abricot
 hr: Kulis od marelice
 hu: Sárgabarack öntet
 nl: Abrikozencoulis
-#wikidata:en:
 
 < en: Fruits coulis
 en: Mango coulis
@@ -56618,7 +54366,6 @@ hr: Mango coulis
 it: Coulis di mango
 lt: Mangų čatnis
 nl: Mangocoulis
-#wikidata:en:
 
 < en: Desserts
 < en: Fruit-based foods
@@ -57508,7 +55255,6 @@ ja: フルーツティラミス
 lt: Vaisių tiramisas
 nl: Fruit tiramisu
 pl: Tiramisu owocowe
-#wikidata:en:
 
 < en: Tiramisu
 en: Chocolate tiramisu
@@ -57520,7 +55266,6 @@ ja: チョコレートティラミス
 lt: Šokoladinis tiramisas
 nl: Chocolade tiramisu
 pl: Tiramisu czekoladowe
-#wikidata:en:
 
 < en: Tiramisu
 en: Coffee tiramisu
@@ -57598,7 +55343,6 @@ ja: シロップ漬けフルーツサラダ
 lt: Vaisių salotos su sirupu
 nl: Fruitsalade in siroop
 pl: Sałatki owocowe w syropie
-#wikidata:en:
 
 < en: Fruit salads in syrup
 en: Canned drained fruit cocktail in syrup, Canned drained fruit salad in syrup
@@ -58640,14 +56384,12 @@ it: Marrone della Valle di Susa
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0564
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chestnuts
 it: Marrone di Serino, Castagna di Serino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02147
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chestnuts
 it: Marrone del Mugello
@@ -58744,7 +56486,6 @@ nl: Hazelnoten uit Cervione
 origins:en: en:haute-corse
 protected_name_file_number:en: PGI-FR-1083
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hazelnuts
 < en: Spanish fruits
@@ -58753,7 +56494,6 @@ es: Avellana de Reus
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0046, PDO-ES-0046-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Hazelnuts
 en: Unshelled hazelnuts, Hazelnuts with shell
@@ -59498,7 +57238,6 @@ fr: Farine de châtaigne corse, Farina castagnina corsa
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0581
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chestnut flours
 it: Farina di castagne della Lunigiana
@@ -59949,14 +57688,12 @@ fr: Miels belges, Miels de Belgique
 hr: Medovi iz belgije
 lt: Medus iš Belgijos
 origins:en: en:belgium
-#wikidata:en:
 
 < en: Honeys from Belgium
 fr: Miel wallon
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-02409
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Honeys
 en: Italian honeys
@@ -59967,152 +57704,130 @@ hr: Talijanski medovi
 lt: Medus iš Italijos
 nl: Italiaanse honing
 origins:en: en:italy
-#wikidata:en:
 
 < en: Italian honeys
 it: Miele della Lunigiana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0195
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian honeys
 it: Miele Varesino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0990
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian honeys
 it: Miele delle Dolomiti Bellunesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0776
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Honeys
 en: Portuguese honeys
 lt: Medus iš Portugalijos
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel do Ribatejo Norte (Serra d'Aire, Albufeira de Castelo de Bode, Bairro, Alto Nabão
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0240
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel das Terras Altas do Minho
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0244
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel da Terra Quente
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0245
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel da Serra de Monchique
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0250
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel do Alentejo
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0252
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel dos Açores
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0268
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel da Serra da Lousã
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0222
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel de Barroso
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0229
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese honeys
 pt: Mel do Parque de Montezinho
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-9234
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Honeys
 en: Spanish honeys
 lt: Medus iš Ispanijos
 origins:en: en:spain
-#wikidata:en:
 
 < en: Spanish honeys
 es: Miel Villuercas-Ibores
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-01268
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish honeys
 es: Miel de Liébana
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-01196
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish honeys
 es: Miel de Campoo- los Valles
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-1258
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish honeys
 es: Miel de Tenerife
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0943
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish honeys
 es: Miel de Galicia, Mel de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0278
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish honeys
 es: Miel de Granada
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0243
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish honeys
 es: Miel de La Alcarria
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0079
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Honeys
 en: Honeys from France, French honeys
@@ -60128,7 +57843,6 @@ nl: Franse honingen
 pt: Méis de França
 ru: Французский мед
 origins:en: en:france
-#wikidata:en:
 
 < en: Honeys from France
 en: Honeys from Alsace
@@ -60279,7 +57993,6 @@ hu: Mézek Romániából
 lt: Medus iš Rumunijos
 nl: Roemeense honingen
 # Disabled for safety: origins:en: en:Romania
-#wikidata:en:
 
 < en: Honeys from Romania
 fr: Miels des rives du Danube de Roumanie
@@ -60739,7 +58452,6 @@ hr: Omleti
 ja: オムレツ
 nl: Omeletten
 intake24_category_code:en: OMLT
-#wikidata:en:
 
 < en: Omelettes
 fr: Omelette avec garniture
@@ -60756,7 +58468,6 @@ lt: Omletai su mėsa
 ciqual_food_code:en: 22511
 ciqual_food_name:en: Omelette, with vegetables, cheese, meat
 ciqual_food_name:fr: Omelette, garnitures diverses : légumes, fromages, viandes... (aliment moyen)
-#wikidata:en:
 
 < fr: Omelette avec garniture
 en: Omelettes with cheese
@@ -60766,7 +58477,6 @@ lt: Omletai su sūriu
 agribalyse_food_code:en: 22506
 ciqual_food_code:en: 22506
 ciqual_food_name:en: Omelette, with cheese
-#wikidata:en:
 
 < fr: Omelette avec garniture
 en: Omelette with vegetables
@@ -60776,7 +58486,6 @@ lt: Omletai su daržovėmis
 ciqual_food_code:en: 22511
 ciqual_food_name:en: Omelette, with vegetables, cheese, meat
 ciqual_food_name:fr: Omelette, garnitures diverses : légumes, fromages, viandes... (aliment moyen)
-#wikidata:en:
 
 < fr: Omelettes
 en: Herb omelette
@@ -60787,7 +58496,6 @@ agribalyse_food_code:en: 22509
 ciqual_food_code:en: 22509
 ciqual_food_name:en: Omelette, with herbs
 ciqual_food_name:fr: Omelette aux fines herbes
-#wikidata:en:
 
 < fr: Omelettes
 en: Omelette with lardoons
@@ -60796,7 +58504,6 @@ agribalyse_food_code:en: 22507
 ciqual_food_code:en: 22507
 ciqual_food_name:en: Omelette, with lardoons
 ciqual_food_name:fr: Omelette aux lardons
-#wikidata:en:
 
 < fr: Omelettes
 en: Omelette with mushrooms, Mushroom Omelette
@@ -60807,7 +58514,6 @@ agribalyse_food_code:en: 22508
 ciqual_food_code:en: 22508
 ciqual_food_name:en: Omelette, with mushrooms
 ciqual_food_name:fr: Omelette aux champignons
-#wikidata:en:
 
 < en: Eggs and their products
 < en: Farming products
@@ -61015,7 +58721,6 @@ fr: Œufs de Loué
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0356
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chicken eggs
 < en: Frozen foods
@@ -62075,7 +59780,6 @@ de: Lausitzer Leinöl
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0547
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cereal oils
 en: Rice bran oils
@@ -62489,7 +60193,6 @@ fr: Huile de noix du Périgord
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02445
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetable oils
 en: Vegetable oil sprays
@@ -62658,7 +60361,6 @@ lt: Alyvuogių aliejai iš Prancūzijos
 nl: Olijfoliën uit Frankrijk, Olijfolies uit Frankrijk, Franse olijfoliën, Franse olijfolies
 sv: Olivoljor från Frankrike, Franska olivoljor
 # Disabled for safety: origins:en: en:France
-#wikidata:en:
 
 < en: Olive oils from France
 en: Olive oils from Aix-en-Provence, Olive oil from Aix-en-Provence
@@ -62668,7 +60370,6 @@ nl: Olijfoliën uit Aix-en-Provence, Olijfolies uit Aix-en-Provence
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-9111
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from France
 en: Olive oils from Corsica, Olive oil from Corsica
@@ -62679,7 +60380,6 @@ nl: Olijfoliën uit Corsica, Corsicaanse olijfoliën, Olijfolies uit Corsica
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0428
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from France
 en: Olive oils from Haute-Provence, Olive oil from Haute-Provence
@@ -62698,7 +60398,6 @@ nl: Olijfoliën uit de vallei van Baux-de-Provence, Olijfolies uit de vallei van
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0050
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from France
 en: Olive oils from Nice, Olive oil from Nice
@@ -62726,7 +60425,6 @@ nl: Olijfoliën uit Nyons, Olijfolies uit Nyons
 origins:en: en:france, en:nyons
 protected_name_file_number:en: PDO-FR-0142
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from France
 fr: Huile d'olive de Provence
@@ -62752,7 +60450,6 @@ lt: Alyvuogių aliejai iš Italijos
 nl: Olijfoliën uit Italië, Olijfolies uit Italië, Italiaanse olijfolies, Italiaanse olijfoliën
 sv: Olivoljor från Italien, Italienska olivoljor
 # Disabled for safety: origins:en: en:Italy
-#wikidata:en:
 
 < en: Extra-virgin olive oils
 < en: Olive oils from Italy
@@ -62769,7 +60466,6 @@ nl: Olijfoliën uit Alto Crotonese, Olijfolies uit Alto Crotonese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0200
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Aprutino Pescarese
@@ -62780,7 +60476,6 @@ nl: Olijfoliën uit Aprutino Pescarese, Olijfolies uit Aprutino Pescarese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1526-AM05
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Brisighella
@@ -62791,7 +60486,6 @@ nl: Olijfoliën uit Brisighella, Olijfolies uit Brisighella
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1513
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Bruzio
@@ -62802,7 +60496,6 @@ nl: Olijfoliën uit Bruzio, Olijfolies uit Bruzio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1518
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Canino
@@ -62813,7 +60506,6 @@ nl: Olijfoliën uit Canino, Olijfolies uit Canino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1506
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Cartoceto
@@ -62824,7 +60516,6 @@ nl: Olijfoliën uit Cartoceto, Olijfolies uit Cartoceto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1513
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Chianti Classico
@@ -62835,7 +60526,6 @@ nl: Olijfoliën uit Chianti Classico, Olijfolies uit Chianti Classico
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0108-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Cilento
@@ -62846,7 +60536,6 @@ nl: Olijfoliën uit Cilento, Olijfolies uit Cilento
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1547
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Collina di Brindisi
@@ -62857,7 +60546,6 @@ nl: Olijfoliën uit Collina di Brindisi, Olijfolies uit Collina di Brindisi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1508
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Colline Pontine
@@ -62868,7 +60556,6 @@ nl: Olijfoliën uit Colline Pontine, Olijfolies uit Colline Pontine
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0499
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Colline di Romagna
@@ -62879,7 +60566,6 @@ nl: Olijfoliën uit Colline di Romagna, Olijfolies uit Colline di Romagna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0211
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Colline Salernitane
@@ -62890,7 +60576,6 @@ nl: Olijfoliën uit Colline Salernitane, Olijfolies uit Colline Salernitane
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1545
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Colline Teatine
@@ -62901,7 +60586,6 @@ nl: Olijfoliën uit Colline Teatine, Olijfolies uit Colline Teatine
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1541
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Dauno
@@ -62912,7 +60596,6 @@ nl: Olijfoliën uit Dauno, Olijfolies uit Dauno
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1517
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Irpinia - Colline dell'Ufita
@@ -62932,7 +60615,6 @@ nl: Olijfoliën uit Laghi Lombardi, Olijfolies uit Laghi Lombardi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1543
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Lametia
@@ -62943,7 +60625,6 @@ nl: Olijfoliën uit Lametia, Olijfolies uit Lametia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0068
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Lucca
@@ -62954,7 +60635,6 @@ nl: Olijfoliën uit Lucca, Olijfolies uit Lucca
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0199
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Marche
@@ -62965,7 +60645,6 @@ nl: Olijfoliën uit Marche, Olijfolies uit Marche
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01338
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Molise
@@ -62976,7 +60655,6 @@ nl: Olijfoliën uit Molise, Olijfolies uit Molise
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0166
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Monte Etna
@@ -62987,7 +60665,6 @@ nl: Olijfoliën uit Monte Etna, Olijfolies uit Monte Etna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0060-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Monti Iblei
@@ -62998,7 +60675,6 @@ nl: Olijfoliën uit Monti Iblei, Olijfolies uit Monti Iblei
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1521-AM03
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Olio lucano, Olio lucano
@@ -63009,7 +60685,6 @@ nl: Olijfoliën uit Olio lucano, Olijfolies uit Olio lucano, Olio lucano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02458
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Olio di Calabria, Olio di Calabria
@@ -63020,7 +60695,6 @@ nl: Olijfoliën uit Olio di Calabria, Olijfolies uit Olio di Calabria, Olio di C
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01314
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Olio di Puglia
@@ -63031,7 +60705,6 @@ nl: Olijfoliën uit Olio di Puglia, Olijfolies uit Olio di Puglia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02381
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Olio di Roma
@@ -63042,7 +60715,6 @@ nl: Olijfoliën uit Olio di Roma, Olijfolies uit Olio di Roma
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02453
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Penisola Sorrentina
@@ -63053,7 +60725,6 @@ nl: Olijfoliën uit Penisola Sorrentina, Olijfolies uit Penisola Sorrentina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1546
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Pretuziano delle Colline Teramane
@@ -63064,7 +60735,6 @@ nl: Olijfoliën uit Pretuziano delle Colline Teramane, Olijfolies uit Pretuziano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0174
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Riviera Ligure
@@ -63075,7 +60745,6 @@ nl: Olijfoliën uit Riviera Ligure, Olijfolies uit Riviera Ligure
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1540-AM02, PDO-IT-1540
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Sabina
@@ -63086,7 +60755,6 @@ nl: Olijfoliën uit Sabina, Olijfolies uit Sabina
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1511
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Sardegna
@@ -63097,7 +60765,6 @@ nl: Olijfoliën uit Sardegna, Olijfolies uit Sardegna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0284
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Seggiano
@@ -63108,7 +60775,6 @@ nl: Olijfoliën uit Seggiano, Olijfolies uit Seggiano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0561
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Sicilia
@@ -63119,7 +60785,6 @@ nl: Olijfoliën uit Sicilia, Olijfolies uit Sicilia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01305
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Tergeste
@@ -63130,7 +60795,6 @@ nl: Olijfoliën uit Tergeste, Olijfolies uit Tergeste
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0256
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Terre Aurunche
@@ -63141,7 +60805,6 @@ nl: Olijfoliën uit Terre Aurunche, Olijfolies uit Terre Aurunche
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0571
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Terra di Bari
@@ -63152,7 +60815,6 @@ nl: Olijfoliën uit Terra di Bari
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1542
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Terre di Siena
@@ -63163,7 +60825,6 @@ nl: Olijfoliën uit Terre di Siena, Olijfolies uit Terre di Siena
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0109
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Terra d'Otranto
@@ -63174,7 +60835,6 @@ nl: Olijfoliën uit Terra d'Otranto, Olijfolies ui Terra d'Otranto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1519
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Terre Tarentine
@@ -63185,7 +60845,6 @@ nl: Olijfoliën uit Terre Tarentine, Olijfolies uit Terre Tarentine
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0259
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Toscano
@@ -63196,7 +60855,6 @@ nl: Olijfoliën uit Toscano, Olijfolies uit Toscano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1512
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Tuscia
@@ -63207,7 +60865,6 @@ nl: Olijfoliën uit Tuscia, Olijfolies uit Tuscia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0210
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Umbria
@@ -63218,7 +60875,6 @@ nl: Olijfoliën uit Umbria, Olijfolies uit Umbria
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1520
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Valdemone
@@ -63229,7 +60885,6 @@ nl: Olijfoliën uit Valdemone, Olijfolies uit Valdemone
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0218
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Val di Mazara
@@ -63240,7 +60895,6 @@ nl: Olijfoliën uit Val di Mazara, Olijfolies uit Val di Mazara
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0061
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Valle del Belice
@@ -63251,7 +60905,6 @@ nl: Olijfoliën uit Valle del Belice, Olijfolies uit Valle del Belice
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0258
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Valli Trapanesi
@@ -63262,7 +60915,6 @@ nl: Olijfoliën uit Valli Trapanesi, Olijfolies uit Valli Trapanesi
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1510
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Veneto
@@ -63273,7 +60925,6 @@ nl: Olijfoliën uit Veneto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-9067
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Veneto
 en: Olive oils from Veneto Valpolicella
@@ -63284,7 +60935,6 @@ nl: Olijfoliën uit Veneto Valpolicella, Olijfolies uit Veneto Valpolicella
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-9067
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Veneto
 en: Olive oils from Veneto Euganei e Berici
@@ -63295,7 +60945,6 @@ nl: Olijfoliën uit Veneto Euganei e Berici, Olijfolies uit Veneto Euganei e Ber
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-9067
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Veneto
 en: Olive oils from Veneto del Grappa
@@ -63306,7 +60955,6 @@ nl: Olijfoliën uit Veneto del Grappa, Olijfolies uit Veneto del Grappa
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-9067
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Italy
 en: Olive oils from Vulture
@@ -63317,7 +60965,6 @@ nl: Olijfoliën uit Vulture, Olijfolies uit Vulture
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0452
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Fats
 en: Greek oils and fats
@@ -63327,42 +60974,36 @@ hr: Grčka ulja i masti
 lt: Aliejai ir riebalai iš Graikijos
 sv: Grekiska oljor och fetter
 origins:en: en:greece
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Κριτσά, Kritsa
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-2317
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Ελαιόλαδο Μάκρης, Elaiolado Makris
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-02388
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Γαλανό Μεταγγιτσίου Χαλκιδικής, Galano Metaggitsiou Chalkidikis
 origins:en: en:greece
 protected_name_file_number:en: PDO-EL-1027
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Μεσσαρά, Messara
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0973
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Αγουρέλαιο Χαλκιδικής, Agoureleo Chalkidikis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0736
 protected_name_type:en: pdo
-#wikidata:en:
 
 
 < en: Greek oils and fats
@@ -63370,35 +61011,30 @@ el: Άγιος Ματθαίος Κέρκυρας, Agios Mattheos Kerkyras
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0214
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Ελαιόλαδ Φοινίκι Λακωνίας, Elaiolado Finiki Lakonias
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0361
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Σάμος, Samos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0032
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Ζάκυνθος, Zakynthos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0051
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Αποκορώνας Χανίων Κρήτης, Apokoronas Chanion Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0047
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek oils and fats
 < en: Olive oils from Greece
@@ -63413,7 +61049,6 @@ el: Καλαμάτα, Kalamata
 origins:en: en:messenia
 protected_name_file_number:en: PDO-GR-0037
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 el: Κολυμβάρι Χανίων Κρήτης, Kolymvari Chanion Kritis
@@ -63428,28 +61063,24 @@ el: Χανιά Κρήτης, Chania Kritis
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0033
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Ολυμπία, Olympia
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0034
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Πεζά Ηρακλείου Κρήτης, Peza Irakliou Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0035
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Βόρειος Μυλοπόταμος Ρεθύμνης Κρήτης, Vorios Mylopotamos Rethymnis Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0039
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 el: Βιάννος Ηρακλείου Κρήτης, Viannos Irakliou Kritis
@@ -63479,28 +61110,24 @@ el: Λέσβος, Mυτιλήνη, Lesvos ; Mytilini
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0059
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Θάσος, Thassos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0377
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Κεφαλονιά, Kefalonia
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0388
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Ρόδος, Rodos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0390
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Πέτρινα Λακωνίας, Petrina Lakonias
@@ -63514,7 +61141,6 @@ el: Πρέβεζα, Preveza
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0399
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 el: Κρανίδι Αργολίδας, Kranidi Argolidas
@@ -63529,14 +61155,12 @@ el: Κροκεές Λακωνίας, Krokees Lakonias
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0407
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek oils and fats
 el: Λακωνία, Lakonia
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0457
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils
 en: Olive oils from Hungary, Hungarian olive oils
@@ -63549,7 +61173,6 @@ hu: Őrségi tökmagolaj
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02482
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils
 en: Olive oils from Spain, Spanish olive oils
@@ -63563,7 +61186,6 @@ lt: Alyvuogių aliejai iš Ispanijos
 nl: Olijfoliën uit Spanje, Olijfolies uit Spanje, Spaanse olijfolies, Spaanse olijfoliën
 sv: Olivoljor från Spanien, Spanska olivoljor
 origins:en: en:spain
-#wikidata:en:
 
 < en: Extra-virgin olive oils
 < en: Olive oils from Spain
@@ -63606,7 +61228,6 @@ nl: Olijfoliën uit Baena, Olijfolies uit Baena
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0069
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Baix Ebre-Montsià
@@ -63619,7 +61240,6 @@ nl: Olijfoliën uit Baix Ebre-Montsià, Olijfolies uit Baix Ebre-Montsià
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0274
 protected_name_type:en: pdo
-#wikidata:en:
 
 # Is also a wine region
 < en: Olive oils from Spain
@@ -63746,7 +61366,6 @@ nl: Olijfoliën uit Les Garrigues, Olijfolies uit Les Garrigues
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0070
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Lucena
@@ -63758,7 +61377,6 @@ nl: Olijfoliën uit Lucena, Olijfolies uit Lucena
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0760
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Mallorca
@@ -63771,7 +61389,6 @@ nl: Olijfoliën uit Mallorca, Olijfolies uit Mallorca
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0263
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Monterrubio
@@ -63809,7 +61426,6 @@ nl: Olijfoliën uit Montes de Toledo, Olijfolies uit Montes de Toledo
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0083
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Montoro-Adamuz
@@ -63859,7 +61475,6 @@ nl: Olijfoliën uit Priego de Córdoba, Olijfolies uit Priego de Córdoba
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0053
 protected_name_type:en: pdo
-#wikidata:en:
 
 # Rioja also has some other PDO products
 < en: Olive oils from Spain
@@ -63898,7 +61513,6 @@ nl: Olijfoliën uit Sierra de Cazorla, Olijfolies uit Sierra de Cazorla
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0137
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Sierra del Moncayo
@@ -63922,7 +61536,6 @@ nl: Olijfoliën uit Sierra de Segura, Olijfolies uit Sierra de Segura
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0071
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Sierra Mágina
@@ -63934,7 +61547,6 @@ nl: Olijfoliën uit Sierra Mágina, Olijfolies uit Sierra Mágina
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0054
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Siurana
@@ -63946,7 +61558,6 @@ nl: Olijfoliën uit Siurana, Olijfolies uit Siurana
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0072
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Spain
 en: Olive oils from Terra Alta
@@ -63959,7 +61570,6 @@ nl: Olijfoliën uit Terra Alta, Olijfolies uit Terra Alta
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0245
 protected_name_type:en: pdo
-#wikidata:en:
 
 ### OLIVE OILS FROM GREECE
 
@@ -63978,7 +61588,6 @@ lt: Alyvuogių aliejai iš Graikijos
 nl: Olijfoliën uit Griekenland, Griekse olijfoliën, Olijfolies uit Griekenland, Griekse olijfolies
 sv: Olivoljor från Grekland, Grekiska olivoljor
 origins:en: en:greece
-#wikidata:en:
 
 < en: Extra-virgin olive oils
 < en: Olive oils from Greece
@@ -63997,7 +61606,6 @@ pt: Azeites do Agios Mattheos Kerkyras
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0214-
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Apokoronas Chanion Kritis
@@ -64010,7 +61618,6 @@ pt: Azeites do Apokoronas Chanion Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0047
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Arxanes Irakliou Kritis
@@ -64023,7 +61630,6 @@ pt: Azeites do Arxanes Irakliou Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0055
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Exeretiko Partheno Eleolado Selino Kritis
@@ -64036,7 +61642,6 @@ pt: Azeites do Exeretiko Partheno Eleolado Selino Kritis
 origins:en: en:greece
 #protected_name_file_number:en: PDO-GR-0515
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Exeretiko partheno eleolado "Trizinia"
@@ -64049,7 +61654,6 @@ pt: Azeites do Exeretiko partheno eleolado "Trizinia"
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0206
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Elaiolado Finiki Lakonias
@@ -64062,7 +61666,6 @@ pt: Azeites do Elaiolado Finiki Lakonias
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0361
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Exeretiko partheno eleolado Thrapsano
@@ -64075,7 +61678,6 @@ pt: Azeites do Exeretiko partheno eleolado Thrapsano
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0125
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Kalamata
@@ -64088,7 +61690,6 @@ pt: Azeites do Kalamata
 origins:en: en:messenia
 protected_name_file_number:en: PDO-GR-0037
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Kefalonia
@@ -64101,7 +61702,6 @@ pt: Azeites do Kefalonia
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0388
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Kolymvari Chanion Kritis
@@ -64114,7 +61714,6 @@ pt: Azeites do Kolymvari Chanion Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0053
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Kranidi Argolidas
@@ -64127,7 +61726,6 @@ pt: Azeites do Kranidi Argolidas
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0400
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Krokees Lakonias
@@ -64140,7 +61738,6 @@ pt: Azeites do Krokees Lakonias
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0407
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Lakonia
@@ -64153,7 +61750,6 @@ pt: Azeites do Lakonia
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0457
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Lesvos Mytilini
@@ -64166,7 +61762,6 @@ pt: Azeites do Lesvos Mytilini
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0059
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Lygourio Asklipiou
@@ -64179,7 +61774,6 @@ pt: Azeites do Lygourio Asklipiou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0050
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Olympia
@@ -64192,7 +61786,6 @@ pt: Azeites do Olympia
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0034
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Petrina Lakonias
@@ -64205,7 +61798,6 @@ pt: Azeites do Petrina Lakonias
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0394
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Peza Irakliou Kritis
@@ -64218,7 +61810,6 @@ pt: Azeites do Peza Irakliou Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0035
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Preveza
@@ -64231,7 +61822,6 @@ pt: Azeites do Preveza
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0399
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Rhodos
@@ -64244,7 +61834,6 @@ pt: Azeites do Rhodos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0390
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Samos
@@ -64257,7 +61846,6 @@ pt: Azeites do Samos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0032
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Sitia Lasithiou Kritis
@@ -64270,7 +61858,6 @@ pt: Azeites do Sitia Lasithiou Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0052
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Thassos
@@ -64283,7 +61870,6 @@ pt: Azeites do Thassos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0377
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Viannos Irakliou Kritis
@@ -64296,7 +61882,6 @@ pt: Azeites do Viannos Irakliou Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0045
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Vorios Mylopotamos Rethymnis Kritis
@@ -64309,7 +61894,6 @@ pt: Azeites do Vorios Mylopotamos Rethymnis Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0039
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olive oils from Greece
 en: Olive oils from Zakynthos
@@ -64322,7 +61906,6 @@ pt: Azeites do Zakynthos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0051
 protected_name_type:en: pgi
-#wikidata:en:
 
 ####### OLIVE OILS FROM PORTUGAL
 
@@ -64592,7 +62175,6 @@ en: Iveagh Rapeseed Oil
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-2464
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British oils and fats
 < en: Rapeseed oils
@@ -64600,7 +62182,6 @@ en: Broighter Gold Rapeseed Oil
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-2198
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Fats
 en: Austrian oils and fats
@@ -64614,7 +62195,6 @@ de: Steirisches Kürbiskernöl
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-1460, PGI-AT-1460-AM02
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Fats
 en: Croatian oils and fats
@@ -64622,42 +62202,36 @@ fr: Huiles et graisses croates
 hr: Hrvatska ulja i masti
 lt: Kroatiški aliejai ir riebalai
 origins:en: en:croatia
-#wikidata:en:
 
 < en: Croatian oils and fats
 hr: Bračko maslinovo ulje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-02599
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian oils and fats
 hr: Šoltansko maslinovo ulje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-01346
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian oils and fats
 hr: Korčulansko maslinovo ulje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-01351
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian oils and fats
 hr: Krčko maslinovo ulje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-01345
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian oils and fats
 hr: Ekstra djevičansko maslinovo ulje Cres
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-1206
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Rapeseed oils
 en: Canola oils
@@ -66419,7 +63993,6 @@ lt: Grikių miltai iš Bretanės
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0555
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Buckwheat flours
 en: T80 buckwheat flour
@@ -66947,14 +64520,12 @@ fr: Farines de petit épeautre de Haute-Provence, Farine de Petit Épeautre de H
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0476
 protected_name_type:en: pgi
-#wikidata:en:
 
 #<en:Einkorn wheat flours
 #fr:Petit Épeautre de Haute Provence
 #protected_name_file_number:en: PGI-FR-0475
 #protected_name_type:en: pgi
 #origins:en: en:France
-#wikidata:en:
 
 < en: Wheat flours
 en: Emmer wheat flours
@@ -69955,14 +67526,12 @@ fr: Plate de Florenville
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-1151
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Belgian vegetables
 nl: Poperingse hopscheuten, Poperingse hoppescheuten
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-0968
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Belgian endives
 < en: Belgian vegetables
@@ -69970,14 +67539,12 @@ nl: Brussels grondwitloof
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-0535
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Belgian fruits
 nl: Vlaams-Brabantse tafeldruif
 origins:en: en:belgium
 protected_name_file_number:en: PDO-BE-0534
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Fruits
 en: Dutch fruits
@@ -70053,21 +67620,18 @@ de: Pöllauer Hirschbirne
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-1190
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Austrian vegetables
 de: Steirischer Kren
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-0249
 protected_name_type:en: pgi
-#wikidata:en:
 
 #<en:Poppies
 #de:Waldviertler Graumohn
 #protected_name_file_number:en: PDO-AT-1463
 #protected_name_type:en: pdo
 #origins:en: en:Austria
-#wikidata:en:
 
 < en: Apricots
 < en: Austrian fruit
@@ -70075,7 +67639,6 @@ de: Wachauer Marille
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-1473
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Apples
 < en: British fruit
@@ -70084,7 +67647,6 @@ fr: Pommes Bramley, Bramley
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0792
 protected_name_type:en: pgi
-#wikidata:en:
 
 
 < en: Fruits
@@ -70124,14 +67686,12 @@ es: Garbanzo de Fuentesaúco
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0264, PGI-ES-0264-AM02
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Castaña de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0609, PGI-ES-0609-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Tomatoes
 < en: Vegetables from Spain
@@ -70139,21 +67699,18 @@ es: Tomate La Cañada
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0664, PGI-ES-0664-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Kaki Ribera del Xúquer
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0114, PDO-ES-0114-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pimientos del Piquillo de Lodosa
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0080, PDO-ES-0080-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olives
 < en: Vegetables from Spain
@@ -70161,7 +67718,6 @@ es: Aceituna Gordal de Sevilla, Aceituna Gordal Sevillana
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-2183
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olives
 < en: Vegetables from Spain
@@ -70169,42 +67725,36 @@ es: Aceituna Manzanilla de Sevilla, Aceituna Manzanilla Sevillana
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-2182
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pimiento de Gernika, Gernikako Piperra
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0673, PGI-ES-0673-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Granada Mollar de Elche, Granada de Elche
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-01230
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish fruits
 es: Melón de Torre Pacheco-Murcia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-1235
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Fesols de Santa Pau
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-1226
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pemento de Mougán
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-1133
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Almonds
 < en: Spanish fruits
@@ -70212,7 +67762,6 @@ es: Almendra de Mallorca, Almendra Mallorquina, Ametlla de Mallorca, Ametlla Mal
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-1037
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Olives
 < en: Vegetables from Spain
@@ -70220,21 +67769,18 @@ es: Aceituna de Mallorca, Aceituna Mallorquina, Oliva de Mallorca, Oliva Mallorq
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-1051
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish fruits
 es: Gofio Canario
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0942
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Onions
 es: Cebolla Fuentes de Ebro
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0817
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chickpeas
 < en: Vegetables from Spain
@@ -70242,14 +67788,12 @@ es: Garbanzo de Escacena
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0945
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Pasas de Málaga
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0849
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olives
 < en: Vegetables from Spain
@@ -70257,98 +67801,84 @@ es: Aceituna Aloreña de Málaga
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0785
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Papas Antiguas de Canarias
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0866
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pimiento de Fresno-Benavente
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0705
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Mongeta del Ganxet
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0636
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish fruits
 es: Pera de Lleida
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0698
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish fruits
 es: Melón de La Mancha
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0511
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pemento de Herbón
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0509
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pemento da Arnoia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0510
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pemento de Oímbra
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0486
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Alubia de La Bañeza-León
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0492
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Chirimoya de la Costa tropical de Granada-Málaga
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0244
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pemento do Couto
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0464
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Grelos de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0469
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Faba de Lourenzá
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0480
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Rice
 < en: Spanish cereals
@@ -70356,112 +67886,96 @@ es: Arroz del Delta del Ebro, Arròs del Delta de l'Ebre
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0336
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish legumes
 es: Lenteja de Tierra de Campos
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0313
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Cereza del Jerte
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0233
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Coliflor de Calahorra
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0268
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pataca de Galicia, Patata de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0205
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Patatas de Prades, Patates de Prades
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0232
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pimiento Asado del Bierzo
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0262
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Pera de Jumilla
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0315
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Pimiento Riojano
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0275
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Peras de Rincón de Soto
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0251
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Alcachofa de Benicarló, Carxofa de Benicarló
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0202
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish fruits
 es: Manzana de Girona, Poma de Girona
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0154
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Cítricos Valencianos, Cítrics Valencians
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0152
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Calçot de Valls
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0171
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Manzana Reineta del Bierzo
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0115
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Alcachofa de Tudela
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0139
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Rices
 < en: Spanish cereals
@@ -70478,63 +67992,54 @@ es: Melocotón de Calanda
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0103
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Berenjena de Almagro
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0011
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Uva de mesa embolsada del Vinalopó
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0075
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish fruits
 es: Cerezas de la Montaña de Alicante
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0099
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Faba Asturiana
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0100
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Judías de El Barco de Ávila
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0101
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Spain
 es: Lenteja de La Armuña
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0102
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish fruits
 es: Calasparra
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0073
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish fruits
 es: Nísperos Callosa d'En Sarriá
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0074
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Fruits
 en: Kumquats, kumquat
@@ -70872,7 +68377,6 @@ it: Mela Rossa Cuneo
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0915
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Apples
 it: Mela Alto Adige
@@ -70880,14 +68384,12 @@ de: Südtiroler Apfel
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0207
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Apples
 it: Mela Val di Non
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0197
 protected_name_type:en: pdo
-#wikidata:en:
 
 
 < en: Apples
@@ -71030,28 +68532,24 @@ fr: Pomme du Limousin
 origins:en: en:limousin
 protected_name_file_number:en: PDO-FR-0442
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Apples
 fr: Pommes des Alpes de Haute Durance
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0498
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Apples
 it: Mele del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-2320
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Apples
 it: Mela di Valtellina
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0574-AM01, PGI-IT-0574
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Acidic apples
 < en: Apples
@@ -71484,7 +68982,6 @@ fr: Fraises de Nîmes
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0809
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French fruits
 < en: Strawberries
@@ -71745,7 +69242,6 @@ fr: Cerise des coteaux du Ventoux
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02446
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Fruits
 en: Citrus, Citrus fruits
@@ -72241,7 +69737,6 @@ es: Clementinas de las Tierras del Ebro, Clementines de les Terres de l'Ebre
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0173
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Clementines
 < en: Fresh fruits
@@ -72267,7 +69762,6 @@ it: Clementine di Calabria
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1548
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Clementines
 < en: French fruits
@@ -72440,7 +69934,6 @@ fr: Figue de Solliès
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0544, PDO-FR-0544-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Fruits
 en: Grapes
@@ -73094,7 +70587,6 @@ it: Pesca di Delia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02469
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Fresh fruits
 < en: Peaches
@@ -73313,7 +70805,6 @@ fr: Melon du Quercy
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0086
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French fruits
 < en: Muskmelons
@@ -73321,7 +70812,6 @@ fr: Melon de Guadeloupe
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0844
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French fruits
 < en: Muskmelons
@@ -73329,7 +70819,6 @@ fr: Melon du Haut-Poitou
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0029
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Muskmelons
 en: Branco melons, White melons
@@ -74334,7 +71823,6 @@ nl: Bananen van de Canarische eilanden
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0867
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Bananas
 en: Frecinette Bananas, Frécinette bananas, Frécinettes bananas, Bananas (frécinette)
@@ -74368,7 +71856,6 @@ agribalyse_food_code:en: 53101
 ciqual_food_code:en: 53101
 ciqual_food_name:en: Plantain banana, cooked
 ciqual_food_name:fr: Banane plantain, cuite
-#wikidata:en:
 
 #< en:Bananas
 < en: Flours
@@ -74490,7 +71977,6 @@ hr: Ribani kokos
 lt: Tarkuotas kokosas
 nl: Geraspte kokos, Kokosrasp
 sales_format:en: weight, package
-#wikidata:en:
 
 < en: Tropical fruits
 en: Guavas
@@ -78396,14 +75882,12 @@ fr: Sels croates
 hr: Hrvatske soli
 lt: Kroatiškos druskos
 origins:en: en:croatia
-#wikidata:en:
 
 < en: Croatian salts
 hr: Paška sol
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-02178
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Salts
 en: British salts
@@ -78422,7 +75906,6 @@ wikidata:en: Q16526855
 en: Italian salts
 lt: Itališkos druskos
 origins:en: en:italy
-#wikidata:en:
 
 < en: Italian salts
 it: Sale Marino di Trapani
@@ -78463,7 +75946,6 @@ fr: Fleurs de sel de Guérande
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0861
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Guerande salts
 < fr: Gros sels
@@ -78483,7 +75965,6 @@ fr: Fleur de sel de Camargue
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02443
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French salts
 fr: Sel de Salies-de-Béarn
@@ -78528,14 +76009,12 @@ fr: Sels portugais
 hr: Portugalske soli
 lt: Portogališkos druskos
 origins:en: en:portugal
-#wikidata:en:
 
 < en: Portuguese salts
 pt: Sal de Rio Maior, Flor de Sal de Rio Maior
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-02589
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese salts
 pt: Sal de Tavira, Flor de Sal de Tavira
@@ -78550,14 +76029,12 @@ fr: Sels slovènes
 hr: Slovenske soli
 lt: Slovėniškos druskos
 origins:en: en:slovenia
-#wikidata:en:
 
 < en: Slovenian salts
 sl: Piranska sol
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-1098
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Salts
 en: Salts from Québec
@@ -80064,7 +77541,6 @@ fr: Piments d'Espelette, Piment d'Espelette, Ezpeletako biperra, Capsicum annuum
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-9131
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chili peppers
 fr: Piments jaunes, Piment jaune
@@ -80783,7 +78259,6 @@ agribalyse_food_code:en: 11158
 ciqual_food_code:en: 11158
 ciqual_food_name:en: Sauce, butter, prepacked
 ciqual_food_name:fr: Sauce au beurre, préemballée
-#wikidata:en:
 
 < en: Sauces
 en: Roux
@@ -80791,7 +78266,6 @@ fr: Roux, Roux blancs
 agribalyse_proxy_food_code:en: 11140
 agribalyse_proxy_food_name:en: White butter sauce, prepacked
 agribalyse_proxy_food_name:fr: Sauce au beurre blanc, préemballée
-#wikidata:en:
 
 < en: Roux
 en: Brown roux
@@ -80799,16 +78273,13 @@ fr: Roux bruns
 agribalyse_proxy_food_code:en: 11158
 agribalyse_proxy_food_name:en: Sauce, butter, prepacked
 agribalyse_proxy_food_name:fr: Sauce au beurre, préemballée
-#wikidata:en:
 
 < en: Roux
 < en: Sauces
 fr: Sauces blanches
-#wikidata:en:
 
 < en: Sauces
 fr: Sauces bordelaises
-#wikidata:en:
 
 < en: Sauces
 en: Burgundy-style sauces
@@ -81055,7 +78526,6 @@ fr: Sauces caesar, sauces césar
 hr: Cezar umaci
 it: Salse caesar, salsa caesar
 lt: Cezario padažai
-#wikidata:en:
 
 < en: Sauces
 en: Mustard sauces, Mustard sauce
@@ -81070,7 +78540,6 @@ agribalyse_food_code:en: 11157
 ciqual_food_code:en: 11157
 ciqual_food_name:en: Mustard sauce prepacked
 ciqual_food_name:fr: Sauce moutarde, préemballée
-#wikidata:en:
 
 < en: Sauces
 en: Barbecue sauces, BBQ sauces
@@ -81146,7 +78615,6 @@ wikidata:en: Q115618401
 
 < en: Curry sauces
 en: Madras curry sauce
-#wikidata:en:
 
 < en: Sauces
 fr: Sauce Hannibal
@@ -81164,7 +78632,6 @@ agribalyse_food_code:en: 11112
 ciqual_food_code:en: 11112
 ciqual_food_name:en: Harissa (hot spicy sauce), prepacked
 ciqual_food_name:fr: Harissa (sauce condimentaire)
-#wikidata:en:
 
 < en: Sauces
 en: Algerian-style sauces, Algerian sauces
@@ -81219,7 +78686,6 @@ nl: Pitasausen
 agribalyse_proxy_food_code:en: 11196
 agribalyse_proxy_food_name:en: Burger sauce, prepacked
 agribalyse_proxy_food_name:fr: Sauce burger, préemballée
-#wikidata:en:
 
 < en: Sauces
 en: Indian-style sauces, Indian sauces
@@ -81229,7 +78695,6 @@ hr: Umaci na indijski način
 hu: Indiai mártások
 lt: Indiški padažai
 nl: Indiaase sauzen
-#wikidata:en:
 
 < en: Indian-style sauces
 en: Tikka masala sauce, garam masala sauce
@@ -81243,7 +78708,6 @@ agribalyse_food_code:en: 11202
 ciqual_food_code:en: 11202
 ciqual_food_name:en: Indian-style sauce, tandoori or garam masala type, prepacked
 ciqual_food_name:fr: Sauce indienne type tandoori ou tikka masala, préemballée
-#wikidata:en:
 
 < en: Indian-style sauces
 en: Tandoori sauces, Indian-style tandoori sauce
@@ -81255,7 +78719,6 @@ agribalyse_food_code:en: 11202
 ciqual_food_code:en: 11202
 ciqual_food_name:en: Indian-style sauce, tandoori or garam masala type, prepacked
 ciqual_food_name:fr: Sauce indienne type tandoori ou tikka masala, préemballée
-#wikidata:en:
 
 < en: Indian-style sauces
 en: Korma sauces
@@ -81321,7 +78784,6 @@ fr: Sauces Yakitori
 hr: Yakitori umaci
 ja: 焼き鳥のタレ
 nl: Yakitorisauzen
-#wikidata:en:
 
 < fr: Sauces au soja sucrées
 en: Tare sauces
@@ -81498,7 +78960,6 @@ agribalyse_food_code:en: 11191
 ciqual_food_code:en: 11191
 ciqual_food_name:en: Roquefort (blue cheese) sauce, prepacked
 ciqual_food_name:fr: Sauce au roquefort, préemballée
-#wikidata:en:
 
 < en: Dips
 < en: Plant-based spreads
@@ -81861,14 +79322,12 @@ lt: Vokiškos garstyčios
 nl: Duitse mosterds
 pl: Musztardy niemieckie
 origins:en: en:germany
-#wikidata:en:
 
 < en: German mustards
 de: Düsseldorfer Mostert, Düsseldorfer Senf Mostert, Düsseldorfer Urtyp Mostert, Aechter Düsseldorfer Mostert
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0799
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Mustards
 en: Fine mustards
@@ -82146,7 +79605,6 @@ nl: Potjesvlees uit de Westhoek
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-1130
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Belgian meat products
 fr: Jambon d'Ardenne
@@ -82163,7 +79621,6 @@ hr: Češki mesni proizvodi
 lt: Čekiški mėsos produktai
 pl: Czeskie produkty mięsne
 origins:en: en:czech-republic
-#wikidata:en:
 
 < en: Czech meat products
 cs: Pražská šunka
@@ -82215,35 +79672,30 @@ hr: Baranjski kulen
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-1207
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian meat products
 hr: Dalmatinska pečenica
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-02456
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian meat products
 hr: Dalmatinska panceta
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-02455
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian meat products
 hr: Slavonska kobasica
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-02441
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian meat products
 hr: Međimursko meso 'z tiblice
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-02180
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian meat products
 < en: Hams
@@ -82262,14 +79714,12 @@ hr: Drniški pršut
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-01212
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian meat products
 hr: Krčki pršut
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-1204
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Meats and their products
 en: Cypriot meat products, Meat products from Cyprus
@@ -82277,7 +79727,6 @@ hr: Ciparski mesni proizvodi
 lt: Kipro mėsos produktai
 pl: Cypryjskie produkty mięsne, Produkty mięsne z Cypru
 # disabled for safety: origins:en: en:Cyprus
-#wikidata:en:
 
 < en: Cypriot meat products
 en: Hiromeri Pitsilias
@@ -82285,7 +79734,6 @@ el: Χοιρομέρι Πιτσιλιάς, Hiromeri Pitsilias
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-02368
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cypriot meat products
 en: Lountza Pitsilias
@@ -82293,7 +79741,6 @@ el: Λούντζα Πιτσιλιάς, Lountza Pitsilias
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-02367
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cypriot meat products
 en: Loukaniko Pitsilias
@@ -82301,7 +79748,6 @@ el: Λουκάνικο Πιτσιλιάς, Loukaniko Pitsilias
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-02369
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cypriot meat products
 en: Pafitiko Loukaniko
@@ -82309,7 +79755,6 @@ el: Παφίτικο Λουκάνικο, Pafitiko Loukaniko
 origins:en: en:cyprus
 protected_name_file_number:en: PGI-CY-1244
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Meats and their products
 en: Bulgarian meat products
@@ -82325,7 +79770,6 @@ bg: Луканка Панагюрска, Lukanka Panagyurska
 origins:en: en:bulgaria
 protected_name_file_number:en: TSG-BG-1099, TSG-BG-1099-AM01
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Bulgarian meat products
 en: Pastarma Govezhda
@@ -82333,7 +79777,6 @@ bg: Пастърма говежда, Pastarma Govezhda
 origins:en: en:bulgaria
 protected_name_file_number:en: TSG-BG-1255
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Bulgarian meat products
 en: Kayserovan vrat Trakiya
@@ -82341,7 +79784,6 @@ bg: Кайсерован врат Тракия, Kayserovan vrat Trakiya
 origins:en: en:bulgaria
 protected_name_file_number:en: TSG-BG-1018
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Bulgarian meat products
 en: Role Trapezitsa
@@ -82349,7 +79791,6 @@ bg: Роле Трапезица, Role Trapezitsa
 origins:en: en:bulgaria
 protected_name_file_number:en: TSG-BG-1020
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Bulgarian meat products
 en: File Elena
@@ -82357,7 +79798,6 @@ bg: Филе Елена, File Elena
 origins:en: en:bulgaria
 protected_name_file_number:en: TSG-BG-1017
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Bulgarian meat products
 en: Gornooryahovski sudzhuk
@@ -82365,7 +79805,6 @@ bg: Горнооряховски суджук, Gornooryahovski sudzhuk
 origins:en: en:bulgaria
 protected_name_file_number:en: PGI-BG-0732
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Bulgarian meat products
 en: Troyanska lukanka, Lukanka Troyanska
@@ -82373,7 +79812,6 @@ bg: Троянска луканка, Луканка Троянска
 origins:en: en:bulgaria
 protected_name_file_number:en: TSG-BG-02797
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Meats and their products
 en: Finnish meat products
@@ -82382,14 +79820,12 @@ hr: Finski mesni proizvodi
 lt: Suomiški mėsos produktai
 pl: Fińskie produkty mięsne
 origins:en: en:finland
-#wikidata:en:
 
 < en: Finnish meat products
 fi: Aito saunapalvikinkku, Äkta basturökt skinka
 origins:en: en:finland
 protected_name_file_number:en: PGI-FI-02462
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Reindeer meat
 fi: Lapin Poron kylmäsavuliha
@@ -82403,7 +79839,6 @@ fi: Lapin Poron kuivaliha
 origins:en: en:finland
 protected_name_file_number:en: PDO-FI-0384
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Meats and their products
 en: German meat products
@@ -82419,7 +79854,6 @@ de: Thüringer Leberwurst
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0222, PGI-DE-0222-AM02
 protected_name_type:en: pgi
-#wikidata:en:
 
 #<en:Blood sausages
 < en: German meat products
@@ -82458,14 +79892,12 @@ de: Westfälischer Knochenschinken
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0854
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German meat products
 de: Eichsfelder Feldgieker, Eichsfelder Feldkieker
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0773
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German meat products
 de: Holsteiner Katenschinken, Holsteiner Schinken, Holsteiner Katenrauchschinken, Holsteiner Knochenschinken
@@ -82479,7 +79911,6 @@ de: Göttinger Feldkieker
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0721
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German meat products
 de: Göttinger Stracke
@@ -82557,7 +79988,6 @@ de: Greußener Salami
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1266
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German meat products
 de: Ammerländer Schinken, Ammerländer Knochenschinken
@@ -82571,7 +80001,6 @@ de: Ammerländer Dielenrauchschinken, Ammerländer Katenschinken
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1225
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German meat products
 < en: German sausages
@@ -82614,7 +80043,6 @@ hu: Szegedi szalámi, Szegedi téliszalámi
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-0392
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: sausages
 en: debrecener
@@ -82658,7 +80086,6 @@ it: Salame Piemonte
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1237
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian meat products
 it: Finocchiona
@@ -82721,7 +80148,6 @@ it: Crudo di Cuneo
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0490
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian meat products
 it: Ciauscolo
@@ -82742,7 +80168,6 @@ it: Salame Cremona
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0265
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian meat products
 it: Lardo di Colonnata
@@ -82988,14 +80413,12 @@ pl: Kiełbasa piaszczańska
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-02154
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish meat products
 pl: Kiełbasa biała parzona wielkopolska
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-02119
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish meat products
 < en: kaszanka
@@ -83018,14 +80441,12 @@ pl: Kiełbasa jałowcowa staropolska
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0047
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Polish meat products
 pl: Kiełbasa myśliwska staropolska
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0053
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Polish meat products
 pl: Kiełbasa lisiecka
@@ -83059,7 +80480,6 @@ no: Fenalår fra Norge
 origins:en: en:norway
 protected_name_file_number:en: PGI-NO-1360
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Meats and their products
 en: Portuguese meat products
@@ -83080,28 +80500,24 @@ pt: Chouriça de carne de Melgaço
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-1011
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese meat products
 pt: Presunto de Melgaço
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-1013
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese meat products
 pt: Chouriça de sangue de Melgaço
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-1010
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese meat products
 pt: Salpicão de Melgaço
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-1012
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese meat products
 pt: Presunto de Campo Maior e Elvas, Paleta de Campo Maior e Elvas
@@ -83397,28 +80813,24 @@ sl: Prekmurska šunka
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-1025
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian meat products
 sl: Kraška panceta
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0833
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian meat products
 sl: Kraški zašink
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0824
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian meat products
 sl: Kraški pršut
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0417
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian meat products
 sl: Zgornjesavinjski želodec
@@ -83432,14 +80844,12 @@ sl: Šebreljski želodec
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0415
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian meat products
 sl: Prleška tünka
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0533
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Meats and their products
 en: Spanish meat products
@@ -83474,7 +80884,6 @@ es: Carne de Salamanca
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01174
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish meat products
 es: Capón de Vilalba
@@ -83488,14 +80897,12 @@ es: Vaca e Boi de Galicia, Vaca y Buey de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-2308
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish meat products
 es: Gall del Penedès
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01308
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish meat products
 es: Ternera de Aliste
@@ -83589,11 +80996,9 @@ es: Pollo y Capón del Prat
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0095
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish meat products
 es: Capón del Prat
-#wikidata:en:
 
 < en: Spanish meat products
 es: Pollo del Prat
@@ -83664,7 +81069,6 @@ es: Jamón de Serón
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-1052
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish meat products
 es: Chorizo de Cantimpalos
@@ -83728,7 +81132,6 @@ es: Guijuelo
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0077
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish meat products
 es: Jamón de Teruel, Paleta de Teruel
@@ -83792,7 +81195,6 @@ nl: Vleessauzen, Jussauzen
 pl: Sosy mięsne
 pt: Molhos à base de carne
 zh: 肉类酱汁
-#wikidata:en:
 
 < en: Sauces
 en: Pestos, Pesto sauces
@@ -83971,7 +81373,6 @@ hr: Tamaris
 it: Tamaris
 ja: たまり醤油
 nl: Tamari sojasauzen
-#wikidata:en:
 
 < en: Soy sauces
 en: Sukiyaki sauces
@@ -84414,7 +81815,6 @@ he: ממרחי זיתים, ממרח זית
 hr: Umaci od maslina
 lt: Alyvuogių padažai
 nl: Sauzen met olijven
-#wikidata:en:
 
 en: Meals, Prepared meals, Prepared dishes
 bg: Готови ястия
@@ -85077,14 +82477,12 @@ de: Lachsrisotto, Lachs-Risotto
 fr: Risottos au saumon
 hr: Rižoto od lososa
 nl: Zalmrisotto
-#wikidata:en:
 
 < en: Risottos
 en: Veal risottos
 fr: Risottos au veau, risottos de veau
 hr: Teleći rižoti
 nl: Kalfsvleesrisotto
-#wikidata:en:
 
 < en: Meals with chicken
 < en: Risottos
@@ -85093,7 +82491,6 @@ fi: Kanarisotot
 fr: Risottos au poulet
 hr: Pileći rižoti
 nl: Kiprisottos, kiprisotto
-#wikidata:en:
 
 < en: Risottos
 en: Risotto with cheese, Cheese risotto
@@ -85228,7 +82625,6 @@ agribalyse_food_code:en: 25150
 ciqual_food_code:en: 25150
 ciqual_food_name:en: Couscous with vegetables
 ciqual_food_name:fr: Couscous de légumes
-#wikidata:en:
 
 < en: Prepared couscous
 en: Couscous with fish
@@ -85240,7 +82636,6 @@ agribalyse_food_code:en: 25107
 ciqual_food_code:en: 25107
 ciqual_food_name:en: Couscous w fish
 ciqual_food_name:fr: Couscous au poisson
-#wikidata:en:
 
 < en: Prepared couscous
 en: Couscous with mutton
@@ -85250,7 +82645,6 @@ lt: Kuskusas su aviena
 agribalyse_food_code:en: 25029
 ciqual_food_code:en: 25029
 ciqual_food_name:en: Couscous w mutton
-#wikidata:en:
 
 < en: Prepared couscous
 en: Couscous with meat
@@ -85262,7 +82656,6 @@ agribalyse_food_code:en: 25152
 ciqual_food_code:en: 25152
 ciqual_food_name:en: Couscous w meat
 ciqual_food_name:fr: Couscous à la viande
-#wikidata:en:
 
 < en: Couscous with meat
 en: Royal couscous, Royal couscous with different meats
@@ -85271,7 +82664,6 @@ agribalyse_food_code:en: 25127
 ciqual_food_code:en: 25127
 ciqual_food_name:en: Couscous royal (with different meats)
 ciqual_food_name:fr: Couscous royal (avec plusieurs viandes)
-#wikidata:en:
 
 < en: Couscous with meat
 en: Chicken couscous
@@ -85282,7 +82674,6 @@ agribalyse_food_code:en: 25138
 ciqual_food_code:en: 25138
 ciqual_food_name:en: Couscous w chicken
 ciqual_food_name:fr: Couscous au poulet
-#wikidata:en:
 
 < en: Couscous with meat
 en: Light couscous with meat, Light couscous with chicken, Low fat couscous with meat, Low fat couscous with chicken
@@ -85324,7 +82715,6 @@ fr: Plats aux crevettes
 hr: Jela sa škampima
 lt: Patiekalai su krevetėmis
 nl: Schaaldiermaaltijd, Schaaldiermaaltijden
-#wikidata:en:
 
 < en: Meals
 en: Meals with fish, fish dishes
@@ -85344,7 +82734,6 @@ pl: Dania z rybami, Dania z rybą
 pt: Refeições com peixe, pratos com peixe
 ru: Блюда с рыбой
 intake24_category_code:en: FDSH
-#wikidata:en:
 
 < en: Meals with fish
 it: piatto a base di tonno
@@ -85458,7 +82847,6 @@ hr: Jela s bakalarom
 it: Pasti con merluzzo
 lt: Patiekalai su menke
 nl: Kabeljauwgerechten
-#wikidata:en:
 
 < en: Meals with fish
 en: Meals with salmon
@@ -85471,7 +82859,6 @@ hr: Jela s lososom
 it: Pasti con salmone
 lt: Patiekalai su lašiša
 nl: Zalmmaaltijden
-#wikidata:en:
 
 < en: Meals with salmon
 fr: Parmentiers de saumon
@@ -87222,7 +84609,6 @@ wikidata:en: Q244617
 < en: Vegetable soups
 fr: Soupes à l'ortie
 nl: Brandnetelsoepen
-#wikidata:en:
 
 < en: Onion soups
 < en: Reheatable soups
@@ -88078,7 +85464,6 @@ hr: Hladna predjela
 it: Antipasti freddi
 lt: Šalti užkandžiai
 nl: Koude voorgerechten
-#wikidata:en:
 
 < en: Prepared salads
 en: Coleslaw, Coleslaw with sauce
@@ -88150,7 +85535,6 @@ ja: 野菜のパテ
 lt: Daržovių paplotėliai
 nl: Groentenschijven
 pl: Warzywne kotlety
-#wikidata:en:
 
 < en: Frozen foods
 < en: Vegetable patties
@@ -88213,7 +85597,6 @@ agribalyse_food_code:en: 25511
 ciqual_food_code:en: 25511
 ciqual_food_name:en: Stuffed vegetables (excluding tomato)
 ciqual_food_name:fr: Légumes farcis (sauf tomate)
-#wikidata:en:
 
 < en: Frozen foods
 < en: Stuffed vegetables
@@ -88254,7 +85637,6 @@ agribalyse_food_code:en: 25162
 ciqual_food_code:en: 25162
 ciqual_food_name:en: Vegetables au gratin (oven grilled)
 ciqual_food_name:fr: Gratin de légumes
-#wikidata:en:
 
 < en: Frozen foods
 < en: Vegetable gratins
@@ -88279,7 +85661,6 @@ agribalyse_food_code:en: 25052
 ciqual_food_code:en: 25052
 ciqual_food_name:en: Eggplant au gratin (oven grilled)
 ciqual_food_name:fr: Gratin d'aubergine
-#wikidata:en:
 
 < en: Vegetable gratins
 en: Cauliflower gratins, Cauliflower au gratin, Oven grilled cauliflower
@@ -88290,7 +85671,6 @@ agribalyse_food_code:en: 25101
 ciqual_food_code:en: 25101
 ciqual_food_name:en: Cauliflower au gratin (oven grilled)
 ciqual_food_name:fr: Gratin de chou-fleur
-#wikidata:en:
 
 < en: Gratins
 < en: Pasta dishes
@@ -88303,7 +85683,6 @@ agribalyse_food_code:en: 25122
 ciqual_food_code:en: 25122
 ciqual_food_name:en: Pasta au gratin (oven grilled)
 ciqual_food_name:fr: Gratin de pâtes
-#wikidata:en:
 
 < en: Gratins
 < en: Potato dishes
@@ -88317,7 +85696,6 @@ nl: Aardappelovenschotels
 agribalyse_proxy_food_code:en: 25056
 agribalyse_proxy_food_name:en: Dauphiné-style creamed potatoes au gratin
 agribalyse_proxy_food_name:fr: Gratin dauphinois
-#wikidata:en:
 
 < en: Potato gratin
 en: Dauphiné-style creamed potatoes au gratin
@@ -88363,7 +85741,6 @@ lt: Paruoštos lazanijos
 nl: Kant-en-klaar lasagnas
 pl: Gotowa lasagne, Gotowa lazania
 pt: Lasanha preparada
-#wikidata:en:
 
 < en: Prepared lasagne
 en: Vegetable lasagnas, Vegetable lasagne, Lasagna with vegetables
@@ -88378,7 +85755,6 @@ agribalyse_food_code:en: 25131
 ciqual_food_code:en: 25131
 ciqual_food_name:en: Lasagna or cannelloni with vegetables
 ciqual_food_name:fr: Lasagnes ou cannelloni aux légumes
-#wikidata:en:
 
 < en: Prepared lasagne
 en: Vegetarian lasagne
@@ -88390,7 +85766,6 @@ hr: Vegetarijanske lazanje
 it: Lasagne vegetariane
 lt: Vegetariškos lazanijos
 nl: Vegetarische lasagna
-#wikidata:en:
 
 < en: Vegetable lasagnas
 en: Lasagna with cooked vegetables
@@ -88409,7 +85784,6 @@ hr: Lazanje s kozjim sirom i špinatom
 it: Lasagne al formaggio di capra e spinaci
 lt: Lazanijos su ožkų sūriu ir špinatais
 nl: Lasagna met geitenkaas en spinazie
-#wikidata:en:
 agribalyse_food_code:en: 25635
 ciqual_food_code:en: 25635
 ciqual_food_name:en: Lasagna or cannelloni with goat cheese and spinach
@@ -88441,7 +85815,6 @@ it: Lasagne surgelate
 lt: Šaldytos lazanijos
 nl: Diepvrieslasagna
 sv: Fryst lasagne
-#wikidata:en:
 
 < en: Meat lasagnas
 en: Bolognese lasagne
@@ -88457,7 +85830,6 @@ nl: Kant-en-klaar bolognese lasagnas
 agribalyse_food_code:en: 25081
 ciqual_food_code:en: 25081
 ciqual_food_name:en: Lasagna or cannelloni with meat (bolognese sauce)
-#wikidata:en:
 
 < en: Prepared lasagne
 en: Fish lasagnas, Lasagne with fish, Lasagna with fish
@@ -88469,7 +85841,6 @@ agribalyse_food_code:en: 25139
 ciqual_food_code:en: 25139
 ciqual_food_name:en: Lasagna or cannelloni with fish
 ciqual_food_name:fr: Lasagnes ou cannelloni au poisson
-#wikidata:en:
 
 < en: Fish lasagnas
 < en: Meals with salmon
@@ -88480,7 +85851,6 @@ hr: Lazanje od lososa
 it: Lasagne al salmone
 lt: Lazanijos su lašiša
 nl: Zalmlasagnes, Zalmlasagne, Lasagne met zalm
-#wikidata:en:
 
 < en: Salmon lasagne
 en: Salmon and spinach lasagna
@@ -88495,7 +85865,6 @@ fr: Lasagnes au thon
 hr: Lazanje od tune
 lt: Lazanijos su tunu
 nl: Tonijnlasagnes, Tonijnlasagne
-#wikidata:en:
 
 < en: Meals
 en: Braised European hake
@@ -88513,7 +85882,6 @@ en: Hake fillet
 fr: Filet de merlu
 hr: File oslića
 lt: Jūrų lydekų filė
-#wikidata:en:
 
 < en: Frozen fishes
 < en: Hake fillet
@@ -88537,7 +85905,6 @@ agribalyse_food_code:en: 26044
 ciqual_food_code:en: 26044
 ciqual_food_name:en: European hake, raw
 ciqual_food_name:fr: Merlu, cru
-#wikidata:en:
 
 < en: Fishes
 en: Shallow-water Cape hake
@@ -88546,7 +85913,6 @@ agribalyse_food_code:en: 26233
 ciqual_food_code:en: 26233
 ciqual_food_name:en: Shallow-water Cape hake, raw
 ciqual_food_name:fr: Merlu blanc du Cap, surgelé, cru
-#wikidata:en:
 
 < en: Fishes
 en: Blue grenadier
@@ -88557,7 +85923,6 @@ agribalyse_food_code:en: 26214
 ciqual_food_code:en: 26214
 ciqual_food_name:en: Blue grenadier, raw
 ciqual_food_name:fr: Grenadier bleu ou hoki de Nouvelle-Zélande cru
-#wikidata:en:
 
 < en: Fishes
 en: Pond smelt
@@ -88569,7 +85934,6 @@ agribalyse_food_code:en: 26083
 ciqual_food_code:en: 26083
 ciqual_food_name:en: Pond smelt, raw
 ciqual_food_name:fr: Éperlan, cru
-#wikidata:en:
 
 < en: Fishes
 en: Garfish
@@ -88580,7 +85944,6 @@ agribalyse_food_code:en: 26166
 ciqual_food_code:en: 26166
 ciqual_food_name:en: Garfish, raw
 ciqual_food_name:fr: Orphie commune, crue
-#wikidata:en:
 
 < en: Fishes
 en: European sprat
@@ -88609,7 +85972,6 @@ lt: Paruoštos daržovės
 nl: Kant-en-klaar groenten
 pt: Legumes preparados
 ru: Приготовленные овощи
-#wikidata:en:
 
 < en: Prepared vegetables
 en: Cooked vegetables
@@ -88758,7 +86120,6 @@ hr: Pripremljena leća
 it: Lenticchie pronte
 lt: Paruošti lęšiai
 nl: Kant-en-klaar linzen
-#wikidata:en:
 
 < en: Lentil dishes
 < en: Meals with meat
@@ -89051,7 +86412,6 @@ it: Pizze ai peperoni
 ja: ペパロニピザ
 lt: Pepperoni picos, Picos su pepperoni
 nl: Pepperonipizzas
-#wikidata:en:
 
 < en: Pizzas
 en: Tuna pizzas, Tuna pizza
@@ -89114,7 +86474,6 @@ fr: Pizzas chèvre-lardons, Pizza au chèvre et lardons
 hr: Pizze od kozjeg sira i slanine
 lt: Picos su ožkų sūriu ir bekonu
 nl: Geitenkaas-spekpizzas
-#wikidata:en:
 agribalyse_food_code:en: 25468
 ciqual_food_code:en: 25468
 ciqual_food_name:en: Pizza, goat cheese and lardoons
@@ -90557,7 +87916,6 @@ nl: Vlees van het rood ras van West-Vlaanderen
 origins:en: en:belgium
 protected_name_file_number:en: PDO-BE-02261
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Belgian fresh meat and offal
 fr: Viande de Blanc-Bleu Belge
@@ -90565,7 +87923,6 @@ nl: Belgisch Witblauw Vlees
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-02377
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: meats
 en: Italian fresh meat and offal
@@ -90576,42 +87933,36 @@ it: Vitelloni Piemontesi della Coscia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01198
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fresh meat and offal
 it: Agnello del Centro Italia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0808
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fresh meat and offal
 it: Cinta Senese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0491
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fresh meat and offal
 it: Abbacchio Romano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0293
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fresh meat and offal
 it: Agnello di Sardegna
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0097
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fresh meat and offal
 it: Vitellone Bianco dell'Appennino Centrale
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1552
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Meat preparations
 en: Meatloafs
@@ -90838,35 +88189,30 @@ en: West Country Beef
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0668
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beef
 en: Orkney beef
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0272
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Beef
 en: Scotch Beef
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0274
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beef
 en: Welsh Beef
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0057
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beef
 fr: Bœuf charolais du Bourbonnais
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0181
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beef
 en: Beef from Bazas
@@ -90898,7 +88244,6 @@ fr: Bœuf de Vendée, Boeuf de Vendée
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0592
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beef
 en: Beef from Maine
@@ -90906,7 +88251,6 @@ fr: Bœuf du Maine
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0183
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Beef
 fr: Taureau de Camargue
@@ -90920,7 +88264,6 @@ fr: Maine-Anjou
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0379
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Beef
 fr: Génisse Fleur d'Aubrac
@@ -92556,28 +89899,24 @@ fr: Porc noir de Bigorre
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02106
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French pork
 fr: Porc du Sud-Ouest
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0909
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French pork
 fr: Porc d'Auvergne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0697
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French pork
 fr: Porc de Franche-Comté
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0504
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French pork
 fr: Porc de l’Aveyron
@@ -92741,7 +90080,6 @@ en: Traditionally Farmed Gloucestershire Old Spots Pork
 origins:en: en:united-kingdom
 protected_name_file_number:en: TSG-GB-0024
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Pork
 fr: Filets mignons de porc
@@ -93282,7 +90620,6 @@ fr: Volaille d'Ancenis
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0167, PGI-FR-0167-AM02
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 en: Poultries from Bresse
@@ -93290,14 +90627,12 @@ fr: Volaille de Bresse
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0145-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Poultries from Bresse
 fr: Poulet de Bresse
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0145-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Poultries
 fr: Poulardes
@@ -93311,14 +90646,12 @@ fr: Poularde de Bresse
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0145-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Poultries from Bresse
 fr: Chapon de Bresse
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0145-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Poultries
 < fr: Poulardes
@@ -93326,7 +90659,6 @@ fr: Poularde du Périgord
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01373
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volaille de Gascogne
@@ -93337,7 +90669,6 @@ fr: Volailles de Houdan
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0156
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles de Vendée
@@ -93395,7 +90726,6 @@ fr: Volaille du Lauragais
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0174
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles d'Alsace
@@ -93426,21 +90756,18 @@ fr: Volailles de Challans
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0157
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles de Cholet
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0161
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles de l'Orléanais
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-9150
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles de l'Ain
@@ -93453,14 +90780,12 @@ fr: Volailles de Licques
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0162
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles de Loué
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-9149
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles de Normandie
@@ -93473,7 +90798,6 @@ fr: Volailles des Landes
 origins:en: en:france, en:landes
 protected_name_file_number:en: PGI-FR-0163
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles du Béarn
@@ -93492,14 +90816,12 @@ fr: Volailles du Forez
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0159
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles du Gers
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0147
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chickens
 < fr: Volailles du Gers
@@ -93511,14 +90833,12 @@ fr: Volailles du Maine
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0148
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles du plateau de Langres
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0152
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 fr: Volailles du Val de Sèvres
@@ -93531,7 +90851,6 @@ fr: Volailles du Velay
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0165
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chickens
 en: Hen meat and skin
@@ -93968,7 +91287,6 @@ fr: Canard à foie gras du Sud-Ouest, Canard à foie gras de Chalosse, Canard à
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0034
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Duck breasts
 fr: aiguillettes de canard
@@ -94181,7 +91499,6 @@ fr: Dinde de Bresse
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0144
 protected_name_type:en: pdo
-#wikidata:en:
 
 # TODO check this one
 < en: Turkeys
@@ -94321,7 +91638,6 @@ fr: Oie d'Anjou
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0477
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Geese
 en: goose meat with skin
@@ -94411,14 +91727,12 @@ fr: Pintadeau de la Drôme
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0546
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Guinea fowl
 fr: Pintade de l'Ardèche
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01297
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Guinea fowl
 en: Guinea fowl leg
@@ -94676,21 +91990,18 @@ fr: Poulet du Périgord
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01374
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chickens
 fr: Poulet de l'Ardèche, Chapon de l'Ardèche
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01296
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chickens
 fr: Poulet des Cévennes, Chapon des Cévennes
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0862
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Poultries
 < fr: Allumettes de volaille
@@ -95122,7 +92433,6 @@ wikidata:en: Q2846193
 < fr: Andouillettes
 fr: Andouillettes provençales, Andouillettes de Provence
 origins:en: en:france
-#wikidata:en:
 
 #fr:Andouillettes de canard
 
@@ -95290,28 +92600,24 @@ en: Teewurst spreads
 en: French meat products
 fr: Produits carnés français
 origins:en: en:france
-#wikidata:en:
 
 < en: French meat products
 fr: Pancetta de l'Ile de Beauté, Panzetta de l'Ile de Beauté
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02427
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French meat products
 fr: Lonzo de l'Ile de Beauté
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02428
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French meat products
 fr: Bulagna de l'Ile de Beauté
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02429
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Prepared meats
 en: Hams
@@ -95545,7 +92851,6 @@ fr: Jambons français
 hr: Francuske šunke
 it: Prosciutto francese
 origins:en: en:france
-#wikidata:en:
 
 < en: Hams
 en: British hams
@@ -95553,7 +92858,6 @@ fr: Jambons britanniques
 hr: Britanske šunke
 pt: Presuntos britânicos
 origins:en: en:united-kingdom
-#wikidata:en:
 
 < en: Hams
 en: Italian hams
@@ -95562,7 +92866,6 @@ fr: Jambons italiens
 hr: Talijanske šunke
 it: Prosciutti italiani
 origins:en: en:italy
-#wikidata:en:
 
 < en: Hams
 en: Dalmatian hams, Dalmatian prosciutto
@@ -95582,14 +92885,12 @@ bg: Испанска шунка
 fr: Jambons espagnols
 hr: Španjolske šunke
 origins:en: en:spain
-#wikidata:en:
 
 < en: British hams
 en: Carmarthen Ham
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-01229
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hams
 es: Jamón Curado
@@ -95700,14 +93001,12 @@ fr: Jambon du Kintoa
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02166
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French hams
 fr: Jambon sec de l'Ile de Beauté
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02426
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French hams
 fr: Jambon noir de Bigorre
@@ -96615,7 +93914,6 @@ fr: Figatelli de l'Ile de Beauté, Figatellu de l'Ile de Beauté
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02432
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: French sausages
 en: Lyon sausage, Lyon sausages
@@ -96759,7 +94057,6 @@ fr: Boudin blanc de Rethel
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0100
 protected_name_type:en: pgi
-#wikidata:en:
 
 < fr: Boudins blancs
 en: Truffled white pudding
@@ -97021,7 +94318,6 @@ it: Mortadella di Prato
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01333, PGI-IT-01333-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < fr: Charcuteries cuites
 en: Lyoner
@@ -97225,7 +94521,6 @@ fr: Pâté de Campagne Breton
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0879
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Pâté
 en: Breton pâté
@@ -97636,14 +94931,12 @@ fr: Saucisson de Lacaune, Saucisse de Lacaune
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01201
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cured sausages
 fr: Saucisson de l'Ardèche
 origins:en: en:france, en:ardeche
 protected_name_file_number:en: PGI-FR-0596
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Cured sausages
 fr: Saucisses sèches, Saucisse sèche
@@ -97805,7 +95098,6 @@ agribalyse_food_code:en: 8082
 ciqual_food_code:en: 8082
 ciqual_food_name:en: Rillettes, tuna
 ciqual_food_name:fr: Rillettes de thon
-#wikidata:en:
 
 < en: Meats
 en: Sheep meat
@@ -97830,7 +95122,6 @@ agribalyse_food_code:en: 21006
 ciqual_food_code:en: 21006
 ciqual_food_name:en: Mutton, leg, raw
 ciqual_food_name:fr: Mouton, gigot, cru
-#wikidata:en:
 
 < en: Feet
 < en: sheep meat
@@ -97840,7 +95131,6 @@ agribalyse_food_code:en: 21004
 ciqual_food_code:en: 21004
 ciqual_food_name:en: Sheep, foot, raw
 ciqual_food_name:fr: Mouton, pied, cru
-#wikidata:en:
 
 < en: sheep meat
 en: Sheep head
@@ -98277,28 +95567,24 @@ en: Orkney lamb
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0273
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Lamb meat
 en: Scotch Lamb
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0275
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lamb meat
 en: Shetland Lamb
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0276
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Lamb meat
 en: Comeragh Mountain Lamb
 origins:en: en:ireland
 protected_name_file_number:en: PGI-IE-02496
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lamb meat
 en: Connemara Hill Lamb, Uain Sléibhe Chonamara
@@ -98312,28 +95598,24 @@ en: Gower Salt Marsh Lamb
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-02452
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Lamb meat
 en: Cambrian Mountains Lamb
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-2285
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Lamb meat
 en: Welsh Lamb
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0081, PGI-GB-0081-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lamb meat
 en: West Country Lamb
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0667
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lamb meat
 en: Isle of Man Manx Loaghtan Lamb
@@ -98347,7 +95629,6 @@ sv: Hånnlamb
 origins:en: en:sweden
 protected_name_file_number:en: PDO-SE-01327
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Lamb meat
 fr: Agneau de lait des Pyrénées
@@ -98755,7 +96036,6 @@ agribalyse_food_code:en: 6590
 ciqual_food_code:en: 6590
 ciqual_food_name:en: Veal, neck, raw
 ciqual_food_name:fr: Veau, collier, cru
-#wikidata:en:
 
 < en: Veal neck
 en: Frozen veal neck
@@ -98918,7 +96198,6 @@ agribalyse_food_code:en: 6580
 ciqual_food_code:en: 6580
 ciqual_food_name:en: Calf, foot, raw
 ciqual_food_name:fr: Veau, pied, cru
-#wikidata:en:
 
 < en: Veal meat
 en: Veal tenderloins
@@ -98927,7 +96206,6 @@ agribalyse_food_code:en: 6522
 ciqual_food_code:en: 6522
 ciqual_food_name:en: Veal, tenderloin, raw
 ciqual_food_name:fr: Veau, noix, crue
-#wikidata:en:
 
 < en: Cooked veal meat
 < en: Veal tenderloins
@@ -99209,7 +96487,6 @@ en: Scottish Wild Venison
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-2448
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Game
 en: Hart
@@ -99469,7 +96746,6 @@ fr: Tomme des Pyrénées, Tommes des Pyrénées
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0176-AM01, PGI-FR-0176
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Tomme cheese from cow's milk
 fr: Tomme de Suisse, Tommes de Suisse
@@ -100697,7 +97973,6 @@ de: Schwäbische Maultaschen, Schwäbische Suppenmaultaschen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0521
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Pastas
 en: Italian pasta
@@ -100710,35 +97985,30 @@ it: Amatriciana tradizionale
 origins:en: en:italy
 protected_name_file_number:en: TSG-IT-2390
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Italian pasta
 it: Culurgionis d'Ogliastra
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01307
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian pasta
 it: Pizzoccheri della Valtellina
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01349
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian pasta
 it: Cappellacci di zucca ferraresi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01324
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian pasta
 it: Maccheroncini di Campofilone
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0886
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian pasta
 hr: Gragnano tjestenina
@@ -100746,7 +98016,6 @@ it: Pasta di Gragnano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0870
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Pastas
 en: Udon
@@ -101400,7 +98669,6 @@ nl: Pastas uit de Alsace
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0324
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Egg pastas
 en: Fresh egg pasta
@@ -102757,14 +100025,12 @@ pt: Pastel de Chaves
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-1126
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Pastries
 pt: Pastel de Tentúgal
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0938
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Desserts
 < en: Pastries
@@ -103961,7 +101227,6 @@ ciqual_food_name:en: Sandwich made with panini bread, raw cured ham, mozzarella 
 < en: Paninis
 fr: Panini au poulet
 nl: Kippaninis
-#wikidata:en:
 
 < en: Sandwiches
 en: Sandwich made with panini bread raw cured ham mozzarella cheese and tomato
@@ -104987,14 +102252,12 @@ fr: Produits de la mer belges
 hr: Belgijski morski proizvodi
 it: Prodotti ittici belgi
 origins:en: en:belgium
-#wikidata:en:
 
 < en: Belgian sea products
 fr: Escavèche de Chimay
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-02359
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Seafood
 en: Brazilian sea products
@@ -105032,14 +102295,12 @@ cs: Třeboňský kapr
 origins:en: en:czech-republic
 protected_name_file_number:en: PGI-CZ-0377
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Czech sea products
 cs: Pohořelický kapr
 origins:en: en:czech-republic
 protected_name_file_number:en: PDO-CZ-0360
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Seafood
 en: German sea products
@@ -105054,14 +102315,12 @@ de: Glückstädter Matjes
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1112
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German sea products
 de: Schwarzwaldforelle
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1232
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Seafood
 en: Hungarian sea products
@@ -105076,28 +102335,24 @@ hu: Szegedi tükörponty
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02491
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian sea products
 hu: Szilvásváradi pisztráng
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02472
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian sea products
 hu: Balatoni hal
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02470
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian sea products
 hu: Akasztói szikiponty
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-02410
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Seafood
 en: Italian sea products
@@ -105108,42 +102363,36 @@ it: Colatura di alici di Cetara
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-02440
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian sea products
 it: Cozza di Scardovari
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0981
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian sea products
 it: Trote del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0965
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian sea products
 it: Salmerino del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0964
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian sea products
 it: Acciughe sotto sale del mar Ligure
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0358
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian sea products
 it: Tinca Gobba Dorata del Pianalto di Poirino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0357
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Fishes
 en: Fatty fishes, blue fishes, fatty fish, blue fish, fat fishes, fat fish
@@ -105415,7 +102664,6 @@ en: Lough Neagh Pollan
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-02159
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British sea products
 < en: Trouts
@@ -105423,7 +102671,6 @@ en: West Wales Coracle Caught Sewin
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-01180
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British sea products
 < en: Wild salmons
@@ -105431,7 +102678,6 @@ en: West Wales Coracle Caught Salmon
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-01179
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British sea products
 < en: Oysters
@@ -105439,7 +102685,6 @@ en: Fal Oyster
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0885
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Seafood
 en: Irish sea products
@@ -105516,7 +102761,6 @@ en: Isle of Man Queenies
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0856
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Fishes
 en: Eels
@@ -105564,7 +102808,6 @@ en: Lough Neagh Eel
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0796
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British sea products
 < en: Sardines
@@ -105572,7 +102815,6 @@ en: Cornish Sardines
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0589
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British sea products
 < en: Smoked fishes
@@ -105580,7 +102822,6 @@ en: Traditional Grimsby Smoked Fish
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0132
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British sea products
 < en: Smoked haddock
@@ -105658,14 +102899,12 @@ fi: Puruveden muikku
 origins:en: en:finland
 protected_name_file_number:en: PGI-FI-0989
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Finnish sea products
 fi: Kitkan viisas
 origins:en: en:finland
 protected_name_file_number:en: PDO-FI-0872
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Meats and their products
 en: Norwegian sea products
@@ -105681,7 +102920,6 @@ no: Tørrfisk fra Lofoten
 origins:en: en:norway
 protected_name_file_number:en: PGI-NO-1054
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Seafood
 en: Portuguese sea products
@@ -105697,7 +102935,6 @@ pt: Bacalhau de Cura Tradicional Portuguesa
 origins:en: en:portugal
 protected_name_file_number:en: TSG-PT-0064
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Seafood
 en: Romanian sea products
@@ -105713,28 +102950,24 @@ ro: Salată tradițională cu icre de crap
 origins:en: en:romania
 protected_name_file_number:en: TSG-RO-2457
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Romanian sea products
 ro: Scrumbie de Dunăre afumată
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02234
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian sea products
 ro: Salată cu icre de știucă de Tulcea
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-02476
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Romanian sea products
 ro: Novac afumat din Ţara Bârsei
 origins:en: en:romania
 protected_name_file_number:en: PGI-RO-01183
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Seafood
 en: Spanish sea products
@@ -105749,35 +102982,30 @@ es: Mojama de Barbate
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01210, PGI-ES-01210-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish sea products
 es: Mojama de Isla Cristina
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01211, PGI-ES-01211-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish sea products
 es: Caballa de Andalucia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0281
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish sea products
 es: Melva de Andalucia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0280
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Spanish sea products
 es: Mejillón de Galicia, Mexillón de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0165
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Sardine fillets
 < en: Sardines in olive oil
@@ -106951,7 +104179,6 @@ fr: Anchois de Collioure
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0180
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Fish fillets
 en: Capelin
@@ -107611,7 +104838,6 @@ en: London Cure Smoked Salmon
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-01350
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Breams
 < en: Smoked fishes
@@ -107838,14 +105064,12 @@ de: Peitzer Karpfen, Carpy z picnjo (Sorbisch)
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02587
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Carp
 de: Oberlausitzer Biokarpfen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01070
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Carp
 < en: German sea products
@@ -107853,28 +105077,24 @@ de: Aischgründer Karpfen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0689, PGI-DE-0689-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Carp
 de: Fränkischer Karpfen, Frankenkarpfen, Karpfen aus Franken
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0688
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Carp
 de: Holsteiner Karpfen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0343
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Carp
 de: Oberpfälzer Karpfen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0191
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Fishes
 < en: Lean fishes
@@ -109049,7 +106269,6 @@ fr: Coquille Saint-Jacques des Côtes d'Armor
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0033
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Mollusc
 en: Boiled clam, Clam cooked in water
@@ -109097,7 +106316,6 @@ fr: Bulot de la Baie de Granville
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02319
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Mollusc
 en: Mussels
@@ -109187,7 +106405,6 @@ en: Conwy Mussels
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-01304
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Mussels
 en: Boiled mussels, Mussels cooked in water
@@ -109260,7 +106477,6 @@ en: Whitstable oysters
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0371
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Oysters
 en: Pacific oysters
@@ -112807,14 +110023,12 @@ de: Salate von der Insel Reichenau
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0317
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Germany
 de: Feldsalat von der Insel Reichenau
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0318
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Tomatoes
 < en: Vegetables from Germany
@@ -112822,14 +110036,12 @@ de: Tomaten von der Insel Reichenau
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0319
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Germany
 de: Gurken von der Insel Reichenau
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0320
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Culinary plants
 < en: Vegetables based foods
@@ -113784,7 +110996,6 @@ it: Carciofo Brindisino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0798
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Artichokes
 it: Carciofo Romanesco del Lazio
@@ -114073,7 +111284,6 @@ de: Marchfeldspargel
 origins:en: en:austria
 protected_name_file_number:en: PGI-AT-1462
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Asparagus
 < en: French vegetables
@@ -114093,7 +111303,6 @@ fr: Asperges du Blayais
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01254
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Asparagus
 < en: German vegetables
@@ -114101,7 +111310,6 @@ de: Abensberger Spargel, Abensberger Qualitätsspargel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0852
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Asparagus
 < en: German vegetables
@@ -114109,7 +111317,6 @@ de: Walbecker Spargel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0857
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Asparagus
 < en: German vegetables
@@ -114117,7 +111324,6 @@ de: Spargel aus Franken, Fränkischer Spargel, Franken-Spargel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0804
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Green asparagus
 < en: Vegetables from Italy
@@ -114141,7 +111347,6 @@ it: Asparago di Cantello
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01267
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables from Italy
 < en: White asparagus
@@ -114165,7 +111370,6 @@ nl: Brabantse Wal Asperges
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-01177, PDO-NL-01177-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Asparagus
 < en: Vegetables from Spain
@@ -114173,7 +111377,6 @@ es: Espárrago de Huétor-Tájar
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0056, PGI-ES-0056-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Green asparagus
 < en: Vegetables from Spain
@@ -114188,7 +111391,6 @@ en: Vale of Evesham Asparagus
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-02108
 protected_name_type:en: pgi
-#wikidata:en:
 
 #< en:Asparagus
 #en: Wild asparagus
@@ -114975,7 +112177,6 @@ origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-0887
 protected_name_type:en: pgi
 sales_format:en: weight, package
-#wikidata:en:
 
 < en: Celery
 en: Celery stalk, celery stalk
@@ -115572,7 +112773,6 @@ xx: Aglio di Voghiera
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0638
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Garlics
 it: Aglio Bianco Polesano
@@ -115580,7 +112780,6 @@ xx: Aglio Bianco Polesano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0566
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Garlics and their products
 fr: Ail doux au piment
@@ -115629,7 +112828,6 @@ es: Ajo Morado de Las Pedroñeras
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-0228
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Allium neapolitanum
 fr: Ail blanc de Lomagne
@@ -115669,7 +112867,6 @@ xx: Ail violet de Cadours
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02103-AM01, PDO-FR-02103
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables
 en: Green garlic
@@ -115827,7 +113024,6 @@ fr: Poireaux de Créances
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0198
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Leaf vegetables
 en: Lettuces, lettuce
@@ -116063,14 +113259,12 @@ it: Cipolla bianca di Margherita
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1231
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: onions
 it: Cipolla Rossa di Tropea Calabria
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0369
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Fresh vegetables
 < en: Onions
@@ -116211,7 +113405,6 @@ expected_ingredients:en: en:shallots
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01253
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables
 en: Sweet peppers, Bell peppers
@@ -116747,7 +113940,6 @@ de: Speisekartoffeln
 #protected_name_file_number:en: PDO-FI-1390
 #protected_name_type:en: pdo
 #origins:en: en:Finland
-#wikidata:en:
 #no products @2023-04-15
 
 < en: Potatoes
@@ -116759,7 +113951,6 @@ hr: Krompir iz italije
 nl: Aardappelen uit Italië
 sv: Potatis från Italien
 origins:en: en:italy
-#wikidata:en:
 
 < en: Potatoes from Italy
 en: Potatoes from Fucino
@@ -116822,7 +114013,6 @@ hr: Krumpir iz Španjolske
 nl: Aardappelen uit Spanje
 sv: Potatis från Spanien
 origins:en: en:spain
-#wikidata:en:
 
 < en: Potatoes from Spain
 en: Potatoes from Val de Picones
@@ -116842,7 +114032,6 @@ nl: Aardappelen uit Val de Picones
 #protected_name_file_number:en: PGI-GB-0810
 #protected_name_type:en: pgi
 #origins:en: en:United Kingdom
-#wikidata:en:
 #no products on 14-04-2023
 
 #<en:Potatoes from the United Kingdom
@@ -116850,7 +114039,6 @@ nl: Aardappelen uit Val de Picones
 #protected_name_file_number:en: PGI-GB-02286
 #protected_name_type:en: pgi
 #origins:en: en:United Kingdom
-#wikidata:en:
 #no products on 14-04-2023
 
 < en: Potatoes
@@ -116863,7 +114051,6 @@ nl: Aardappelen uit Frankrijk, Franse aardappelen
 sv: Potatis från Frankrike
 origins:en: en:france
 sales_format:en: weight, package
-#wikidata:en:
 #add the origin France if you want to specify this category
 
 < en: Potatoes from France
@@ -118289,7 +115476,6 @@ fr: Mâche nantaise
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0072
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Leaf vegetables
 en: rocket, arugula, garden rocket, eruca, rucola, rucoli, rugula, colewort, roquette, salad rocket
@@ -118765,7 +115951,6 @@ fr: Haricot de Castelnaudary
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02450
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Legumes
 < en: Vegetables
@@ -119335,7 +116520,6 @@ fr: Cocos de paimpol, Coco de Paimpol
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0062
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Coco white beans
 en: Canned coco white beans
@@ -119406,14 +116590,12 @@ it: Lenticchia di Altamura
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02204
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lentils
 it: Lenticchia di Castelluccio di Norcia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1557
 protected_name_type:en: pgi
-#wikidata:en:
 
 
 < en: Lentils
@@ -119569,14 +116751,12 @@ fr: Lentilles vertes du Berry
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0030
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Green lentils
 fr: Lentille verte du Puy
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0202
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cooked vegetables
 < en: Green lentils
@@ -119779,35 +116959,30 @@ it: Fagioli Bianchi di Rotonda
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0683
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vegetables
 it: Fagiolo Cuneo
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0775
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables
 it: Fagiolo di Sorana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0134
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables
 it: Fagiolo di Lamon della Vallata Bellunese
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1530
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vegetables
 it: Fagiolo di Sarconi
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1531
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: White kidney beans
 it: Fagiolo Cannellino di Atina
@@ -119815,7 +116990,6 @@ origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0681
 protected_name_type:en: pdo
 wikidata:en: Q118819104
-#wikidata:en:
 
 < en: Vegetables
 en: Broad beans
@@ -119936,7 +117110,6 @@ nl: Pronkbonen uit Stiermarken
 origins:en: en:austria
 protected_name_file_number:en: PDO-AT-01272
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Pulses
 en: Sword beans
@@ -120671,28 +117844,24 @@ es: Vinagres españoles
 fr: Vinaigres espagnols
 hr: Španjolski ocat
 origins:en: en:spain
-#wikidata:en:
 
 < en: Spanish vinegars
 es: Vinagre de Montilla-Moriles
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0726
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish vinegars
 es: Vinagre del Condado de Huelva
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0724
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish vinegars
 es: Vinagre de Jerez
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0723
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Vinegars
 en: Balsamic vinegars
@@ -120731,7 +117900,6 @@ origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0430, PGI-IT-0430-AM01
 protected_name_type:en: pgi
 wikidata:en: Q3604285
-#wikidata:en:
 
 < en: Balsamic vinegars
 en: Traditional Balsamic Vinegars, Aceto balsamico tradizionale
@@ -120743,7 +117911,6 @@ hu: Hagyományos balzsamecet, Tradícionális balzsamecet
 it: Aceto balsamico tradizionale
 nl: Traditionele balsamico azijn
 origins:en: en:italy
-#wikidata:en:
 
 < en: Traditional Balsamic Vinegars
 en: Traditional Balsamic Vinegar of Modena, Aceto Balsamico Tradizionale di Modena
@@ -120757,7 +117924,6 @@ origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1565
 protected_name_type:en: pdo
 wikidata:en: Q2822974
-#wikidata:en:
 
 < en: Traditional Balsamic Vinegars
 en: Traditional Balsamic Vinegar of Reggio Emilia, Aceto Balsamico Tradizionale di Reggio Emilia
@@ -121402,7 +118568,6 @@ fr: Olive de Nice
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0333
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olives
 en: Kalamon olives
@@ -121517,7 +118682,6 @@ fr: Olives cassées de la Vallée des Baux-de-Provence
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0051
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chopped olives
 < en: Green olives
@@ -121701,7 +118865,6 @@ fr: Olives noires de la Vallée des Baux-de-Provence
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0052
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Olives
 en: Semi-ripe olives
@@ -121811,7 +118974,6 @@ it: Cappero delle Isole Eolie
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-02395
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Plant-based foods
 < en: Seafood
@@ -124177,7 +121339,6 @@ fr: Brioches Vendéennes, Brioche vendéenne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-0271
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Brioches
 en: Brioche filled with custard, Chinese brioche
@@ -126679,7 +123840,6 @@ wikidata:en: Q3518776
 en: Pork terrines
 bg: Свински терин
 fr: Terrines de porc
-#wikidata:en:
 
 < en: Prepared meats
 < en: Terrines
@@ -126693,7 +123853,6 @@ nl: Konijnterrines, Konijnterrine, Konijnevleespotten
 agribalyse_food_code:en: 8242
 ciqual_food_code:en: 8242
 ciqual_food_name:en: Rabbit terrine
-#wikidata:en:
 
 < en: Prepared meats
 < en: Terrines
@@ -126715,7 +123874,6 @@ fr: Terrines de sanglier
 hr: Terine od vepra
 it: Terrine di cinghiale
 nl: Everzwijnterrines, Everzwijnterrine, Everzwijnvleespotten
-#wikidata:en:
 
 < en: Prepared meats
 < en: Terrines
@@ -126725,7 +123883,6 @@ fi: siipikarjaterriinit
 fr: Terrines de volailles
 hr: Terine za perad
 nl: Gevogelte terrines, Gevogelte terrine, Gevogelte vleespotten
-#wikidata:en:
 
 < en: Prepared meats
 < fr: Terrines de volailles
@@ -126739,7 +123896,6 @@ nl: Eendterrines, Eendterrine, Eendevleespotten
 agribalyse_food_code:en: 8232
 ciqual_food_code:en: 8232
 ciqual_food_name:en: Duck terrine
-#wikidata:en:
 
 < en: Duck terrines
 fr: Terrines de canard aux morilles
@@ -127044,7 +124200,6 @@ it: Frappè Proteico
 ja: プロテインシェイク
 nl: Proteineshakes
 ro: Shake-uri cu proteine, Shake-uri proteice
-#wikidata:en:
 
 < en: Bodybuilding supplements
 en: Protein bars
@@ -127358,7 +124513,6 @@ en: Large sausage rolls, Sausage friands, Puff pastries with sausage, puff pastr
 fr: Friands à la saucisse
 hr: Prijatelji kobasica
 nl: Worst friands
-#wikidata:en:
 
 < en: Friands
 < en: Puff pastry meals
@@ -127368,7 +124522,6 @@ agribalyse_food_code:en: 25402
 ciqual_food_code:en: 25402
 ciqual_food_name:en: Meat in puff pastry
 ciqual_food_name:fr: Feuilleté ou Friand à la viande
-#wikidata:en:
 
 < en: Friands
 < en: Puff pastry meals
@@ -127524,12 +124677,10 @@ fr: Risottos aux champignons
 hr: Rižoto od gljiva
 it: Risotti ai funghi
 nl: Paddenstoelrisotto
-#wikidata:en:
 
 < en: Mushrooms risottos
 en: Risottos with porcini mushrooms
 fr: Risottos aux cèpes
-#wikidata:en:
 
 < en: Meals
 xx: Dumplings
@@ -127614,13 +124765,11 @@ wikidata:en: Q107015868
 en: Vegetable gyoza
 fr: Gyoza aux légumes, Gyosa aux légumes
 nl: Gyozas met kip
-#wikidata:en:
 
 < en: Gyoza
 en: Shrimp gyoza
 fr: Gyozas aux crevettes, Gyosas aux crevettes, Gyosas aux crevettes, Gyoza à la crevette
 nl: Gyozas met garnalen
-#wikidata:en:
 
 < en: Tortellini
 en: Meat tortellinis
@@ -127869,7 +125018,6 @@ ciqual_food_name:en: Fish terrine
 
 food_groups:en: en:fish-and-seafood
 pnns_group_2:en: Fish and seafood
-#wikidata:en:
 
 < en: Fish terrines
 en: Salmon terrines
@@ -127878,14 +125026,12 @@ fi: lohiterriinit
 fr: Terrines de saumon
 hr: Terine od lososa
 nl: Zalmterrines, Zalmterrine, Zalmvleespotten
-#wikidata:en:
 
 < en: Fish terrines
 en: Trout terrines
 fr: Terrines de truite
 hr: Terine za pastrve
 nl: Forelterinnes, Forelterrine
-#wikidata:en:
 
 
 ### Extra categories
@@ -128111,19 +125257,16 @@ en: Samoussas with poultry
 fr: Samoussas à la volaille, samossas à la volaille
 hr: Samousse s peradi
 nl: Gevogelte samosa
-#wikidata:en:
 
 < en: Samosas
 en: Chicken samosas, Samoussas with chicken
 fr: Samoussas au poulet, samossas au poulet
-#wikidata:en:
 
 < en: Samosas
 en: Beef samosas
 fr: Samoussas au bœuf, samossas au bœuf
 hr: Goveđe samose
 nl: Rundvleessamosa
-#wikidata:en:
 
 < en: Samosas
 en: Cheese samosas
@@ -128135,19 +125278,16 @@ en: Pork samosas
 fr: Samoussas au porc, samossas au porc
 hr: Svinjske samose
 nl: Varkensvleessamosa
-#wikidata:en:
 
 < en: Samosas
 en: Tuna samosas
 fr: Samoussas au thon, samossas au thon
-#wikidata:en:
 
 < en: Samosas
 en: Vegetable samosas
 fr: Samoussas aux légumes, samossas aux légumes
 hr: Samose od povrća
 nl: Groentesamosa
-#wikidata:en:
 
 < en: Salty snacks
 en: Salty fritters
@@ -128156,7 +125296,6 @@ fr: Beignets salés
 hr: Slane popečke
 it: Frittelle salate
 nl: Hartige gefrituurde producten
-#wikidata:en:
 
 < en: Salty fritters
 en: Vegetable fritters
@@ -128343,7 +125482,6 @@ agribalyse_food_code:en: 23493
 ciqual_food_code:en: 23493
 ciqual_food_name:en: Apple crumble
 ciqual_food_name:fr: Crumble aux pommes
-#wikidata:en:
 
 en: stuffing
 de: Füllung

--- a/taxonomies/minerals.txt
+++ b/taxonomies/minerals.txt
@@ -146,7 +146,6 @@ vegetarian:en: yes
 # wuu:礦物
 # zh-min-nan:Khòng-bu̍t
 # yue:礦物
-#wikidata:en:
 wikipedia:en: https://en.wikipedia.org/wiki/Mineral
 
 

--- a/taxonomies/product/labels.txt
+++ b/taxonomies/product/labels.txt
@@ -81,7 +81,6 @@ xx: UKNI, UK(NI)
 en: UKNI, UKNI marking
 image:en: ukni.90x90.png
 web:en: https://www.gov.uk/guidance/using-the-ukni-marking
-# wikidata:en:
 
 xx: ICASA Approved
 en: ICASA Approved

--- a/taxonomies/unused/categories.wip.txt
+++ b/taxonomies/unused/categories.wip.txt
@@ -3,14 +3,12 @@ nl: Vlaamse laurier
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-1125
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Belgian flowers and ornamental plants
 nl: Gentse azalea
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-0536
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Belgian juniper-flavoured spirit drinks
 nl: Peket-Pekêt
@@ -18,49 +16,42 @@ fr: Pèket-Pèkèt de Wallonie
 origins:en: en:belgium
 protected_name_file_number:en: PGI-BE-02077
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: British fresh meat and offal
 en: Lakeland Herdwick
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0891
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British fresh meat and offal
 en: Traditional Farmfresh Turkey
 origins:en: en:united-kingdom
 protected_name_file_number:en: TSG-GB-0004-AM01
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: British fresh meat and offal
 en: Traditional Farmfresh Turkey
 origins:en: en:united-kingdom
 protected_name_file_number:en: TSG-GB-0004
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: British fruit, vegetables and cereals
 en: Watercress
 origins:en: en:united-kingdom
 protected_name_file_number:en: TSG-GB-62
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: British fruit, vegetables and cereals
 en: The Vale of Clwyd Denbigh Plum
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-02287
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British fruit, vegetables and cereals
 en: Traditional Bramley Apple Pie Filling
 origins:en: en:united-kingdom
 protected_name_file_number:en: TSG-UK-0057
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: British fruit, vegetables and cereals
 en: Pembrokeshire Earlies, Pembrokeshire Early Potatoes
@@ -74,42 +65,36 @@ en: Yorkshire Forced Rhubarb
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0633
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British meat products
 en: Forfar Bridie
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-2297
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British other products
 en: Traditional Welsh Perry
 origins:en: en:united-kingdom
 protected_name_file_number:en: PGI-GB-01250
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: British other products
 en: Welsh Laverbread
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-01188
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British other products
 en: East Kent Goldings
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0951
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: British Wool
 en: Native Shetland Wool
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-0737
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Bulgarian products of animal origin
 bg: Странджански манов мед, Strandzhanski manov med, Maнов мед от Странджа, Manov med ot Strandzha
@@ -150,28 +135,24 @@ zh: 蠡县麻山药, Lixian Ma Shan Yao
 origins:en: en:china
 protected_name_file_number:en: PGI-CN-0627
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chinese fruit, vegetables and cereals
 zh: 陕西苹果, Shaanxi ping guo
 origins:en: en:china
 protected_name_file_number:en: PDO-CN-0629
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Chinese other products
 zh: 镇江香醋, Zhenjiang Xiang Cu
 origins:en: en:china
 protected_name_file_number:en: PGI-CN-0630
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Chinese other products
 zh: 龙井茶, Longjing cha
 origins:en: en:china
 protected_name_file_number:en: PDO-CN-0621
 protected_name_type:en: pdo
-#wikidata:en:
 
 
 
@@ -193,77 +174,66 @@ hr: Lička janjetina
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-02179
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian fresh meat and offal
 hr: Paška janjetina
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-01347
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian fresh meat and offal
 hr: Zagorski puran
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-01234
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian fruit, vegetables and cereals
 hr: Varaždinsko zelje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-01132
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian fruit, vegetables and cereals
 hr: Lički krumpir
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-1242
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian fruit, vegetables and cereals
 hr: Ogulinski kiseli kupus, Ogulinsko kiselo zelje
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-1233
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian fruit, vegetables and cereals
 hr: Neretvanska mandarina
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-1225
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian Maraschino, Marrasquino or Maraskino
 hr: Zadarski maraschino
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-01960
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Croatian other products
 hr: Brački varenik
 origins:en: en:croatia
 protected_name_file_number:en: PGI-HR-02454
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Croatian products of animal origin
 hr: Slavonski med
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-02187
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Croatian sea products
 hr: Malostonska kamenica
 origins:en: en:croatia
 protected_name_file_number:en: PDO-HR-02426
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cypriot fruit, vegetables and cereals
 el: Κολοκάσι Σωτήρας, Κολοκάσι-Πούλλες Σωτήρας, Kolokasi Sotiras, Kolokasi-Poulles Sotiras
@@ -382,7 +352,6 @@ nl: De Meerlander
 origins:en: en:netherlands
 protected_name_file_number:en: PGI-NL-1175
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Dutch fruit, vegetables and cereals
 nl: Westlandse druif
@@ -396,14 +365,12 @@ nl: Opperdoezer Ronde
 origins:en: en:netherlands
 protected_name_file_number:en: PDO-NL-0313
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Dutch sea products
 nl: Hollandse maatjesharing, Hollandse Nieuwe, Holländischer Matjes
 origins:en: en:netherlands
 protected_name_file_number:en: TSG-NL-1178
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Dutch, Belgian juniper-flavoured spirit drinks
 origins:en: en:netherlands, en:belgium
@@ -450,14 +417,12 @@ fr: Huile essentielle de lavande de Haute-Provence, Essence de lavande de Haute-
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0141
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French fresh meat and offal
 fr: Kintoa
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02165
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French fresh meat and offal
 fr: Charolais de Bourgogne
@@ -471,7 +436,6 @@ fr: Fin Gras, Fin Gras du Mézenc
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0545
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French fresh meat and offal
 fr: Barèges-Gavarnie
@@ -500,7 +464,6 @@ fr: Genièvre Flandre Artois
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02028
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French meat products
 fr: Lonzo de Corse, Lonzo de Corse - Lonzu
@@ -514,77 +477,66 @@ fr: Cornouaille
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0043-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Other French products
 fr: Domfront
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0276
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Other French products
 fr: Pays d'Auge, Pays d'Auge-Cambremer
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0042
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Other French products
 fr: Cornouaille
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-0043
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: French prepared meals
 fr: Berthoud
 origins:en: en:france
 protected_name_file_number:en: TSG-FR-2466
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: German bitter-tasting spirit drinks or bitter
 de: Rheinberger Kräuter
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01968
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German caraway-flavoured spirit drinks
 de: Hamburger Kümmel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01972-AM01
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German caraway-flavoured spirit drinks
 de: Münchener Kümmel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01992-AM01
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German caraway-flavoured spirit drinks
 de: Berliner Kümmel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02049
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German fresh meat and offal
 de: Weideochse vom Limpurger Rind
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-0881
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: German fresh meat and offal
 de: Schwäbisch-Hällisches Qualitätsschweinefleisch
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1272
 protected_name_type:en: pgi
-#wikidata:en:
 
 < fr: race ovine allemande
 de: Lüneburger Heidschnucke
@@ -605,84 +557,72 @@ de: Rheinisches Apfelkraut
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0716-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Beelitzer Spargel
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02167
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Hiffenmark, Fränkisches Hiffenmark
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02349
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Frankfurter Grüne Soße, Frankfurter Grie Soß
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-00884
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Spreewälder Meerrettich
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0562-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Fränkischer Grünkern
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-1144
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Bornheimer Spargel, Spargel aus dem Anbaugebiet Bornheim
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0803
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Höri Bülle
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1040
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Dithmarscher Kohl
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1015
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Stromberger Pflaume
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-0841
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Bamberger Hörnla, Bamberger Hörnle, Bamberger Hörnchen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0802
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Filderkraut, Filderspitzkraut
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0822
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Rheinisches Zuckerrübenkraut, Rheinischer Zuckerrübensirup, Rheinisches Rübenkraut
@@ -696,70 +636,60 @@ de: Rheinisches Apfelkraut
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0716
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Schrobenhausener Spargel, Spargel aus dem Schrobenhausener Land, Spargel aus dem Anbaugebiet Schrobenhausen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0678
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Lüneburger Heidekartoffeln
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0614
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Bayerischer Meerrettich, Bayerischer Kren
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0299
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Spreewälder Gurken
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0561
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German fruit, vegetables and cereals
 de: Spreewälder Meerrettich
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0562
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German Geist
 de: Schwarzwälder Himbeergeist
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01998
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German gentian
 de: Bayerischer Gebirgsenzian
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01898
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German juniper-flavoured spirit drinks
 de: Ostfriesischer Korngenever
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-02050
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: German juniper-flavoured spirit drinks
 de: Steinhäger
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-01931
 protected_name_type:en: gi
-#wikidata:en:
 
 
 < en: Other German products
@@ -767,42 +697,36 @@ de: Elbe-Saale Hopfen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1071
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Other German products
 de: Spalt Spalter
 origins:en: en:germany
 protected_name_file_number:en: PDO-DE-0843
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Other German products
 de: Hessischer Apfelwein
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0620
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Other German products
 de: Tettnanger Hopfen
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0528
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Other German products
 de: Hopfen aus der Hallertau
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-0529
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German products of animal origin
 de: Obazda, Obatzter
 origins:en: en:germany
 protected_name_file_number:en: PGI-DE-1069
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: German, Austria, Switzerlandn fruit spirit
 origins:en: en:germany, en:austria, en:switzerland
@@ -834,420 +758,360 @@ el: Κρητικό παξιμάδι, Kritiko paximadi
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0064
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek essential oils
 el: Μαστιχέλαιο Χίου, Mastichelaio Chiou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-1559
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fresh meat and offal
 el: Κατσικάκι Ελασσόνας, Katsikaki  Elassonas
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0734
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fresh meat and offal
 el: Αρνάκι Ελασσόνας, Arnaki  Elassonas
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0735
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φασόλια Κατταβιάς Ρόδου, Fasolia Kattavias Rodou, Λόπια Κατταβιάς Ρόδου, Lopia Kattavias Rodou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-02422
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Πατάτα Νάξου, Patata Naxou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0708-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κλαρίσιο Ροδάκινο
 origins:en: en:greece
 protected_name_file_number:en: TSG-GR-2463
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Το Φάβα της Αμοργού, To Fava tis Amorgou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-2461
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Αγκινάρα Ιρίων, Agkinara Irion
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-02293
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Ρόδι Ερμιόνης, Rodi Ermionis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-02389
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φάβα Φενεού, Fava Feneou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01339
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Σταφίδα Σουλτανίνα Κρήτης, Stafida Soultanina Kritis
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01058
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Τοματάκι Σαντορίνης, Tomataki Santorinis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0888
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Ξηρά Σύκα Ταξιάρχη, Xira Syka Taxiarchi
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0790
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Μανταρίνι Χίου, Mandarini Chiou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0709
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φασόλια Βανίλιες Φενεού, Fasolia Vanilies Feneou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0840
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Πράσινες Ελιές Χαλκιδικής, Prasines Elies Chalkidikis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0539
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Πατάτα Νάξου, Patata Naxou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0708
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Σταφίδα Ηλείας, Stafida Ilias
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0707
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φιρίκι Πηλίου, Firiki Piliou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0540
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φάβα Σαντορίνης, Fava Santorinis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0520
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Σταφίδα Ζακύνθου, Stafida Zakynthou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0493
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: ΦΑΣΟΛΙΑ ΓΙΓΑΝΤΕΣ — ΕΛΕΦΑΝΤΕΣ ΚΑΣΤΟΡΙΑΣ, Fasolia Gigantes — Elefantes Kastorias
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0123
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Μήλο Καστοριάς, Milo Kastorias
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0128
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Ακτινίδιο Πιερίας, Aktinidio Pierias
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0129
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Πατάτα Κάτω Νευροκοπίου, Patata Kato Nevrokopiou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0107
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κορινθιακή Σταφίδα Βοστίτσα, Korinthiaki Stafida Vostitsa
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0358
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φασόλια (Γίγαντες Ελέφαντες) Πρεσπών Φλώρινας, Fasolia Gigantes Elefantes Prespon Florinas
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0417
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φασόλια (πλακέ μεγαλόσπερμα) Πρεσπών Φλώρινας, Fasolia (plake megalosperma) Prespon Florinas
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0418
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Ροδάκινα Νάουσας, Rodakina Naoussas
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0337
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φασόλια κοινά μεσόσπερμα Κάτω Νευροκοπίοu, Fassolia kina Messosperma Kato Nevrokopiou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0420
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φασόλια γίγαντες ελέφαντες Κάτω Νευροκοπίου, Fassolia Gigantes Elefantes Kato Nevrokopiou
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0422
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Μήλα Ντελίσιους Πιλαφά Τριπόλεως, Mila Delicious Pilafa de Tripoli
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0338
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κεράσια τραγανά Ροδοχωρίου, Kerassia Tragana Rodochoriou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0336
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κονσερβολιά Πηλίου Βόλου, Konservolia Piliou Volou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0347
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Θρούμπα Αμπαδιάς Ρεθύμνης Κρήτης, Throumpa Ampadias Rethymnis Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0031
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Πορτοκάλια Μάλεμε Χανίων Κρήτης, Portokalia Maleme Chanion Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0333
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Σύκα Βραβρώνας Μαρκοπούλου Μεσογείων, Syka Vravronas Markopoulou Mesogeion
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0335
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κονσερβολιά Στυλίδας, Konservolia Stylidas
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0345
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κονσερβολιά Αμφίσσης, Konservolia Amfissis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0346
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κονσερβολιά Ροβίων, Konservolia Rovion
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0348
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κονσερβολιά Άρτας, Konservolia Artas
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0349
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Θρούμπα Χίου, Throumpa Chiou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0350
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Θρούμπα Θάσου, Throumpa Thassou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0351
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κονσερβολιά Αταλάντης, Konservolia Atalantis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0356
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φυστίκι Μεγάρων, Fystiki Megaron
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0424
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Φυστίκι Αίγινας, Fystiki Aeginas
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0426
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Τσακώνικη μελιτζάνα Λεωνιδίου, Tsakoniki Melitzana Leonidiou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0029
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Ελιά Καλαμάτας, Elia Kalamatas
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0030
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Ακτινίδιο Σπερχειού, Aktinidio Sperchiou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0332
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Μήλα Ζαγοράς Πηλίου, Mila Zagoras Piliou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0342
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Ξερά σύκα Κύμης, Xera syka Kymis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-9361
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κουμ Κουάτ Κέρκυρας, Koum kouat Kerkyras
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-0419
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Greek fruit, vegetables and cereals
 el: Κελυφωτό φυστίκι Φθιώτιδας, Kelifoto fystiki Fthiotidas
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0425
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek grape marc spirit or grape marc
 el: Τσικουδιά, Tsikoudia, Τσίπουρo, Tsipouro
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-02079
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek grape marc spirit or grape marc
 el: Τσικουδιά Κρήτης, Tsikoudia of Crete
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-02054
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek grape marc spirit or grape marc
 el: Τσίπουρο Θεσσαλίας, Tsipouro of Thessaly
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-02022
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek grape marc spirit or grape marc
 el: Τσίπουρο Τυρνάβου, Tsipouro of Tyrnavos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-02019
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek grape marc spirit or grape marc
 el: Τσίπουρο Μακεδονίας, Tsipouro of Macedonia
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-02038
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek liqueur
 el: Τεντούρα, Tentoura
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01845
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek liqueur
 el: Κουμκουάτ Κέρκυρας, Koum Kouat of Corfu
@@ -1261,56 +1125,48 @@ el: Κίτρο Νάξου, Kitro of Naxos
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01941
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek liqueur
 el: Μαστίχα Χίου, Masticha of Chios
 origins:en: en:greece
 protected_name_file_number:en: PGI-GR-01850
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Greek natural gums and resins
 el: Μαστίχα Χίου, Masticha Chiou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-1558
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek natural gums and resins
 el: Τσίχλα Χίου, Tsikla Chiou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-1560
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek other products
 el: Κρόκος Κοζάνης, Krokos Kozanis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0048
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek products of animal origin
 el: Πευκοθυμαρόμελο Κρήτης, Pefkothymaromelo Kritis
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-02142
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek products of animal origin
 el: Μέλι Ελάτης Μαινάλου Βανίλια, Meli Elatis Menalou Vanilia
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0453
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Greek sea products
 el: Αυγοτάραχο Μεσολογγίου, Avgotaracho Messolongiou
 origins:en: en:greece
 protected_name_file_number:en: PDO-GR-0446
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Guatemalan rum
 es: Ron de Guatemala
@@ -1329,161 +1185,138 @@ hu: Szőregi rózsatő
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-0389
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fresh meat and offal
 hu: Keleméri bárányhús
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02480
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fresh meat and offal
 hu: Magyar szürkemarha hús
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-0772
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Derecske alma
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02586
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Fertőd vidéki sárgarépa
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02493
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Hegykői petrezselyemgyökér
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02492
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Tuzséri alma
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-02483
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Jászsági nyári szarvasgomba
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02475
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Nagykun rizs
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02416
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Nagykörűi cseresznye, Nagykörűi ropogós cseresznye
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02415
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Budaörsi őszibarack
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02417
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Újfehértói meggy
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02411
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Szomolyai rövidszárú fekete cseresznye
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-02380
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Makói petrezselyemgyökér
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02155
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Szentesi paprika
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-0912
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Gönci kajszibarack
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-0388
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Makói vöröshagyma, Makói hagyma
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-0387
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Hungarian fruit, vegetables and cereals
 hu: Hajdúsági torma
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-0391
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Hungarian grape marc spirit or grape marc
 hu: Pannonhalmi törkölypálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02231
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian grape marc spirit or grape marc
 hu: Törkölypálinka
 origins:en: en:hungary
 protected_name_file_number:en: PGI-HU-02031
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Hungarian other products
 hu: Kalocsai fűszerpaprika-őrlemény
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-0393
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Hungarian other products
 hu: Alföldi kamillavirágzat
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-0516
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Hungarian other products
 hu: Szegedi fűszerpaprika-őrlemény, Szegedi paprika
 origins:en: en:hungary
 protected_name_file_number:en: PDO-HU-0395
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Hungary, Austrian fruit spirit
 de: Pálinka
@@ -1497,63 +1330,54 @@ en: Basmati
 origins:en: en:india
 protected_name_file_number:en: PGI-IN-2425
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Indian other products
 en: Darjeeling
 origins:en: en:india
 protected_name_file_number:en: PGI-IN-0659
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Indian other products
 en: Kangra Tea
 origins:en: en:india
 protected_name_file_number:en: PGI-IN-672
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Indonesian other products
 id: Kopi Arabika Gayo
 origins:en: en:indonesia
 protected_name_file_number:en: PGI-ID-2115
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Irish bakery products
 ie: Waterford Blaa, Blaa
 origins:en: en:ireland
 protected_name_file_number:en: PGI-IE-0980
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Irish fruit, vegetables and cereals
 ie: Wexford Blackcurrant, Wexford Blackcurrants
 origins:en: en:ireland
 protected_name_file_number:en: PGI-IE-02229
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Irish, British liqueur
 en: Irish Cream
 origins:en: en:ireland, en:united-kingdom
 protected_name_file_number:en: PGI-IE+GB-02057
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Irish, British spirit drinks
 ie: Irish Poteen, Irish Poitín
 origins:en: en:ireland, en:united-kingdom
 protected_name_file_number:en: PGI-IE+GB-02080
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Irish, British whisky or whiskey
 en: Irish Whiskey, Uisce Beatha Eireannach, Irish Whisky
 origins:en: en:ireland, en:united-kingdom
 protected_name_file_number:en: PGI-IE+GB-01897
 protected_name_type:en: gi
-#wikidata:en:
 
 
 < en: Italian cheeses
@@ -1561,63 +1385,54 @@ it: Silter
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1252-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian cheeses
 it: Stelvio, Stilfser
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0255-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian cheeses
 it: Silter
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1252
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian cheeses
 it: Piave
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0686
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian cheeses
 it: Stelvio, Stilfser
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0255
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian cheeses
 it: Mozzarella
 origins:en: en:italy
 protected_name_file_number:en: TSG-IT-0001
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Italian cheeses
 it: Bra
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0002
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian cheeses
 it: Asiago
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0001
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian essential oils
 it: Bergamotto di Reggio Calabria - Olio essenziale
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0105
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Riso Nano Vialone Veronese
@@ -1631,21 +1446,18 @@ it: Rucola della Piana del Sele
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-02436
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Pera Mantovana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1533-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Oliva di Gaeta
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-02101
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Watermelons
 it: Anguria Reggiana
@@ -1673,7 +1485,6 @@ it: Ficodindia di San Cono
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0647
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cherries
 it: Ciliegia di Vignola
@@ -1687,7 +1498,6 @@ it: Susina di Dro
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0779
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Cherries
 it: Ciliegia dell'Etna
@@ -1708,14 +1518,12 @@ it: Fichi di Cosenza
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0682
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Arancia di Ribera
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0669
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Carota Novella di Ispica
@@ -1729,287 +1537,246 @@ it: Pesca di Leonforte
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0651
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Farro di Monteleone di Spoleto
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0603
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Melanzana Rossa di Rotonda
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0662
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Sedano Bianco di Sperlonga
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0481
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Pistacchio Verde di Bronte
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0305
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Pomodorino del Piennolo del Vesuvio
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0576
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Pesca di Verona
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0579
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Insalata di Lusia
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0433
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Marroni del Monfenera
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0563
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Riso del Delta del Po
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0712
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Amarene Brusche di Modena
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0714
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Nocciola Romana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0573
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Castagna di Vallerano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0474
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Cipollotto Nocerino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0453
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Castagna Cuneo
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0342
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Arancia del Gargano
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0296
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Riso di Baraggia Biellese e Vercellese
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0337
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Carota dell'Altopiano del Fucino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0270
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Melannurca Campana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0193
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Fico Bianco del Cilento
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0282
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Oliva Ascolana del Piceno
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0331
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Kiwi Latina
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0295
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Farina di Neccio della Garfagnana
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0196
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Clementine del Golfo di Taranto
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0247
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Ficodindia dell'Etna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0241
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Pomodoro di Pachino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0153
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Ciliegia di Marostica
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0146
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Castagna del Monte Amiata
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0084
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: La Bella della Daunia
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0085
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Pesca e Nettarina di Romagna
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1535
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Nocellara del Belice
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1551
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Pera mantovana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1533
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Nocciola di Giffoni
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1538
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Scalogno di Romagna
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1539
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Pomodoro San Marzano dell'Agro Sarnese-Nocerino
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-1524
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Farro della Garfagnana
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1528
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Riso Nano Vialone Veronese
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-1529
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Nocciola del Piemonte, Nocciola Piemonte
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0305
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Fungo di Borgotaro
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0306
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Cappero di Pantelleria
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0307
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Castagna di Montella
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-0309
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Italian fruit, vegetables and cereals
 it: Arancia Rossa di Sicilia
@@ -2023,91 +1790,78 @@ it: Genziana trentina, Genziana del Trentino
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01906
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Italian gentian
 it: Südtiroler Enzian, Genziana dell'Alto Adige
 origins:en: en:italy
 protected_name_file_number:en: PGI-IT-01890
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Other Italian products
 it: Liquirizia di Calabria
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0644
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Other Italian products
 it: Zafferano di Sardegna
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0570
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Other Italian products
 it: Zafferano dell'Aquila
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0266
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Other Italian products
 it: Zafferano di San Gimignano
 origins:en: en:italy
 protected_name_file_number:en: PDO-IT-0289
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Latvian bakery products
 lv: Salinātā rudzu rupjmaize
 origins:en: en:latvia
 protected_name_file_number:en: TSG-LV-1043
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Latvian bakery products
 lv: Sklandrausis
 origins:en: en:latvia
 protected_name_file_number:en: TSG-LV-0914
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Latvian cheeses
 lv: Jāņu siers
 origins:en: en:latvia
 protected_name_file_number:en: TSG-LV-1264
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Latvian fruit, vegetables and cereals
 lv: Latvijas lielie pelēkie zirņi
 origins:en: en:latvia
 protected_name_file_number:en: PDO-LV-01194
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Latvian oils and fats
 lv: Rucavas baltais sviests
 origins:en: en:latvia
 protected_name_file_number:en: PGI-LV-02170
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Latvian sea products
 lv: Salacgrīvas nēģi
 origins:en: en:latvia
 protected_name_file_number:en: PGI-LV-02507
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Latvian sea products
 lv: Carnikavas nēģi
 origins:en: en:latvia
 protected_name_file_number:en: PGI-LV-1153
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lithuania, Polish products of animal origin
 origins:en: en:lithuania, en:poland
@@ -2120,105 +1874,90 @@ lt: Nijolės Šakočienės šakotis
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-02401
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lithuanian bakery products
 lt: Daujėnų naminė duona
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-1059
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lithuanian bitter-tasting spirit drinks or bitter
 lt: Trejos devynerios
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-01872
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Lithuanian grain spirit
 lt: Samanė
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-01964
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Lithuanian juniper-flavoured spirit drinks
 lt: Vilniaus Džinas, Vilnius Gin
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-02030
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Lithuanian meat products
 lt: Lietuviškas skilandis
 origins:en: en:lithuania
 protected_name_file_number:en: TSG-LT-0032
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Lithuanian other products
 lt: Stakliškės
 origins:en: en:lithuania
 protected_name_file_number:en: PGI-LT-0819
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Lithuanian products of animal origin
 lt: Žemaitiškas kastinys
 origins:en: en:lithuania
 protected_name_file_number:en: TSG-LT-0910
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Luxembourgish fresh meat and offal
 lu: Viande de porc, marque nationale grand-duché de Luxembourg
 origins:en: en:luxembourg
 protected_name_file_number:en: PGI-LU-0062-CANCEL
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Luxembourgish fresh meat and offal
 lu: Viande de porc, marque nationale grand-duché de Luxembourg
 origins:en: en:luxembourg
 protected_name_file_number:en: PGI-LU-0062
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Luxembourgish meat products
 lu: Salaisons fumées, marque nationale grand-duché de Luxembourg
 origins:en: en:luxembourg
 protected_name_file_number:en: PGI-LU-0063-CANCEL
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Luxembourgish meat products
 lu: Salaisons fumées, marque nationale grand-duché de Luxembourg
 origins:en: en:luxembourg
 protected_name_file_number:en: PGI-LU-0063
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Luxembourgish oils and fats
 lu: Beurre rose — Marque nationale du Grand-Duché de Luxembourg
 origins:en: en:luxembourg
 protected_name_file_number:en: PDO-LU-0060
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Luxembourgish products of animal origin
 lu: Miel - Marque nationale du Grand-Duché de Luxembourg
 origins:en: en:luxembourg
 protected_name_file_number:en: PDO-LU-0061-CANCEL
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Luxembourgish products of animal origin
 lu: Miel - Marque nationale du Grand-Duché de Luxembourg
 origins:en: en:luxembourg
 protected_name_file_number:en: PDO-LU-0061
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Mongolian fruit, vegetables and cereals
 mg: Увс чацаргана, Uvs Seabuckthorn
@@ -2249,77 +1988,66 @@ pl: Jagnięcina podhalańska
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-0837
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Suska sechlońska
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-0600-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Czosnek galicyjski
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-02211
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Fasola Wrzawska
 origins:en: en:poland
 protected_name_file_number:en: PDO-PL-0645
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Fasola Piękny Jaś z Doliny Dunajca, Fasola z Doliny Dunajca
 origins:en: en:poland
 protected_name_file_number:en: PDO-PL-0710
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Jabłka grójeckie
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-0730
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Jabłka łąckie
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-0617
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Śliwka szydłowska
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-0634
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Suska sechlońska
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-0600
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Fasola korczyńska
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-0613
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Wiśnia nadwiślanka
 origins:en: en:poland
 protected_name_file_number:en: PDO-PL-0586
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Polish fruit, vegetables and cereals
 pl: Truskawka kaszubska, kaszëbskô malëna
@@ -2333,77 +2061,66 @@ pl: Olej rydzowy tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0049
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Other Polish products
 pl: Podpiwek kujawski
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-2212
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Other Polish products
 pl: Trójniak staropolski tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0033-AM02
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Other Polish products
 pl: Półtorak staropolski tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0034-AM02
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Other Polish products
 pl: Czwórniak staropolski tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0035-AM02
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Other Polish products
 pl: Dwójniak staropolski tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0036-AM02
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Other Polish products
 pl: Trójniak staropolski tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0033
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Other Polish products
 pl: Półtorak staropolski tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0034
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Other Polish products
 pl: Czwórniak staropolski tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0035
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Other Polish products
 pl: Dwójniak staropolski tradycyjny
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-0036
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Polish products of animal origin
 pl: Miód spadziowy z Beskidu Wyspowego
 origins:en: en:poland
 protected_name_file_number:en: PDO-PL-02316
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Polish products of animal origin
 pl: Miód drahimski
@@ -2417,7 +2134,6 @@ pl: Podkarpacki miód spadziowy
 origins:en: en:poland
 protected_name_file_number:en: PDO-PL-0578
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Polish products of animal origin
 pl: Miód kurpiowski
@@ -2431,56 +2147,48 @@ pl: Miód wrzosowy z Borów Dolnośląskich
 origins:en: en:poland
 protected_name_file_number:en: PGI-PL-0449
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Polish sea products
 pl: Karp zatorski
 origins:en: en:poland
 protected_name_file_number:en: PDO-PL-0601
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Arouquesa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0235-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Mirandesa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0241-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Barrosã
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0239-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Mertolenga
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0212-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Capão de Freamunde
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0846
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne de Bravo do Ribatejo
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0789
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Cabrito do Alentejo
@@ -2494,14 +2202,12 @@ pt: Cordeiro Mirandês, Canhono Mirandês
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0787
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne de Bísaro Transmontano, Carne de Porco Transmontano
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0457
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Cordeiro de Barroso, Anho de Barroso, Cordeiro de leite de Barroso
@@ -2515,7 +2221,6 @@ pt: Borrego do Nordeste Alentejano
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0143
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne dos Açores
@@ -2529,63 +2234,54 @@ pt: Carne de Porco Alentejano
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0158
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne de Bovino Cruzado dos Lameiros do Barroso
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0144
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Cachena da Peneda
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0095
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne da Charneca
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0096
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Borrego do Baixo Alentejo
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0032
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Barrosã
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0239
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Mirandesa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0241
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Maronesa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0223
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Cabrito Transmontano
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0225
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Cabrito das Terras Altas do Minho
@@ -2599,7 +2295,6 @@ pt: Vitela de Lafões
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0249
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Cabrito da Beira
@@ -2613,7 +2308,6 @@ pt: Borrego da Beira
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0259
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Cabrito da Gralheira
@@ -2627,42 +2321,36 @@ pt: Carnalentejana
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0209
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Mertolenga
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0212
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Borrego de Montemor-o-Novo
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0215
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Borrego Terrincho
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0220
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Borrego Serra da Estrela
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0224
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Cordeiro Bragançano
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0230
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Cabrito de Barroso
@@ -2676,63 +2364,54 @@ pt: Carne Marinhoa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0233
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fresh meat and offal
 pt: Carne Arouquesa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0235
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit spirit
 pt: Medronho do Algarve
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02045
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Cereja do Fundão
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02478
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Azeitona Galega da Beira Baixa
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02508
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Ginja de Óbidos e Alcobaça
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01143
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Arroz Carolino do Baixo Mondego
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0966
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Meloa de Santa Maria — Açores
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-1124
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Maçã Riscadinha de Palmela
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0855
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Batata doce de Aljezur
@@ -2746,14 +2425,12 @@ pt: Arroz Carolino das Lezírias Ribatejanas
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0552
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Azeitonas de Conserva de Elvas e Campo Maior
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-9216
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Batata de Trás-os-Montes
@@ -2767,28 +2444,24 @@ pt: Pêra Rocha do Oeste
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0160
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Anona da Madeira
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0082
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Castanha Marvão-Portalegre
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0236
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Castanha da Terra Fria
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0238
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Maçã de Portalegre
@@ -2802,14 +2475,12 @@ pt: Cereja de São Julião-Portalegre
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0243
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Maçã Bravo de Esmolfe
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0247
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Maçã da Beira Alta
@@ -2823,14 +2494,12 @@ pt: Castanha da Padrela
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0254
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Cereja da Cova da Beira
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-0255
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Maçã da Cova da Beira
@@ -2858,21 +2527,18 @@ pt: Ameixa d'Elvas
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0263
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Ananás dos Açores, São Miguel
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0269
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Maracujá dos Açores, S. Miguel
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0270
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Citrinos do Algarve
@@ -2886,469 +2552,402 @@ pt: Castanha dos Soutos da Lapa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0227
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Amêndoa Douro
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0228
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese fruit, vegetables and cereals
 pt: Azeitona de conserva Negrinha de Freixo
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0231
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese grape marc spirit or grape marc
 pt: Minho
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02405
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese grape marc spirit or grape marc
 pt: Alentejana
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02374
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese grape marc spirit or grape marc
 pt: Trás-os-Montes
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02366
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese grape marc spirit or grape marc
 pt: Aguardente Bagaceira da Região dos Vinhos Verdes
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01934
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese grape marc spirit or grape marc
 pt: Aguardente Bagaceira Bairrada
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01939
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese grape marc spirit or grape marc
 pt: Aguardente Bagaceira Alentejo
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01936
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese oils and fats
 pt: Azeite do Alentejo Interior
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0234
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese oils and fats
 pt: Azeites da Beira Interior (Azeite da Beira Alta, Azeite da Beira Baixa)
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0264
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese oils and fats
 pt: Azeites do Norte Alentejano
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0266
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese oils and fats
 pt: Azeite de Moura
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0211
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese oils and fats
 pt: Azeite de Trás-os-Montes
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0216
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese oils and fats
 pt: Azeites do Ribatejo
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0219
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese products of animal origin
 pt: Requeijão da Beira Baixa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0847
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese products of animal origin
 pt: Travia da Beira Baixa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-0848
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese products of animal origin
 pt: Requeijão Serra da Estrela
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-9235
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Pico
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1445-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Biscoitos
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1444-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Terras da Beira
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02355
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Lisboa
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1535-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Tejo
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1547-AM01
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Bairrada
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1537-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Terras de Cister
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02351
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Beira Atlântico
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02350
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Terras do Dão
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02352
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: DoTejo
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1544
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Lisboa
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1535
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Tejo
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1547
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Península de Setúbal
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1459
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Madeirense
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A0039
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Duriense
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A0124
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Transmontano
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1467
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Terras Madeirenses
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A0040
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Açores
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1447
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Alentejano
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1543
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Beira Interior
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1546
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Távora-Varosa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1541
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Algarve
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1448
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Minho
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-A1536
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Alentejo
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1542
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Douro
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1539
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Tavira
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1449
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Lagoa
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1450
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Portimão
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1452
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Lagos
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1454
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Arruda
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1471
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Óbidos
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1469
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Bucelas
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1463
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Carcavelos
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1462
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Colares
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1461
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Palmela
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1460
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Porto, Port, vinho do Porto, Port Wine, vin de Porto, Oporto, Portvin, Portwein, Portwijn
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1540
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Madeira, Vinho da Madeira, Madère, Vin de Madère, Madera, Madeira Wein, Madeira Wine, Vino di Madera, Madeira Wijn
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A0038
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Encostas d’Aire
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1470
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines
 pt: Setúbal
 origins:en: en:portugal
 protected_name_file_number:en: PDO-PT-A1457
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Minho
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02399
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Bairrada
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02400
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Lisboa
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02373
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Alentejana
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02371
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Trás-os-Montes
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-02364
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Aguardente de Vinho Lourinhã
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01937
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Aguardente de Vinho da Região dos Vinhos Verdes
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01933
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Aguardente de Vinho Ribatejo
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01938
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Aguardente de Vinho Alentejo
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01935
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Portuguese wines spirit
 pt: Aguardente de Vinho Douro
 origins:en: en:portugal
 protected_name_file_number:en: PGI-PT-01932
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Romanian bakery products
 ro: Plăcinta dobrogeană
@@ -3370,84 +2969,72 @@ sk: Hrušovský lepník
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-02474
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovakian bakery products
 sk: Bratislavský rožok, Pozsonyi kifli
 origins:en: en:slovakia
 protected_name_file_number:en: TSG-SK-0056
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Slovakian bakery products
 sk: Skalický trdelník
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-0489
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovakian fruit, vegetables and cereals
 sk: Stupavské zelé
 origins:en: en:slovakia
 protected_name_file_number:en: PDO-SK-02110
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovakian juniper-flavoured spirit drinks
 sk: Spišská borovička
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-01824
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Other Slovakian products
 sk: Paprika Žitava, Žitavská paprika
 origins:en: en:slovakia
 protected_name_file_number:en: PDO-SK-1024-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Other Slovakian products
 sk: Liptovské droby
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-02370
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Other Slovakian products
 sk: Levický slad
 origins:en: en:slovakia
 protected_name_file_number:en: PGI-SK-01181
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Other Slovakian products
 sk: Paprika Žitava, Žitavská paprika
 origins:en: en:slovakia
 protected_name_file_number:en: PDO-SK-1024
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian bakery products
 sl: Belokranjska pogača
 origins:en: en:slovenia
 protected_name_file_number:en: TSG-SI-0029
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Slovenian bakery products
 sl: Prekmurska gibanica
 origins:en: en:slovenia
 protected_name_file_number:en: TSG-SI-0025
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Slovenian Beverages made from plant extracts
 sl: Slovenska Potica
 origins:en: en:slovenia
 protected_name_file_number:en: TSG-SI-2396
 protected_name_type:en: tsg
-#wikidata:en:
 
 
 < en: Slovenian fruit, vegetables and cereals
@@ -3455,14 +3042,12 @@ sl: Ptujski lük
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0811
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian liqueur
 sl: Pelinkovec
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-01831
 protected_name_type:en: gi
-#wikidata:en:
 
 
 < en: Slovenian oils and fats
@@ -3470,56 +3055,48 @@ sl: Štajersko prekmursko bučno olje
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0418
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian oils and fats
 sl: Ekstra deviško oljčno olje Slovenske Istre
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-0420
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian other products
 sl: Štajerski hmelj
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-01191
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian pasta
 sl: Idrijski žlikrofi
 origins:en: en:slovenia
 protected_name_file_number:en: TSG-SI-0026
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Slovenian products of animal origin
 sl: Jajca izpod Kamniških planin
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-02112
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian products of animal origin
 sl: Slovenski med
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0801
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Slovenian products of animal origin
 sl: Kraški med
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-0532
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Slovenian products of animal origin
 sl: Kočevski gozdni med
 origins:en: en:slovenia
 protected_name_file_number:en: PDO-SI-0425
 protected_name_type:en: pdo
-#wikidata:en:
 
 
 
@@ -3534,42 +3111,36 @@ es: Hierbas de Mallorca
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01869-AM01
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish aniseed-flavoured spirit drinks
 es: Hierbas Ibicencas
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01973
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish aniseed-flavoured spirit drinks
 es: Anís Paloma Monforte del Cid
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01893
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish aniseed-flavoured spirit drinks
 es: Hierbas de Mallorca
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01869
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish aniseed-flavoured spirit drinks
 es: Chinchón
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-02017
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish aSloe-aromatised spirit drink or Pacharán
 es: Pacharán navarro
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01878
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish brandy or Weinbrand
 es: Brandy de Jerez
@@ -3583,7 +3154,6 @@ es: Brandy del Penedés
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01946
 protected_name_type:en: gi
-#wikidata:en:
 
 
 < en: Spanish cider spirit and perry spirit
@@ -3591,14 +3161,12 @@ es: Aguardiente de sidra de Asturias
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-02058
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish cochineal
 es: Cochinilla de Canarias
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-01302
 protected_name_type:en: pdo
-#wikidata:en:
 
 
 < en: Spanish grape marc spirit or grape marc
@@ -3606,63 +3174,54 @@ es: Orujo de Galicia
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01914
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish juniper-flavoured spirit drinks
 es: Gin de Mahón
 origins:en: en:spain
 protected_name_file_number:en: PGI-ES-01953
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Spanish spices
 es: Pimentón de Mallorca - Pebre bord mallorquí
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-02465
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish vinegars
 es: Vinagre de Jerez
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0723-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish vinegars
 es: Vinagre del Condado de Huelva
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0724-AM01
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish ciders
 es: Sidra Natural del País Vasco, Euskal Sagardoa
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-2309
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish ciders
 es: Sidra de Asturias, Sidra d'Asturies
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0260
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish chufas
 es: Chufa de Valencia
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0055-AM02
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Spanish chufas
 es: Chufa de Valencia
 origins:en: en:spain
 protected_name_file_number:en: PDO-ES-0055
 protected_name_type:en: pdo
-#wikidata:en:
 
 
 
@@ -3680,35 +3239,30 @@ es: Ternera de los Pirineos Catalanes, Vedella dels Pirineus Catalans, Vedell de
 origins:en: en:spain, en:france
 protected_name_file_number:en: PGI-ES+FR-1042
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Sri Lankan other products
 si: Ceylon cinnamon
 origins:en: en:sri-lanka
 protected_name_file_number:en: PGI-LK-2298
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Swedish akvavit or aquavit
 sv: Svensk Aquavit, Svensk Akvavit, Swedish Aquavit
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-01927
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: Swedish bakery products
 sv: Upplandskubb
 origins:en: en:sweden
 protected_name_file_number:en: PDO-SE-1084
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Swedish bakery products
 sv: Skånsk spettkaka
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-0071
 protected_name_type:en: pgi
-#wikidata:en:
 
 
 < en: Swedish fruit, vegetables and cereals
@@ -3716,95 +3270,81 @@ sv: Färsksaltad vit gurka
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-02590
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Swedish fruit, vegetables and cereals
 sv: Allåkerbär från Norrland
 origins:en: en:sweden
 protected_name_file_number:en: PDO-SE-02494
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Swedish fruit, vegetables and cereals
 sv: Värmländskt skrädmjöl
 origins:en: en:sweden
 protected_name_file_number:en: PDO-SE-02414
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Swedish fruit, vegetables and cereals
 sv: Bruna bönor från Öland
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-0692
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Swedish meat products
 sv: Falukorv
 origins:en: en:sweden
 protected_name_file_number:en: TSG-SE-0020
 protected_name_type:en: tsg
-#wikidata:en:
 
 < en: Swedish products of animal origin
 sv: Kullings kalvdans
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-02511
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Swedish sea products
 sv: Rökt Vättersik
 origins:en: en:sweden
 protected_name_file_number:en: PDO-SE-02591
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Swedish sea products
 sv: Vänerlöjrom
 origins:en: en:sweden
 protected_name_file_number:en: PDO-SE-02412
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Swedish sea products
 sv: Kalix Löjrom
 origins:en: en:sweden
 protected_name_file_number:en: PDO-SE-0650
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Swedish spirit drinks
 sv: Svensk Punsch, Swedish Punch
 origins:en: en:sweden
 protected_name_file_number:en: PGI-SE-01928
 protected_name_type:en: gi
-#wikidata:en:
 
 
 < en: Thai fruit, vegetables and cereals
 th: ข้าวสังข์หยดเมืองพัทลุง, Khao Sangyod Muang Phatthalung
 protected_name_file_number:en: PGI-TH-1115
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Thai fruit, vegetables and cereals
 th: ข้าวหอมมะลิทุ่งกุลาร้องไห้, Khao Hom Mali Thung Kula Rong-Hai
 protected_name_file_number:en: PGI-TH-0729
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Thai other products
 th: กาแฟดอยตุง, Kafae Doi Tung
 protected_name_file_number:en: PGI-TH-0814
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Thai other products
 th: กาแฟดอยตช้าง, Kafae Doi Chaang
 protected_name_file_number:en: PGI-TH-0815
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Trinidad and Tobagon other products
 es: Trinidad Montserrat Hills Cocoa
@@ -3816,130 +3356,109 @@ protected_name_type:en: pgi
 tr: Antep Baklavası, Gaziantep Baklavası
 protected_name_file_number:en: PGI-TR-0781
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Turkish Beverages made from plant extracts
 tr: Antakya Künefesi
 protected_name_file_number:en: PGI-TR-2451
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Turkish Beverages made from plant extracts
 tr: Antep Lahmacunu
 protected_name_file_number:en: PGI-TR-2404
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: Giresun Tombul Fındığı
 protected_name_file_number:en: PDO-TR-2419
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: Edremit Körfezi Yeşil Çizik Zeytini
 protected_name_file_number:en: PDO-TR-2398
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: Bayramiç Beyazı
 protected_name_file_number:en: PDO-TR-2391
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: MİLAS ZEYTİNYAĞI
 protected_name_file_number:en: PDO-TR-2379
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: Antepfıstığı, Antep fıstığı
 protected_name_file_number:en: PDO-TR-2318
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: Malatya Kayısısı
 protected_name_file_number:en: PDO-TR-1221
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: Taşköprü Sarımsağı
 protected_name_file_number:en: PDO-TR-2217
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: Aydın İnciri
 protected_name_file_number:en: PDO-TR-1116
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish fruit, vegetables and cereals
 tr: Aydın Kestanesi
 protected_name_file_number:en: PDO-TR-1362
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Turkish meat products
 tr: Kayseri Pastırması
 protected_name_file_number:en: PGI-TR-2311
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Turkish meat products
 tr: Kayseri Sucuğu
 protected_name_file_number:en: PGI-TR-2312
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Turkish meat products
 tr: İnegöl Köfte
 protected_name_file_number:en: PGI-TR-01260
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Turkish meat products
 tr: Afyon Pastırması
 protected_name_file_number:en: PGI-TR-1030
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Turkish meat products
 tr: Afyon Sucuġu
 protected_name_file_number:en: PGI-TR-1029
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Turkish pasta
 tr: Kayseri Mantısı
 protected_name_file_number:en: PGI-TR-2310
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Vietnamese sea products
 vi: Phú Quốc
 origins:en: en:vietnam
 protected_name_file_number:en: PDO-VN-0788
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Atlantique
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1365
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux de l’Auxois
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1233-AM02
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Cairanne
@@ -3953,21 +3472,18 @@ fr: Côtes de la Charité
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1372-AM03
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Vins de la Corrèze
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1127-AM03
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Corrèze
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-02407
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Bourgogne
@@ -4002,14 +3518,12 @@ fr: Terres du Midi
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-02484
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux Bourguignons, Bourgogne grand ordinaire, Bourgogne ordinaire
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0931
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Grignan-les-Adhémar
@@ -4072,35 +3586,30 @@ fr: Méditerranée
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1154
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Alpes-de-Haute-Provence
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1115
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Alpes-Maritimes
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1148
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Alpilles
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1197
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes de Meuse
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1156
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Val de Loire
@@ -4114,14 +3623,12 @@ fr: Haute-Vienne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1157
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Haute-Marne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1150
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Calvados
@@ -4135,21 +3642,18 @@ fr: Hautes-Alpes
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1208
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Cévennes
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1151
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Yonne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1117
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Comtés Rhodaniens
@@ -4163,56 +3667,48 @@ fr: Coteaux de l'Ain
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1160
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Ariège
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1109
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Sainte-Marie-la-Blanche
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1113
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Saône-et-Loire
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1212
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Thézac-Perricard
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1204
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Périgord
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1105
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Vins de la Corrèze
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1127
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Le Pays Cathare
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1374
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Anjou Villages Brissac
@@ -4226,7 +3722,6 @@ fr: Saint-Mont
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0711
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Orléans
@@ -4254,7 +3749,6 @@ fr: Viré-Clessé
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0661
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 < en: Wines from France
@@ -4263,7 +3757,6 @@ fr: Côte Vermeille
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1155
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 < en: Wines from France
@@ -4272,14 +3765,12 @@ fr: Ajaccio
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0156
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux Varois en Provence
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0725
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Costières de Nîmes
@@ -4293,7 +3784,6 @@ fr: Coteaux de Die
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0397
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Fronsac
@@ -4349,7 +3839,6 @@ fr: Saint-Emilion Grand Cru
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0993
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Floc de Gascogne
@@ -4363,7 +3852,6 @@ fr: Fiefs Vendéens
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0733
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Bouzeron
@@ -4384,7 +3872,6 @@ fr: La Grande Rue
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0581
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Charentais
@@ -4398,21 +3885,18 @@ fr: Franche-Comté
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1217
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Collines Rhodaniennes
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1125
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux de Narbonne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1202
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes Catalanes
@@ -4426,42 +3910,36 @@ fr: Haute Vallée de l'Orb
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1163
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Urfé
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1116
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux du Cher et de l'Arnon
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1129
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Comté Tolosan
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1231
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Agenais
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1207
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Mont Caume
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1206
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Irancy
@@ -4496,154 +3974,132 @@ fr: Île de Beauté
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1166
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Var
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1145
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Cité de Carcassonne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1203
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Gard
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1130
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Vallée du Paradis
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1141
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux du Pont du Gard
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1131
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Pays d'Hérault
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1370
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Maures
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1152
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux de Peyriac
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1371
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Bouches-du-Rhône
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1223
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Vicomté d'Aumelas
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1107
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Haute Vallée de l'Aude
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1126
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes de Thau
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1229
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Puy-de-Dôme
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1211
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux d’Ensérune
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1168
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes de Thongue
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1110
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Pays d'Oc
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1367
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Sable de Camargue
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1227
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux de Glanes
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1216
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Ardèche
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1198
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes du Tarn
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1161
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Gers
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1221
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Landes
@@ -4657,70 +4113,60 @@ fr: Aveyron
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1149
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Drôme
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1121
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Vin des Allobroges
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1144
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux des Baronnies
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1159
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Aude
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1215
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Isère
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1153
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Vallée du Torgan
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1112
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux du Libron
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1146
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes du Lot
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1218
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Vaucluse
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-A1209
 protected_name_type:en: pgi
-#wikidata:en:
 
 < en: Wines from France
 fr: Crémant de Loire
@@ -4755,14 +4201,12 @@ fr: Vin de Savoie, Savoie
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0681
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Coteaux champenois
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A1364
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Régnié
@@ -4839,7 +4283,6 @@ fr: Coteaux d'Aix-en-Provence
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0159
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Châteauneuf-du-Pape
@@ -4895,7 +4338,6 @@ fr: Côte Rôtie
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0199
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Crozes-Hermitage, Crozes-Ermitage
@@ -4930,7 +4372,6 @@ fr: Coteaux de l'Aubance
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0149
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Anjou-Coteaux de la Loire
@@ -4979,7 +4420,6 @@ fr: Côtes du Roussillon
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0919
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Muscat de Lunel
@@ -5014,7 +4454,6 @@ fr: Grand Roussillon
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0721
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Alsace, Vin d'Alsace
@@ -5028,7 +4467,6 @@ fr: Côtes du Roussillon Villages
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0999
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Muscat de Beaumes-de-Venise
@@ -5049,14 +4487,12 @@ fr: Pineau des Charentes
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0489
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Auxey-Duresses
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0647
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Bergerac
@@ -5070,7 +4506,6 @@ fr: Côtes de Bergerac
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0191
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Montravel
@@ -5091,14 +4526,12 @@ fr: Anjou
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0820
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Cabernet d'Anjou
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A1005
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Château-Chalon
@@ -5112,14 +4545,12 @@ fr: Côtes du Jura
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0155
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Rosé d'Anjou
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A1007
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Rosette
@@ -5154,14 +4585,12 @@ fr: Coteaux du Giennois
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0394
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Beaune
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A1022
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes de Duras
@@ -5231,7 +4660,6 @@ fr: Coteaux du Vendômois
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0166
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Ladoix
@@ -5252,7 +4680,6 @@ fr: Côte de Beaune
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0592
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Saint-Nicolas-de-Bourgueil
@@ -5266,7 +4693,6 @@ fr: Bâtard-Montrachet
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0571
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Bienvenues-Bâtard-Montrachet
@@ -5280,7 +4706,6 @@ fr: Côte de Beaune-Villages
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0401
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Saint-Romain
@@ -5308,7 +4733,6 @@ fr: Chevalier-Montrachet
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0573
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Morey-Saint-Denis
@@ -5322,14 +4746,12 @@ fr: Criots-Bâtard-Montrachet
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0574
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: L'Etoile
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0598
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Marsannay
@@ -5378,7 +4800,6 @@ fr: Montrachet
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0402
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Sauternes
@@ -5392,7 +4813,6 @@ fr: Côte de Nuits-Villages, Vins fins de la Côte de Nuits
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0409
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Cadillac
@@ -5406,7 +4826,6 @@ fr: Premières Côtes de Bordeaux
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0274
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Blagny
@@ -5441,7 +4860,6 @@ fr: Côtes de Bordeaux-Saint-Macaire
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0707
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Graves
@@ -5469,7 +4887,6 @@ fr: Chablis
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0736
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Meursault
@@ -5525,7 +4942,6 @@ fr: Chambertin
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0313
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Muscadet Sèvre et Maine
@@ -5560,28 +4976,24 @@ fr: Saint-Emilion
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0988
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Lussac Saint-Emilion
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A1200
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Chapelle-Chambertin
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0316
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Puisseguin Saint-Emilion
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0992
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Charmes-Chambertin
@@ -5595,21 +5007,18 @@ fr: Saint-Georges-Saint-Emilion
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0991
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Montagne-Saint-Emilion
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0990
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Clos de la Roche
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0580
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Béarn
@@ -5623,7 +5032,6 @@ fr: Clos de Vougeot, Clos Vougeot
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0310
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Lalande-de-Pomerol
@@ -5651,7 +5059,6 @@ fr: Gros Plant du Pays nantais
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0275
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Cahors
@@ -5686,7 +5093,6 @@ fr: Latricières-Chambertin
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0564
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Mazis-Chambertin
@@ -5729,7 +5135,6 @@ fr: Richebourg
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0388
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Charlemagne
@@ -5743,7 +5148,6 @@ fr: Corton-Charlemagne
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0307
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Estaing
@@ -5757,7 +5161,6 @@ fr: Rully
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0937
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Côte Roannaise
@@ -5771,7 +5174,6 @@ fr: Entraygues - Le Fel
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0986
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Montagny
@@ -5785,7 +5187,6 @@ fr: Coteaux d'Ancenis
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0928
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Givry
@@ -5799,35 +5200,30 @@ fr: Clos de Tart
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0491
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Mâcon
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0649
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Clos Saint-Denis
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0323
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Muscadet Coteaux de la Loire
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0495
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Muscadet
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0497
 protected_name_type:en: pdo
-#wikidata:en:
 
 
 
@@ -5852,14 +5248,12 @@ fr: Bourgogne Passe-tout-grains
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0738
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Bourgogne aligoté
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0739
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Côte de Brouilly
@@ -5880,14 +5274,12 @@ fr: Bourgogne
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0650
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Gaillac
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0502
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Chiroubles
@@ -5901,14 +5293,12 @@ fr: La Tâche
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0322
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Saint-Amour
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A1028
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Romanée-Conti
@@ -5922,7 +5312,6 @@ fr: Chambertin-Clos de Bèze
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0311
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Chénas
@@ -5964,7 +5353,6 @@ fr: Echezeaux
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0321
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Rosé des Riceys
@@ -5978,14 +5366,12 @@ fr: Chorey-lès-Beaune
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0659
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Banyuls
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0672
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Fixin
@@ -5999,7 +5385,6 @@ fr: Romanée-Saint-Vivant
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0309
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Monthélie
@@ -6020,7 +5405,6 @@ fr: Grands-Echezeaux
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0583
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Savigny-lès-Beaune
@@ -6034,14 +5418,12 @@ fr: Côtes d'Auvergne
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0925
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Côtes du Rhône
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0325
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Blaye
@@ -6118,14 +5500,12 @@ fr: Bordeaux
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0821
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Tursan
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0734
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Irouléguy
@@ -6139,7 +5519,6 @@ fr: Musigny
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0582
 protected_name_type:en: pdo
-#wikidata:en:
 
 < en: Wines from France
 fr: Saumur
@@ -6153,7 +5532,6 @@ fr: Fine de Bourgogne
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01834
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Eau-de-vie de Cognac, Eau-de-vie des Charentes, Cognac
@@ -6167,7 +5545,6 @@ fr: Fine Bordeaux
 origins:en: en:france
 protected_name_file_number:en: PGI-FR-01987
 protected_name_type:en: gi
-#wikidata:en:
 
 < en: French Eaux-de-vie
 fr: Armagnac


### PR DESCRIPTION
We have a number of lines in a few different taxonomy files (apparently 3491 lines prior to this commit) that are just `#wikidata:en:`. They’re not doing anything currently other than taking up space.

Rather than them just adding more bulk to the taxonomy files, this deletes these lines. We can add proper `wikidata` properties once they exist/we learn about them.

Command-used: `sed --follow-symlinks -i -E '/^#\\s*wikidata:en:$/d' taxonomies/**.txt`