### PR TITLE
fix: support allergen markup in compound words

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -7812,11 +7812,10 @@ sub detect_allergens_from_text ($product_ref) {
 
 			$text =~ s/\b___([^,;_\(\)\[\]]+?)___\b/replace_allergen($language,$product_ref,$1,$`)/iesg;
 			$text =~ s/\b__([^,;_\(\)\[\]]+?)__\b/replace_allergen($language,$product_ref,$1,$`)/iesg;
-			$text =~ s/\b_([^,;_\(\)\[\]]+?)_\b/replace_allergen($language,$product_ref,$1,$`)/iesg;
-			# _Weizen_eiweiß is not caught in last regex because of \b (word boundary).
-			if ($language eq 'de') {
-				$text =~ s/\b_([^,;_\(\)\[\]]+?)_/replace_allergen($language,$product_ref,$1,$`)/iesg;
-			}
+			# Do not require a word boundary after the closing underscore: in some
+			# languages, the marked allergen can be the beginning of a compound word
+			# (e.g. Dutch _soja_lecithine or Swedish _vete_mjöl).
+			$text =~ s/\b_([^,;_\(\)\[\]]+?)_/replace_allergen($language,$product_ref,$1,$`)/iesg;
 
 			# allergens in all caps, with other ingredients not in all caps
 

--- a/tests/unit/allergens.t
+++ b/tests/unit/allergens.t
@@ -367,6 +367,25 @@ foreach my $test_ref (@tests) {
 	compare_to_expected_results($product_ref, "$expected_result_dir/$testid.json", $update_expected_results);
 }
 
+# Allergens marked with underscores can be the beginning of compound words.
+my @underscore_compound_word_tests = (
+	["nl", "_soja_lecithine", '<span class="allergen">soja</span>lecithine', "en:soybeans"],
+	["sv", "_vete_mjöl", '<span class="allergen">vete</span>mjöl', "en:gluten"],
+);
+
+foreach my $test_ref (@underscore_compound_word_tests) {
+	my ($lc, $ingredients_text, $expected_html, $expected_allergen) = @{$test_ref};
+	my $product_ref = {lc => $lc, lang => $lc, "ingredients_text_$lc" => $ingredients_text};
+
+	compute_languages($product_ref);
+	extract_ingredients_from_text($product_ref);
+	detect_allergens_from_text($product_ref);
+
+	is($product_ref->{"ingredients_text_with_allergens_$lc"},
+		$expected_html, "allergen markup works inside a $lc compound word");
+	is($product_ref->{allergens_tags}, [$expected_allergen], "allergen is detected inside a $lc compound word");
+}
+
 # Additional tests for canonicalize_allergens_taxonomy_tag
 is(canonicalize_allergens_taxonomy_tag("en", "egg"),
 	"en:eggs", "Testing canonicalize_allergens_taxonomy_tag for egg (en)");


### PR DESCRIPTION
## Summary

- support underscore allergen markup **at the start of** compound words in every language
- remove the German-only workaround
- add focused regression tests for Dutch `_soja_lecithine` and Swedish `_vete_mjöl`

Fixes #179

## Testing

- `yath test tests/unit/allergens.t` (42 assertions)
- `perltidy --assert-tidy` on the two changed Perl files
- `git diff --check`