### PR TITLE
taxonomy: grated carrots

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -86134,39 +86134,32 @@ en: Prepared sweet potatoes
 nl: Geprepareerde zoete aardappelen
 
 < en: Carrots
-en: Grated carrots
+en: Grated carrots, Unseasoned grated carrots, Unseasoned shredded carrots
 de: Geriebene Karotten, geraspelte Karotten
 es: Zanahorias ralladas
 fi: raastetut porkkanat
-fr: Carottes râpées
-hr: Ribana mrkva
+fr: Carottes râpées, Carottes râpées non assaisonnées
+hr: Ribana mrkva, Nezačinjenu ribanu mrkvu
 it: Carote grattugiate
 ja: すりおろした人参
-lt: Tarkuotos morkos
+lt: Tarkuotos morkos, Tarkuotos morkos be prieskonių
 nl: Geraspte wortelen
 pl: Tarta marchew
 tr: Rendelenmiş havuç
-agribalyse_food_code:en: 26257
 wikidata:en: Q22708802
 
-< en: Carrot salads
-en: Seasoned grated carrots, Seasoned shredded carrots
+< en: Prepared vegetables
+en: Carrot salads, Seasoned grated carrots, Seasoned shredded carrots
 de: Gewürzte geriebene Karotten
 fi: maustetut raastetut porkkanat
-fr: Carottes râpées assaisonnées
+fr: Salades de carottes, Carottes râpées assaisonnées
 hr: Začinjenu naribanu mrkvu
 lt: Tarkuotos morkos su prieskoniais
-nl: Aangemaakte geraspte wortels
-
-< en: Grated carrots
-en: Unseasoned grated carrots, Unseasoned shredded carrots
-fr: Carottes râpées non assaisonnées
-hr: Nezačinjenu ribanu mrkvu
-lt: Tarkuotos morkos be prieskonių
-
-< en: Prepared vegetables
-en: Carrot salads
-nl: Wortelsalades
+nl: Wortelsalades, Aangemaakte geraspte wortels
+agribalyse_food_code:en: 26257
+ciqual_food_code:en: 26257
+ciqual_food_name:en: Grated carrot salad, with sauce, prepacked
+ciqual_food_name:fr: Salade de carottes râpées, avec sauce, préemballée
 
 < en: Prepared vegetables
 en: Green beans wrapped in bacon


### PR DESCRIPTION
The categories "unseasoned grated carrots" and "seasoned grated carrots" were created both under "grated carrots" to avoid people putting grated carrots with sauce under carrots. Someone removed "seasoned grated carrots" from "grated carrots" and put "grated carrots" directly under carrots. With this new configuration, "unseasoned grated carrots" became a synonym of "grated carrots" and "seasoned grated carrots" of "carrot salads".

