### PR TITLE
fix: remove unused code to check user short IP address

### DIFF
--- a/lib/ProductOpener/Config2_docker.pm
+++ b/lib/ProductOpener/Config2_docker.pm
@@ -174,7 +174,6 @@ $recipe_estimator_service = $ENV{RECIPE_ESTIMATOR_SERVICE} || "product_opener";
 	minion_backend => {Pg => $postgres_url},
 	minion_local_queue => $server_domain,
 	cookie_domain => $ENV{PRODUCT_OPENER_DOMAIN},
-	ip_whitelist_session_cookie => ["", ""],
 );
 
 if ($producers_platform) {

--- a/lib/ProductOpener/Config2_sample.pm
+++ b/lib/ProductOpener/Config2_sample.pm
@@ -110,7 +110,6 @@ $folksonomy_url = 'https://api.folksonomy.openfoodfacts.org';
 	private_products => 1,    # Make products visible only to the owner
 							  # Tells that session_cookie (which is normally limitted by ip)
 							  # can be trusted also for those ip addresses
-	ip_whitelist_session_cookie => ["172.19.0.1"],
 	minion_backend => {'Pg' => 'postgresql://off:******@10.1.0.120/minion'},
 	minion_local_queue => "openfoodfacts.org",
 

--- a/lib/ProductOpener/Users.pm
+++ b/lib/ProductOpener/Users.pm
@@ -1626,19 +1626,9 @@ sub init_user ($request_ref) {
 					}
 				) if $log->is_debug();
 
-				# Try to keep sessions opened for users with dynamic IPs
-				my $short_ip = sub ($) {
-					my $ip = shift;
-					# Remove the last two bytes
-					$ip =~ s/(\.\d+){2}$//;
-					return $ip;
-				};
-
 				if (   (not defined $user_ref->{'user_sessions'})
 					or (not defined $user_session)
 					or (not defined $user_ref->{'user_sessions'}{$user_session}))
-					# disable the restriction of sessions by ip address (issue 6842 57E0 C2C7 F629 E4CE 5605 42)
-					#	or (not is_ip_known_or_whitelisted($user_ref, $user_session, remote_addr(), $short_ip)))
 				{
 					$log->debug("no matching session for user") if $log->is_debug();
 					$user_id = undef;
@@ -1776,33 +1766,6 @@ sub set_owner_id ($request_ref) {
 	}
 
 	return;
-}
-
-=head2 is_ip_known_or_whitelisted ()
-
-This sub introduces a server option to whitelist IPs for all cookies.
-
-=cut
-
-sub is_ip_known_or_whitelisted ($user_ref, $user_session, $ip, $shorten_ip) {
-
-	my $short_ip = $shorten_ip->($ip);
-
-	if (    (defined $user_ref->{'user_sessions'}{$user_session}{'ip'})
-		and ($shorten_ip->($user_ref->{'user_sessions'}{$user_session}{'ip'}) eq $short_ip))
-	{
-		return 1;
-	}
-
-	if (defined $server_options{ip_whitelist_session_cookie}) {
-		foreach (@{$server_options{ip_whitelist_session_cookie}}) {
-			if ($_ eq $ip) {
-				return 1;
-			}
-		}
-	}
-
-	return 0;
 }
 
 sub check_session ($user_id, $user_session) {


### PR DESCRIPTION
Users.pm has this warning:

`[Fri Aug 21 08:04:33 2026] Users.pm: Implicit use of @_ in shift with signatured subroutine is experimental at lib/ProductOpener/Users.pm line 1631.
`

but in fact this is for code that is unused as we removed checking the IP address of users match the IP used to open the session 3 years ago.

So we can just remove all related code I think.