### PR TITLE
taxonomy: fix broken commas in OBF beauty ingredients taxonomy

### DIFF
--- a/scripts/taxonomies/lint_taxonomy.pl
+++ b/scripts/taxonomies/lint_taxonomy.pl
@@ -365,7 +365,7 @@ sub add_entry_id($entry_ref, $errors_ref) {
 }
 
 # lint lines of an entry
-sub lint_entry($entry_ref, $do_sort) {
+sub lint_entry($entry_ref, $do_sort, $normalize_commas = 1) {
 	my @parents = @{$entry_ref->{parents}};
 	my $entry_id_line = $entry_ref->{entry_id_line};
 	my %entries = %{$entry_ref->{entries}};
@@ -389,32 +389,32 @@ sub lint_entry($entry_ref, $do_sort) {
 	# print parents, line id, synonyms, sorted props
 	for my $parent (@parents) {
 		push @output_lines, @{$parent->{previous}};
-		push @output_lines, normalized_line($parent);
+		push @output_lines, normalized_line($parent, $normalize_commas);
 	}
 	if (defined $entry_id_line) {
 		push @output_lines, @{$entry_id_line->{previous}};
-		push @output_lines, normalized_line($entry_id_line);
+		push @output_lines, normalized_line($entry_id_line, $normalize_commas);
 	}
 	for my $key (@sorted_entries) {
 		push @output_lines, @{$entries{$key}->{previous}};
-		push @output_lines, normalized_line($entries{$key});
+		push @output_lines, normalized_line($entries{$key}, $normalize_commas);
 	}
 	for my $key (@sorted_props) {
 		push @output_lines, @{$props{$key}->{previous}};
-		push @output_lines, normalized_line($props{$key});
+		push @output_lines, normalized_line($props{$key}, $normalize_commas);
 	}
 	push @output_lines, @tail_lines;
 	return join("", @output_lines);
 }
 
 # normalize spaces on a line
-sub normalized_line($entry) {
+sub normalized_line($entry, $normalize_commas = 1) {
 	my $line = $entry->{line};
-	my $normalize_commas
-		= (    ($entry->{type} eq "entry_lc")
-			|| ($entry->{type} eq "entry_id")
-			|| ($entry->{type} eq "synonyms")
-			|| ($entry->{type} eq "stopwords"));
+	my $should_normalize_commas = $normalize_commas
+		&& (($entry->{type} eq "entry_lc")
+		|| ($entry->{type} eq "entry_id")
+		|| ($entry->{type} eq "synonyms")
+		|| ($entry->{type} eq "stopwords"));
 	# ensure exactly one space after line prefix and one space after language
 	if ($entry->{type} eq "parent") {
 		$line =~ s/^< *([^:]+): *(.+)/< $1: $2/;
@@ -429,13 +429,13 @@ sub normalized_line($entry) {
 	}
 	# remove trailing space at end of line
 	$line =~ s/ +$//g;
-	if ($normalize_commas) {
+	if ($should_normalize_commas) {
 		# remove multiple commas
 		$line =~ s/,+/,/g;
 		# remove trailing space and comma at end of line
 		$line =~ s/[ ,]+$//g;
 		# first replace special cases by a lower comma
-		# but if is escape or within a number
+		# if the comma is escaped or within a number (chemical names in Open Beauty Facts categories)
 		# in numbers
 		$line =~ s/(\d),(\d)/$1‚$2/g;
 		# escaped comma \,
@@ -478,7 +478,7 @@ sub check_linted($entry_ref, $linted_output) {
 }
 
 # lint or check the taxonomy
-sub lint_taxonomy($entries_iterator, $out, $is_check, $is_quiet, $do_sort) {
+sub lint_taxonomy($entries_iterator, $out, $is_check, $is_quiet, $do_sort, $normalize_commas = 1) {
 	my @errors = ();
 	while (my $entry_ref = $entries_iterator->()) {
 		my @entry_errors = @{$entry_ref->{errors}};
@@ -487,7 +487,7 @@ sub lint_taxonomy($entries_iterator, $out, $is_check, $is_quiet, $do_sort) {
 		# we will try to lint only if we don't have errors so far
 		my $linted_output;
 		if (!has_errors(\@entry_errors)) {
-			$linted_output = lint_entry($entry_ref, $do_sort);
+			$linted_output = lint_entry($entry_ref, $do_sort, $normalize_commas);
 		}
 		else {
 			# keep original lines
@@ -601,7 +601,13 @@ TXT
 			print("Processing $file =============\n\n") if $is_verbose;
 		}
 		my $entries_iterator = iter_taxonomy_entries(iter_taxonomy_lines($fd));
-		my $errors_ref = lint_taxonomy($entries_iterator, $out, $is_check, $is_quiet, !$no_sort);
+		my $normalize_commas = 1;
+		# Skip normalizing commas for beauty ingredients taxonomy (ingredients.txt or ingredients-cosing.txt),
+		# as it contains chemical names with commas that should not be normalized.
+		if ($file =~ m{/beauty/ingredients}) {
+			$normalize_commas = 0;
+		}
+		my $errors_ref = lint_taxonomy($entries_iterator, $out, $is_check, $is_quiet, !$no_sort, $normalize_commas);
 		close($fd);
 		close($out);
 		if ((!$is_check) and $out_path) {

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -12014,7 +12014,7 @@ inci_functions:en: en:skin-conditioning
 inci_update_date:en: 15/10/2010
 wikidata:en: Q27105732
 
-en: ALPHA, GAMMA, GAMMA-TRIMETHYLCYCLOHEXYLPROPYL ACETATE
+en: ALPHA\,GAMMA\,GAMMA-TRIMETHYLCYCLOHEXYLPROPYL ACETATE
 cas:en: 93917-67-0
 cosing:en: 41209
 einecs:en: 299-845-8
@@ -12022,7 +12022,7 @@ inci_description:en: alpha, gamma, gamma-Trimethylcyclohexylpropyl Acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ALPHA,3,3-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
+en: ALPHA\,3,3-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
 cas:en: 25225-10-9
 cosing:en: 41207
 einecs:en: 246-737-3
@@ -12030,7 +12030,7 @@ inci_description:en: alpha,3,3-Trimethylcyclohexylmethyl Acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ALPHA,3,3-TRIMETHYLCYCLOHEXYLMETHYL FORMATE
+en: ALPHA\,3,3-TRIMETHYLCYCLOHEXYLMETHYL FORMATE
 cas:en: 25225-08-5
 cosing:en: 41208
 einecs:en: 246-735-2
@@ -12038,7 +12038,7 @@ inci_description:en: alpha,3,3-Trimethylcyclohexylmethyl Formate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ALPHA, ALPHA-DIMETHYL-VINYL-O-MENTHENEMETHANOL
+en: ALPHA\,ALPHA-DIMETHYL-VINYL-O-MENTHENEMETHANOL
 cas:en: 639-99-6
 cosing:en: 39261
 einecs:en: 211-360-5
@@ -43259,7 +43259,6 @@ inci_functions:en: en:skin-conditioning
 inci_update_date:en: 15/10/2010
 
 en: CETETH-8 PHOSPHATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-heksadecil-.omega.-hidroksi-, fosfat (povprečno molsko razmerje 8 mol EO)
 cas:en: 50643-20-4
 cosing:en: 75159
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-hexadecyl-.omega.-hydroxy-, phosphate (8 mol EO average molar ratio)
@@ -149228,7 +149227,6 @@ inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 DIOLEATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-(1-oksododecil)-.omega.-[(1-oksododecil)oksi]- Emulgator
 cas:en: 9005-07-6
 cosing:en: 77948
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-(1-oxo-9-octadecenyl)-.omega.-[(1-oxo-9-octadecenyl)oxy]-, (Z,Z)- (20 mol EO average molar ratio)
@@ -149242,7 +149240,6 @@ inci_functions:en: en:skin-conditioning
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 DISTEARATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-(1-okso-9-oktadecenil)-.omega.-[(1-okso-9-oktadecenil)oksi]-, (Z, Z)- Emulgator
 cas:en: 9005-08-7
 cosing:en: 77949
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-(1-oxooctadecyl)-.omega.-[(1-oxooctadecyl)oxy]- (20 mol EO average molar ratio)
@@ -149250,7 +149247,6 @@ inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 EVENING PRIMROSE GLYCERIDES
-sl: Poli(oksi-1,2-etandiil), .alfa.-(1-oksooktadecil)-.omega.-[(1-oksooktadecil)oksi]-
 cas:en: 124046-44-2
 cosing:en: 77950
 inci_description:en: Mono- and diglycerides, evening primrose (Oenethera biennis) oil, ethoxylated (20 mol EO average molar ratio)
@@ -149270,7 +149266,6 @@ inci_functions:en: en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 GLYCERYL LAURATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-, eter z 1,2,3-propantriol mono(16-metilheptadekanoatom) (2:1) Površinsko aktivna snov
 cas:en: 59070-56-3
 cosing:en: 77952
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.,.alpha.',.alpha.''-1,2,3-propanetriyltris-.omega.-hydroxy-, monododecanoate (20 mol EO average molar ratio)
@@ -149278,7 +149273,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 GLYCERYL OLEATE
-sl: Poli(oksi-1,2-etandiil), .alfa., .alfa.', .alfa.''-1,2,3-propantriiltris-.omega.-hidroksi-, monododekanoat Emulgator
 cosing:en: 77953
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.,.alpha.',.alpha.''-1,2,3-propanetriyltris-.omega.-hydroxy-, mono-9-(Z)-octadecenoate (20 mol EO average molar ratio)
 inci_functions:en: en:emulsifying, en:surfactant
@@ -149293,7 +149287,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 GLYCERYL STEARATE
-sl: Poli(oksi-1,2-etandiil), .alfa., .alfa.', .alfa.''-1,2,3-propantriiltris-.omega.-hidroksi-, [r-(Z)]-12-hidroksi-9-oktadecenoat Emulgator
 cosing:en: 77955
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.,.alpha.',.alpha.''-1,2,3-propanetriyltris-.omega.-hydroxy-, monooctadecanoate (10mol EO average molar ratio)
 inci_functions:en: en:emulsifying
@@ -149320,7 +149313,6 @@ inci_functions:en: en:emollient, en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 HEXADECENYLSUCCINATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-, eter z 1,2,3-propantriol monooktadekanoatom (2:1) Emulgator
 cas:en: 178254-04-1
 cosing:en: 36066
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-hydro-.omega.-hydroxy-, monoester with 2-hexadecenylbutanedioic acid (20 mol EO average molar ratio)
@@ -149345,7 +149337,6 @@ inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 HYDROGENATED CASTOR OIL
-sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-, monoester z 2-heksadecenilbutandiojsko kislino (povprečno molsko razmerje 20 mol EO) Emulgator
 cas:en: 61788-85-0
 cosing:en: 77957
 inci_description:en: Castor oil (Ricinus communis), hydrogenated, ethoxylated (20 mol EO average molar ratio)
@@ -149439,7 +149430,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 MANNITAN LAURATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-
 cosing:en: 78044
 inci_description:en: 1,4-Anhydro-D-mannitol, ethoxylated, monododecanoates (20 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
@@ -149454,14 +149444,12 @@ inci_functions:en: en:emollient, en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 METHYL GLUCOSE SESQUICAPRYLATE/SESQUICAPRATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-, eter z metil d-glukopiranozid (4:1), dioktadekanoatom
 cosing:en: 78046
 inci_description:en: Fatty acids, C8-10, esters with methyl-d-glucopyranoside (3:2), ethoxylated (20 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 METHYL GLUCOSE SESQUILAURATE
-sl: PEG-20 METHYL GLUCOSE SESQUICAPRYLATE/SESQUICAPRATE
 cosing:en: 78047
 inci_description:en: Dodecanoic acid, esters with methyl-d-glucopyranoside (3:2), ethoxylated (20 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
@@ -149497,7 +149485,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 PALMITATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-(1-okso-9-oktadecenil)-.omega.-hidroksi-, (Z)- Emulgator/površinsko aktivna snov
 cas:en: 9004-94-8
 cosing:en: 78051
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-(1-oxohexadecyl)-.omega.-hydroxy- (20 mol EO average molar ratio)
@@ -149554,7 +149541,6 @@ inci_functions:en: en:emulsifying, en:humectant, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 TALLATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-(1-oksooktadecil)-.omega.-hidroksi- Emulgator/humektant/površinsko aktivna snov
 cas:en: 61791-00-2
 cosing:en: 78055
 inci_description:en: Fatty acids, tall-oil, ethoxylated (20 mol EO average molar ratio)

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -18098,11 +18098,11 @@ inci_functions:en: en:antistatic, en:hair-conditioning, en:skin-conditioning
 inci_update_date:en: 15/10/2010
 
 en: AQUA, water, aqua / water, water / aqua, H2O, dihydrogen monoxide, Dihydrogen oxide
+xx: aqua
 de: wasser
 es: agua
 fr: eau, aqua / eau, aqua / water / eau
 la: aqua
-xx: aqua
 cas:en: 7732-18-5
 cosing:en: 31959
 einecs:en: 231-791-2

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -226,7 +226,7 @@ inci_functions:en: en:solvent
 inci_update_date:en: 15/10/2010
 wikidata:en: Q20054514
 
-en: 1,2, 3,4, 4A, 5,6, 7-OCTAHYDRO-2,5, 5-TRIMETHYL-2-NAPHTHOL
+en: 1,2,3,4,4A,5,6,7-OCTAHYDRO-2,5,5-TRIMETHYL-2-NAPHTHOL
 cas:en: 41199-19-3
 cosing:en: 40512
 einecs:en: 255-256-8
@@ -234,7 +234,7 @@ inci_description:en: 1,2,3,4,4a,5,6,7-Octahydro-2,5,5-trimethyl-2-naphthol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 1,2, 3,4, 4A, 7,8, 8A-OCTAHYDRO-2,4A, 5,8A-TETRAMETHYL-NAPHTHYL FORMATE
+en: 1,2,3,4,4A,7,8,8A-OCTAHYDRO-2,4A,5,8A-TETRAMETHYL-NAPHTHYL FORMATE
 cas:en: 65405-72-3
 cosing:en: 40507
 einecs:en: 265-742-1
@@ -242,7 +242,7 @@ inci_description:en: 1,2,3,4,4a,7,8,8a-Octahydro-2,4a,5,8a-tetramethyl-1-naphthy
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 1,2, 4-TRIHYDROXYBENZENE
+en: 1,2,4-TRIHYDROXYBENZENE
 cas:en: 533-73-3
 cosing:en: 31465
 einecs:en: 208-575-1
@@ -269,7 +269,7 @@ inci_functions:en: en:hair-dyeing
 inci_update_date:en: 15/10/2010
 wikidata:en: Q903332
 
-en: 1,2, 6-HEXANETRIOL
+en: 1,2,6-HEXANETRIOL
 cas:en: 106-69-4
 cosing:en: 31466
 einecs:en: 203-424-6
@@ -426,7 +426,7 @@ inci_functions:en: en:bleaching
 inci_update_date:en: 14/05/2014
 wikidata:en: Q27274509
 
-en: 1,5, 9-TRIMETHYL-OXABICYCLOTRIDECADIENE
+en: 1,5,9-TRIMETHYL-OXABICYCLOTRIDECADIENE
 cas:en: 13786-79-3 / 71735-79-0
 cosing:en: 41232
 einecs:en: 237-443-6 / 275-967-7
@@ -787,7 +787,7 @@ inci_description:en: 2,2-Dimethyl-3-phenylpropionaldehyde; phenylneopentanal
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,3, 4,4A, 5,6, 7,8-OCTAHYDRO-2,5, 5-TRIMETHYL-2-NAPHTHOL
+en: 2,3,4,4A,5,6,7,8-OCTAHYDRO-2,5,5-TRIMETHYL-2-NAPHTHOL
 cas:en: 643-53-8
 cosing:en: 40511
 einecs:en: 211-399-8
@@ -795,7 +795,7 @@ inci_description:en: 2,3,4,4a,5,6,7,8-Octahydro-2,5,5-trimethyl-2-naphthol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,3, 6-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
+en: 2,3,6-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
 cas:en: 67801-27-8
 cosing:en: 41205
 einecs:en: 267-147-2
@@ -803,7 +803,7 @@ inci_description:en: 2,3,6-Trimethylcyclohexylmethyl acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,3, 6-TRIMETHYLPHENOL
+en: 2,3,6-TRIMETHYLPHENOL
 cas:en: 2416-94-6
 cosing:en: 41239
 einecs:en: 219-330-3
@@ -838,7 +838,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q27273877
 
-en: 2,3-DIHYDRO-2,2, 6-TRIMETHYLBENZALDEHYDE
+en: 2,3-DIHYDRO-2,2,6-TRIMETHYLBENZALDEHYDE
 cas:en: 116-26-7
 cosing:en: 39582
 einecs:en: 204-133-7
@@ -854,7 +854,7 @@ inci_description:en: 2,3-Dimethylnon-2-enenitrile
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,3-DIMETHYL-4-(2,6, 6-TRIMETHYL-1-CYCLOHEXENYL)-2-BUTENAL
+en: 2,3-DIMETHYL-4-(2,6,6-TRIMETHYL-1-CYCLOHEXENYL)-2-BUTENAL
 cas:en: 71850-78-7
 cosing:en: 39254
 einecs:en: 276-097-0
@@ -892,7 +892,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q425375
 
-en: 2,4, 6-TRIMETHYL-3-CYCLOHEXENECARBALDEHYDE
+en: 2,4,6-TRIMETHYL-3-CYCLOHEXENECARBALDEHYDE
 cas:en: 1423-46-7
 cosing:en: 41184
 einecs:en: 215-833-7
@@ -900,7 +900,7 @@ inci_description:en: 2,4,6-Trimethylcyclohex-3-enecarbaldehyde
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,4, 6-TRIMETHYL-3-CYCLOHEXENYL-4-PENTEN-3-ONE
+en: 2,4,6-TRIMETHYL-3-CYCLOHEXENYL-4-PENTEN-3-ONE
 cas:en: 67801-30-3
 cosing:en: 41202
 einecs:en: 267-150-9
@@ -909,7 +909,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q27160975
 
-en: 2,4, 6-TRIMETHYL-4-PHENYL-1,3-DIOXANE
+en: 2,4,6-TRIMETHYL-4-PHENYL-1,3-DIOXANE
 cas:en: 5182-36-5
 cosing:en: 41241
 einecs:en: 225-963-6
@@ -917,7 +917,7 @@ inci_description:en: 2,4,6-Trimethyl-4-phenyl-1,3-dioxane
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,4, 6-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
+en: 2,4,6-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
 cas:en: 67634-05-3
 cosing:en: 41206
 einecs:en: 266-808-2
@@ -978,7 +978,7 @@ inci_description:en: 3-cyclohexene-1-carbonitrile, 2,4-Dimethyl
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,4-DIMETHYL-2-(5,6, 7,8-TETRAHYDRO-3,5, 5,6, 8,8-HEXAMETHYL-2-NAPHTHALENYL)-1,3-DIOXOLANE
+en: 2,4-DIMETHYL-2-(5,6,7,8-TETRAHYDRO-3,5,5,6,8,8-HEXAMETHYL-2-NAPHTHALENYL)-1,3-DIOXOLANE
 cas:en: 131812-48-1
 cosing:en: 39251
 inci_description:en: 2,4-Dimethyl-2-(5,6,7,8-tetrahydro-3,5,5,6,8,8-hexamethyl-2-naphthalenyl)-1,3-dioxolane
@@ -1028,7 +1028,7 @@ inci_description:en: 2,4-Dimethylcyclohex-3-ene-1-methyl acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,4-DIMETHYL-4,4A, 5,9B-TETRAHYDROINDENO-1,3-DIOXIN
+en: 2,4-DIMETHYL-4,4A,5,9B-TETRAHYDROINDENO-1,3-DIOXIN
 cas:en: 27606-09-3
 cosing:en: 39585
 einecs:en: 248-561-2
@@ -1102,7 +1102,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q425375
 
-en: 2,5, 5-TRIMETHYL-2-PHENYL-1,3-DIOXANE
+en: 2,5,5-TRIMETHYL-2-PHENYL-1,3-DIOXANE
 cas:en: 5406-58-6
 cosing:en: 41240
 einecs:en: 226-466-7
@@ -1111,7 +1111,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q27255315
 
-en: 2,5, 6-TRIAMINO-4-PYRIMIDINOL SULFATE
+en: 2,5,6-TRIAMINO-4-PYRIMIDINOL SULFATE
 cas:en: 1603-02-7
 cosing:en: 54184
 einecs:en: 216-500-9
@@ -1121,7 +1121,7 @@ inci_restriction:en: III/301
 inci_update_date:en: 13/03/2018
 wikidata:en: Q27273115
 
-en: 2,5, 6-TRIMETHYL-2-CYCLOHEXENONE
+en: 2,5,6-TRIMETHYL-2-CYCLOHEXENONE
 cas:en: 20030-30-2
 cosing:en: 41193
 einecs:en: 243-473-0
@@ -1172,7 +1172,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q425375
 
-en: 2,6, 6-TRIMETHYL-1-CYCLOHEXENE-1-ACETALDEHYDE
+en: 2,6,6-TRIMETHYL-1-CYCLOHEXENE-1-ACETALDEHYDE
 cas:en: 472-66-2
 cosing:en: 41180
 einecs:en: 207-454-0
@@ -1180,7 +1180,7 @@ inci_description:en: 2,6,6-Trimethyl-1-cyclohexene-1-acetaldehyde
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,6, 6-TRIMETHYL-2-CYCLOHEXENE-1-ACETALDEHYDE
+en: 2,6,6-TRIMETHYL-2-CYCLOHEXENE-1-ACETALDEHYDE
 cas:en: 472-64-0
 cosing:en: 41181
 einecs:en: 207-453-5
@@ -1188,7 +1188,7 @@ inci_description:en: 2,6,6-Trimethyl-2-cyclohexene-1-acetaldehyde
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,6, 6-TRIMETHYL-2-CYCLOHEXENE-1-CARBALDEHYDE
+en: 2,6,6-TRIMETHYL-2-CYCLOHEXENE-1-CARBALDEHYDE
 cas:en: 432-24-6
 cosing:en: 41182
 einecs:en: 207-080-8
@@ -1197,7 +1197,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q27124011
 
-en: 2,6, 6-TRIMETHYLCYCLOHEXENE-1-CARBALDEHYDE
+en: 2,6,6-TRIMETHYLCYCLOHEXENE-1-CARBALDEHYDE
 cas:en: 432-25-7
 cosing:en: 41185
 einecs:en: 207-081-3
@@ -1829,7 +1829,7 @@ inci_description:en: Dodec-2-en-1-ol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-ETHOXY-2,6, 6-TRIMETHYL-9-METHYLENEBICYCLO[3.3.1]NONANE
+en: 2-ETHOXY-2,6,6-TRIMETHYL-9-METHYLENEBICYCLO[3.3.1]NONANE
 cas:en: 68845-00-1
 cosing:en: 39820
 einecs:en: 272-447-1
@@ -1837,7 +1837,7 @@ inci_description:en: 2-Ethoxy-2,6,6-trimethyl-9-methylenebicyclo[ 3.3.1]nonane
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-ETHYL-1,3, 3-TRIMETHYLBICYCLO[2.2.1]HEPTAN-2-OL
+en: 2-ETHYL-1,3,3-TRIMETHYLBICYCLO[2.2.1]HEPTAN-2-OL
 cas:en: 18368-91-7
 cosing:en: 39934
 einecs:en: 242-243-7
@@ -2371,7 +2371,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q425512
 
-en: 2-METHYL-3-(1,7, 7-TRIMETHYLBICYCLOHEPT-2-YLOXY)-PROPANOL
+en: 2-METHYL-3-(1,7,7-TRIMETHYLBICYCLOHEPT-2-YLOXY)-PROPANOL
 cas:en: 128119-70-0
 cosing:en: 40813
 inci_description:en: 2-Methyl-3-[(1,7,7-trimethylbicyclo-[2.2.1]hept-2-yl)oxy]-1-propanol
@@ -2404,7 +2404,7 @@ inci_description:en: 2-Methyl-3-(p-tolyl)propionaldehyde
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-METHYL-4-(2,2, 3-TRIMETHYL-3-CYCLOPENTENYL)-2-BUTEN-1-OL
+en: 2-METHYL-4-(2,2,3-TRIMETHYL-3-CYCLOPENTENYL)-2-BUTEN-1-OL
 cas:en: 28219-60-5
 cosing:en: 40822
 einecs:en: 248-907-2
@@ -2412,7 +2412,7 @@ inci_description:en: 2-Methyl-4-(2,2,3-trimethyl-3-cyclopentenyl)-2-buten-1-ol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-METHYL-4-(2,6, 6-TRIMETHYL-1-CYCLOHEXENYL)-2-BUTENAL
+en: 2-METHYL-4-(2,6,6-TRIMETHYL-1-CYCLOHEXENYL)-2-BUTENAL
 cas:en: 3155-71-3
 cosing:en: 40816
 einecs:en: 221-597-6
@@ -2420,7 +2420,7 @@ inci_description:en: 2-Methyl-4-(2,6,6-trimethyl-1-cyclohexenyl)-2-butenal
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-METHYL-4-(2,6, 6-TRIMETHYL-2-CYCLOHEXENYL)-2-BUTENAL
+en: 2-METHYL-4-(2,6,6-TRIMETHYL-2-CYCLOHEXENYL)-2-BUTENAL
 cas:en: 68555-62-4
 cosing:en: 40817
 einecs:en: 271-439-5
@@ -2428,7 +2428,7 @@ inci_description:en: 2-Methyl-4-(2,6,6-trimethyl-2-cyclohexenyl)-2-butenal
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-METHYL-4-(2,6, 6-TRIMETHYL-2-CYCLOHEXENYL)-3-BUTENAL
+en: 2-METHYL-4-(2,6,6-TRIMETHYL-2-CYCLOHEXENYL)-3-BUTENAL
 cas:en: 58102-02-6
 cosing:en: 40818
 einecs:en: 261-121-4
@@ -2728,7 +2728,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q27131344
 
-en: 2-OLEAMIDO-1,3, 4-OCTADECATRIYL PROLINATE
+en: 2-OLEAMIDO-1,3,4-OCTADECATRIYL PROLINATE
 cas:en: 1319128-52-3
 cosing:en: 90243
 inci_description:en: 2-Oleamido-1,3,4-Octadecatriyl Prolinate is the organic compound
@@ -2882,7 +2882,7 @@ inci_description:en: 2-tert-Butyl-4-methoxyphenol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-TRANS, 6-CIS-NONADIENOL
+en: 2-TRANS,6-CIS-NONADIENOL
 cas:en: 28069-72-9
 cosing:en: 40900
 einecs:en: 248-816-8
@@ -2890,7 +2890,7 @@ inci_description:en: (2E,6Z)-Nona-2,6-dien-1-ol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-TRANS, 6-TRANS-NONADIENAL DIETHYL ACETAL
+en: 2-TRANS,6-TRANS-NONADIENAL DIETHYL ACETAL
 cas:en: 67674-37-7
 cosing:en: 40899
 einecs:en: 266-875-8
@@ -2898,7 +2898,7 @@ inci_description:en: (2Z,6Z)-1,1-Diethoxynona-2,6-diene
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2-TRANS, 6-TRANS-NONADIENYL ACETATE
+en: 2-TRANS,6-TRANS-NONADIENYL ACETATE
 cas:en: 67674-47-9
 cosing:en: 40903
 einecs:en: 266-886-8
@@ -2922,7 +2922,7 @@ inci_description:en: Undec-2-enol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3,3, 5-TRIMETHYLCYCLOHEXYL SUCCINATE DIMETHYLAMIDE
+en: 3,3,5-TRIMETHYLCYCLOHEXYL SUCCINATE DIMETHYLAMIDE
 cas:en: 1449076-27-0
 cosing:en: 91926
 inci_description:en: Butanoic acid, 4-(dimethylamino)-4-oxo-, 3,3,5-trimethylcyclohexyl ester
@@ -3000,7 +3000,7 @@ inci_functions:en: en:antioxidant, en:bleaching, en:skin-conditioning
 inci_update_date:en: 15/10/2010
 wikidata:en: Q27260583
 
-en: 3,5, 6-TRIMETHYL-3-CYCLOHEXENE-1-CARBALDEHYDE
+en: 3,5,6-TRIMETHYL-3-CYCLOHEXENE-1-CARBALDEHYDE
 cas:en: 67634-07-5
 cosing:en: 41183
 einecs:en: 266-810-3
@@ -3008,7 +3008,7 @@ inci_description:en: 3,5,6-Trimethylcyclohex-3-ene-1-carbaldehyde
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3,5, 6-TRIMETHYL-3-CYCLOHEXENYL-4-PENTEN-3-ONE
+en: 3,5,6-TRIMETHYL-3-CYCLOHEXENYL-4-PENTEN-3-ONE
 cas:en: 67801-32-5
 cosing:en: 41203
 einecs:en: 267-153-5
@@ -3288,7 +3288,7 @@ inci_description:en: 3-Dodecyldihydrofuran-2(3H)-one
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3-ETHOXY-1,1, 5-TRIMETHYLCYCLOHEXANE
+en: 3-ETHOXY-1,1,5-TRIMETHYLCYCLOHEXANE
 cas:en: 67583-77-1
 cosing:en: 39819
 einecs:en: 266-722-5
@@ -3552,7 +3552,7 @@ inci_description:en: 3-Methyl-3-octyl acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3-METHYL-4-(2,4, 6-TRIMETHYL-3-CYCLOHEXENYL)-3-BUTEN-2-ONE
+en: 3-METHYL-4-(2,4,6-TRIMETHYL-3-CYCLOHEXENYL)-3-BUTEN-2-ONE
 cas:en: 67801-29-0
 cosing:en: 40819
 einecs:en: 267-149-3
@@ -3560,7 +3560,7 @@ inci_description:en: 3-Methyl-4-(2,4,6-trimethyl-3-cyclohexenyl)-3-buten-2-one
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3-METHYL-4-(3,5, 6-TRIMETHYL-3-CYCLOHEXENYL)-3-BUTEN-2-ONE
+en: 3-METHYL-4-(3,5,6-TRIMETHYL-3-CYCLOHEXENYL)-3-BUTEN-2-ONE
 cas:en: 67801-31-4
 cosing:en: 40820
 einecs:en: 267-151-4
@@ -3568,7 +3568,7 @@ inci_description:en: 3-Methyl-4-(3,5,6-trimethyl-3-cyclohexenyl)-3-buten-2-one
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3-METHYL-5-(2,2, 3-TRIMETHYL-3-CYCLOPENTENYL)METHYL)CYCLOHEXANOL
+en: 3-METHYL-5-(2,2,3-TRIMETHYL-3-CYCLOPENTENYL)METHYL)CYCLOHEXANOL
 cas:en: 71820-51-4
 cosing:en: 40823
 einecs:en: 276-044-1
@@ -3576,7 +3576,7 @@ inci_description:en: 3-Methyl-5-((2,2,3-trimethyl-3-cyclopentenyl)methyl)cyclohe
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3-METHYL-5-(2,2, 3-TRIMETHYL-3-CYCLOPENTENYL)PENT-3-EN-2-ONE
+en: 3-METHYL-5-(2,2,3-TRIMETHYL-3-CYCLOPENTENYL)PENT-3-EN-2-ONE
 cas:en: 65113-95-3
 cosing:en: 40825
 einecs:en: 265-450-4
@@ -3584,7 +3584,7 @@ inci_description:en: 3-Methyl-5-(2,2,3-trimethyl-3-cyclopentenyl)pent-3-en-2-one
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3-METHYL-5-(2,2, 3-TRIMETHYL-3-CYCLOPENTENYL)PENT-4-EN-2-OL
+en: 3-METHYL-5-(2,2,3-TRIMETHYL-3-CYCLOPENTENYL)PENT-4-EN-2-OL
 cas:en: 67801-20-1
 cosing:en: 40824
 einecs:en: 267-140-4
@@ -4013,7 +4013,7 @@ inci_description:en: 4-(2,2-Dimethyl-6-methylenecyclohexyl)butan-2-one
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 4-ETHYL-6-(2,6, 6-TRIMETHYL-2-CYCLOHEXENYL)-2-HEXENE-1,4-DIOL CYCLIZED
+en: 4-ETHYL-6-(2,6,6-TRIMETHYL-2-CYCLOHEXENYL)-2-HEXENE-1,4-DIOL CYCLIZED
 cas:en: 90411-73-7
 cosing:en: 39937
 einecs:en: 291-450-9
@@ -4561,7 +4561,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q27276574
 
-en: 5,5, 6-TRIMETHYLBICYCLOHEPT-2-YLCYCLOHEXANOL
+en: 5,5,6-TRIMETHYLBICYCLOHEPT-2-YLCYCLOHEXANOL
 cas:en: 3407-42-9
 cosing:en: 41172
 einecs:en: 222-294-1
@@ -4750,7 +4750,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q10303982
 
-en: 5-METHYL-1-(2,2, 3-TRIMETHYLCYCLOPENTENYL)-6-OXABICYCLOOCTANE
+en: 5-METHYL-1-(2,2,3-TRIMETHYLCYCLOPENTENYL)-6-OXABICYCLOOCTANE
 cas:en: 139539-66-5
 cosing:en: 40821
 inci_description:en: 5-Methyl-1-(2,2,3-trimethyl-3-cyclopentenyl)-6-oxabicyclo[3.2.1]octane
@@ -4823,7 +4823,7 @@ inci_description:en: 5-Phenylhex-4-en-2-one
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 6,10-DIMETHYLUNDECA-1,5, 9-TRIEN-4-OL
+en: 6,10-DIMETHYLUNDECA-1,5,9-TRIEN-4-OL
 cas:en: 28897-20-3
 cosing:en: 39256
 einecs:en: 249-293-9
@@ -11427,7 +11427,7 @@ inci_functions:en: en:perfuming
 inci_restriction:en: III/148
 inci_update_date:en: 15/10/2010
 
-en: ALLYL 3,5, 5-TRIMETHYLHEXANOATE
+en: ALLYL 3,5,5-TRIMETHYLHEXANOATE
 cas:en: 71500-37-3
 cosing:en: 41332
 einecs:en: 275-536-3
@@ -12022,7 +12022,7 @@ inci_description:en: alpha, gamma, gamma-Trimethylcyclohexylpropyl Acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ALPHA, 3,3-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
+en: ALPHA,3,3-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
 cas:en: 25225-10-9
 cosing:en: 41207
 einecs:en: 246-737-3
@@ -12030,7 +12030,7 @@ inci_description:en: alpha,3,3-Trimethylcyclohexylmethyl Acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ALPHA, 3,3-TRIMETHYLCYCLOHEXYLMETHYL FORMATE
+en: ALPHA,3,3-TRIMETHYLCYCLOHEXYLMETHYL FORMATE
 cas:en: 25225-08-5
 cosing:en: 41208
 einecs:en: 246-735-2
@@ -25629,7 +25629,7 @@ inci_description:en: Beta Vulgaris (Beet) Sprout Extract is the extract of the s
 inci_functions:en: en:skin-conditioning
 inci_update_date:en: 08/06/2018
 
-en: BETA, 4-DIMETHYL-3-CYCLOHEXENE-1-PROPANAL
+en: BETA,4-DIMETHYL-3-CYCLOHEXENE-1-PROPANAL
 cas:en: 6784-13-0
 cosing:en: 39612
 einecs:en: 229-846-0
@@ -50534,7 +50534,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q27273932
 
-en: CIS-3,5, 5-TRIMETHYLCYCLOHEXANOL
+en: CIS-3,5,5-TRIMETHYLCYCLOHEXANOL
 cas:en: 933-48-2
 cosing:en: 41179
 einecs:en: 213-268-0
@@ -59997,7 +59997,7 @@ inci_description:en: DEA-Perfluorohexyl Ethylphosphates is the diethanolamine sa
 inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 19/09/2014
 
-en: DECAHYDRO-4,8, 8-TRIMETHYL-9-METHYLENE-1,4-METHANOAZULENE/FORMIC ACID/BORON TRIFLUORIDE
+en: DECAHYDRO-4,8,8-TRIMETHYL-9-METHYLENE-1,4-METHANOAZULENE/FORMIC ACID/BORON TRIFLUORIDE
 cas:en: 68855-38-9
 cosing:en: 39493
 einecs:en: 272-483-8
@@ -76986,7 +76986,7 @@ inci_functions:en: en:skin-conditioning
 inci_update_date:en: 16/11/2016
 wikidata:en: Q5374862
 
-en: ENDO-1,2, 3,3-TETRAMETHYLBICYCLOHEPTAN-2-OL
+en: ENDO-1,2,3,3-TETRAMETHYLBICYCLOHEPTAN-2-OL
 cas:en: 28462-85-3
 cosing:en: 41054
 einecs:en: 249-036-0
@@ -78369,7 +78369,7 @@ inci_functions:en: en:masking, en:perfuming
 inci_update_date:en: 15/10/2010
 wikidata:en: Q27262908
 
-en: ETHYL 2,6, 6-TRIMETHYLCYCLOHEXA-1,3-ENECARBOXYLATE
+en: ETHYL 2,6,6-TRIMETHYLCYCLOHEXA-1,3-ENECARBOXYLATE
 cas:en: 35044-59-8
 cosing:en: 39936
 einecs:en: 252-335-9
@@ -78377,7 +78377,7 @@ inci_description:en: Ethyl 2,6,6-trimethylcyclohexa-1,3-ene-1-carboxylate.
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ETHYL 2,6, 6-TRIMETHYLCYCLOHEXA-2,4-DIENECARBOXYLATE
+en: ETHYL 2,6,6-TRIMETHYLCYCLOHEXA-2,4-DIENECARBOXYLATE
 cas:en: 35044-57-6
 cosing:en: 39935
 einecs:en: 252-333-8
@@ -78460,7 +78460,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q27159527
 
-en: ETHYL 3,5, 5-TRIMETHYLHEXANOATE
+en: ETHYL 3,5,5-TRIMETHYLHEXANOATE
 cas:en: 67707-75-9
 cosing:en: 39941
 einecs:en: 266-959-4
@@ -78503,7 +78503,7 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 wikidata:en: Q20867275
 
-en: ETHYL 5,5, 7-TRIMETHYL-1-OXASPIROOCTANE-2-CARBOXYLATE
+en: ETHYL 5,5,7-TRIMETHYL-1-OXASPIROOCTANE-2-CARBOXYLATE
 cas:en: 60234-72-2
 cosing:en: 39942
 einecs:en: 262-113-3
@@ -80559,7 +80559,7 @@ inci_functions:en: en:skin-conditioning
 inci_update_date:en: 15/10/2010
 wikidata:en: Q27283981
 
-en: ETHYL-1,3, 3-TRIMETHYLBICYCLO[2.2.1]HEPTAN-2-OL
+en: ETHYL-1,3,3-TRIMETHYLBICYCLO[2.2.1]HEPTAN-2-OL
 cas:en: 67952-68-5
 cosing:en: 39933
 einecs:en: 267-922-5
@@ -80567,7 +80567,7 @@ inci_description:en: Ethyl-1,3,3-trimethylbicyclo[2.2.1]heptan-2-ol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ETHYL-3AALPHA, 4ALPHA, 7ALPHA, 7AALPHA-OCTAHYDRO-4,7-METHANO-INDENE-3A-CARBOXYLATE
+en: ETHYL-3AALPHA,4ALPHA,7ALPHA,7AALPHA-OCTAHYDRO-4,7-METHANO-INDENE-3A-CARBOXYLATE
 cas:en: 80657-64-3
 cosing:en: 39909
 einecs:en: 407-520-0
@@ -80575,7 +80575,7 @@ inci_description:en: Ethyl (3aalpha,4aalpha, 7aalpha,7aalpha)-octahydro-4,7-meth
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ETHYL-3AALPHA, 4BETA, 7BETA, 7AALPHA-OCTAHYDRO-4,7-METHANO-INDENE-3A-CARBOXYLATE
+en: ETHYL-3AALPHA,4BETA,7BETA,7AALPHA-OCTAHYDRO-4,7-METHANO-INDENE-3A-CARBOXYLATE
 cas:en: 80623-07-0
 cosing:en: 39908
 einecs:en: 407-520-0
@@ -93518,7 +93518,7 @@ inci_description:en: Hexafluoropropylene/Tetrafluoroethylene Copolymer is a copo
 inci_functions:en: en:emollient, en:film-forming
 inci_update_date:en: 15/10/2010
 
-en: HEXAHYDRO-4,6, 6,9, 9-PENTAMETHYL-NAPHTHOPYRAN
+en: HEXAHYDRO-4,6,6,9,9-PENTAMETHYL-NAPHTHOPYRAN
 cas:en: 1922-67-4
 cosing:en: 40164
 einecs:en: 217-652-9
@@ -112380,7 +112380,7 @@ inci_description:en: Prunus Armeniaca (Apricot) Kernel Oil (U.S.)
 inci_functions:en: en:skin-conditioning
 inci_update_date:en: 08/10/2015
 
-en: L-1,2, 3,4, 5,6, 7,8-OCTAHYDRO-2,5, 5-TRIMETHYL-2-NAPHTHOL
+en: L-1,2,3,4,5,6,7,8-OCTAHYDRO-2,5,5-TRIMETHYL-2-NAPHTHOL
 cas:en: 670-24-6
 cosing:en: 40510
 einecs:en: 211-575-4
@@ -127975,7 +127975,7 @@ inci_functions:en: en:skin-conditioning
 inci_update_date:en: 15/10/2010
 wikidata:en: Q27293803
 
-en: METHYL 2,6, 10-TRIMETHYLCYCLODODECA-2,5, 9-TRIENYL KETONE
+en: METHYL 2,6,10-TRIMETHYLCYCLODODECA-2,5,9-TRIENYL KETONE
 cas:en: 28371-99-5
 cosing:en: 40814
 einecs:en: 248-995-2
@@ -127983,7 +127983,7 @@ inci_description:en: Methyl 2,6,10-trimethylcyclododeca-2,5,9-trienyl ketone
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: METHYL 2,6, 6-TRIMETHYLCYCLOHEX-2-ENECARBOXYLATE
+en: METHYL 2,6,6-TRIMETHYLCYCLOHEX-2-ENECARBOXYLATE
 cas:en: 28043-10-9
 cosing:en: 40815
 einecs:en: 248-792-9
@@ -135104,7 +135104,7 @@ inci_description:en: Myrtus Communis Stem Extract is an extract obtained from th
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: N, 2-DIMETHYL-N-PHENYLBUTYRAMIDE
+en: N,2-DIMETHYL-N-PHENYLBUTYRAMIDE
 cas:en: 84434-18-4
 cosing:en: 39648
 einecs:en: 282-817-4
@@ -138510,7 +138510,7 @@ inci_functions:en: en:binding
 inci_update_date:en: 15/10/2010
 wikidata:en: Q27284534
 
-en: OCTAHYDRO-2,5, 5-TRIMETHYL-2-NAPHTHOL
+en: OCTAHYDRO-2,5,5-TRIMETHYL-2-NAPHTHOL
 cas:en: 71832-76-3
 cosing:en: 40509
 einecs:en: 276-054-6
@@ -216037,7 +216037,7 @@ inci_description:en: (E,E)-2,6-Dimethylocta-2,4,6-triene
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: TRANS-2,4-DIMETHYL-2-(5,6, 7,8-TETRAHYDRO-5,5, 8,8-TETRAMETHYL-2-NAPHTHALENYL)-1,3-DIOXOLANE
+en: TRANS-2,4-DIMETHYL-2-(5,6,7,8-TETRAHYDRO-5,5,8,8-TETRAMETHYL-2-NAPHTHALENYL)-1,3-DIOXOLANE
 cas:en: 131812-52-7
 cosing:en: 39252
 einecs:en: 412-950-7
@@ -227876,7 +227876,7 @@ fr: Géraniol
 wikidata:en: Q410836
 
 < en: Allergenic fragrances
-en: Hydroxymethylpentylcyclohexenecarboxaldehyde, Hydroxyisohexyl 3-Cyclo Hexene Carboxaldehyde, 4-(4-Hydroxy-4-methylpentyl)-1-cyclohex-3-enecarboxaldehyde, Lyral, Kovanol, Mugonal, Landolal
+en: Hydroxymethylpentylcyclohexenecarboxaldehyde, Hydroxyisohexyl 3-Cyclo Hexene Carboxaldehyde,4-(4-Hydroxy-4-methylpentyl)-1-cyclohex-3-enecarboxaldehyde, Lyral, Kovanol, Mugonal, Landolal
 fr: Hydroxymethylpentylcyclohexenecarboxaldehyde, Hydroxyisohexyl 3-Cyclo Hexene Carboxaldehyde, 4-(4-Hydroxy-4-methylpentyl)-1-cyclohex-3-enecarboxaldehyde, Lyral, Kovanol, Mugonal, Landolal
 
 < en: Allergenic fragrances

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -227733,40 +227733,40 @@ en: Parabens
 fr: Parabènes
 
 # some products do not mention the actual paraben used: http://fr.openbeautyfacts.org/produit/3253581111550/nectar-de-massage-l-occitane-en-provence
-< en:Parabens
+< en: Parabens
 en: methyl/propyl/butyl/ethyl/paraben
 fr: méthyl/propyl/butyl/éthyl/parabène
 
-< en:Parabens
+< en: Parabens
 en: methylparaben, methyl paraben, E218, E219
 fr: méthylparabène, méthyl parabène, 4-hydroxybenzoate de méthyle, E218, E219
 
-< en:Parabens
+< en: Parabens
 en: ethylparaben, ethyl paraben, E214, E215
 fr: éthylparabène, éthyl parabène, 4-hydroxybenzoate d'éthyle, E214, E215
 
-< en:Parabens
+< en: Parabens
 en: propylparaben, propyl paraben, E216, E217
 fr: propylparabène, propyl parabène, 4-hydroxybenzoate de propyle, E216, E217
 
-< en:Parabens
+< en: Parabens
 en: isopropylparaben, isopropyl paraben
 fr: isopropylparabène, isopropyl parabène
 
-< en:Parabens
+< en: Parabens
 en: butylparaben, butyl paraben
 fr: butylparabène, butyl parabène
 wikidata:en: Q3302873
 
-< en:Parabens
+< en: Parabens
 en: isobutylparaben, isobutyl paraben
 fr: isobutylparabène, isobutyl parabène
 
-< en:Parabens
+< en: Parabens
 en: benzylparaben, benzyl paraben
 fr: benzylparabène, benzyl parabène
 
-< en:Parabens
+< en: Parabens
 en: heptylparaben, heptyl paraben, E209
 wikidata:en: Q5732121
 
@@ -227776,42 +227776,42 @@ wikidata:en: Q5732121
 en: Formaldehyde releasers
 fr: Libérateurs de Formaldéhyde
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: Quaternium-15
 fr: Quaternium-15
 wikidata:en: Q7269571
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: Imidazolidinyl Urea
 fr: Imidazolidinyl Urée
 wikidata:en: Q2737856
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: DMDM Hydantoin
 fr: DMDM Hydantoïne
 wikidata:en: Q5205613
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: Diazolidinyl Urea
 fr: Diazolidinyl Urée
 wikidata:en: Q5272201
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: 2-Bromo-2-Nitropropane-1,3-Diol, Bronopol
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: 5-Bromo-5-Nitro-1,3 Dioxane, Bronidox
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: Sodium Hydroxymethylglycinate
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: Ethyl Tosylamide
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: Glyoxal, Ethanedial
 
-< en:Formaldehyde releasers
+< en: Formaldehyde releasers
 en: Polyoxymethylene Urea
 fr: Polyoxymethylene Urée
 
@@ -227821,113 +227821,113 @@ fr: Polyoxymethylene Urée
 en: Allergenic fragrances
 fr: Substances parfumantes allergènes
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Amyl Cinnamal
 fr: Amylcinnamaldehyde, 2-benzylideneheptanal
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Benzyl Alcohol
 fr: Alcool Benzylique
 wikidata:en: Q52353
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Cinnamyl Alcohol
 fr: Alcool Cinnamylique, Alcool Cinnamique
 wikidata:en: Q204030
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Citral
 fr: Citral
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Eugenol
 fr: Eugénol
 wikidata:en: Q423357
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Hydroxycitronellal
 fr: Hydroxycitronellal, 7-Hydroxycitronellal
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Isoeugenol
 fr: Isoeugénol
 wikidata:en: Q420043
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Amylcinnamyl Alcohol
 fr: Alcool Amylcinnamique, 2-pentyl-3-phenylprop-2-1-ol
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Benzyl Salicylate
 fr: Salicylate de Benzyle
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Cinnamal
 fr: Cinnamaldéhyde
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Coumarin
 fr: Coumarine
 wikidata:en: Q111812
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Geraniol
 fr: Géraniol
 wikidata:en: Q410836
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Hydroxymethylpentylcyclohexenecarboxaldehyde, Hydroxyisohexyl 3-Cyclo Hexene Carboxaldehyde, 4-(4-Hydroxy-4-methylpentyl)-1-cyclohex-3-enecarboxaldehyde, Lyral, Kovanol, Mugonal, Landolal
 fr: Hydroxymethylpentylcyclohexenecarboxaldehyde, Hydroxyisohexyl 3-Cyclo Hexene Carboxaldehyde, 4-(4-Hydroxy-4-methylpentyl)-1-cyclohex-3-enecarboxaldehyde, Lyral, Kovanol, Mugonal, Landolal
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Anise Alcohol
 fr: Alcool anisique, Alcool 4-Methoxybenzylique
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Benzyl Cinnamate
 fr: Cinnamate de Benzyle
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Farnesol
 fr: Farnesol
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Butylphenyl Methylpropional, Lilial
 fr: Lilial, 3-(4-tert-Butylphenyl)-2-methylpropanal
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Linalool
 fr: Linalol
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Benzyl Benzoate
 fr: Benzoate de Benzyle
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Citronellol
 fr: Citronellol
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Hexyl Cinnamal
 fr: Hexylcinnamaldéhyde
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Limonene
 fr: Limonene
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Methyl 2-Octynoate
 fr: Methyl Heptin Carbonate
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Alpha-Isomethyl Ionone
 fr: Isométhylionone
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Evernia Prunastri
 fr: Extrait d'Evernia Prunastri, Extrait de mousse de chêne, Extrait de lichen fruticuleux
 
-< en:Allergenic fragrances
+< en: Allergenic fragrances
 en: Evernia Furfuracea
 fr: Extrait d'Evernia Furfuracea
 
@@ -227936,147 +227936,147 @@ fr: Extrait d'Evernia Furfuracea
 en: Silicones
 fr: Silicones
 
-< en:Silicones
+< en: Silicones
 en: Bis-aminopropyl dimethicone
 fr: Bis-aminopropyl dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Aminopropyl Dimethicone
 fr: Aminopropyl Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Caprylyl Methicone
 fr: Caprylyl Methicone
 
-< en:Silicones
+< en: Silicones
 en: Trimethylsiloxyphenyl Dimethicone
 fr: Trimethylsiloxyphenyl Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Bis-hydroxy/methoxy amodimethicone
 fr: Bis-hydroxy/methoxy amodimethicone
 
-< en:Silicones
+< en: Silicones
 en: Hexamethyldisiloxane
 fr: Hexamethyldisiloxane
 
-< en:Silicones
+< en: Silicones
 en: PEG-12 Dimethicone
 fr: PEG-12 Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: PEG-7 Amodimethicone
 fr: PEG-7 Amodimethicone
 
-< en:Silicones
+< en: Silicones
 en: Lauryl Methicone Copolyol
 fr: Lauryl Methicone Copolyol
 
-< en:Silicones
+< en: Silicones
 en: Behenoxy Dimethicone Cetearyl methicone
 fr: Behenoxy Dimethicone Cetearyl methicone
 
-< en:Silicones
+< en: Silicones
 en: Cetyl Dimethicone
 fr: Cetyl Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Vinyldimethicone Crosspolymer
 fr: Vinyldimethicone Crosspolymer
 
-< en:Silicones
+< en: Silicones
 en: Trimethylsiylamodimethicone
 fr: Trimethylsiylamodimethicone
 
-< en:Silicones
+< en: Silicones
 en: Diphenyl Dimethicone
 fr: Diphenyl Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Disiloxane
 fr: Disiloxane
 
-< en:Silicones
+< en: Silicones
 en: Phenyl Trimethicone
 fr: Phenyl Trimethicone
 
-< en:Silicones
+< en: Silicones
 en: Trimethylsiloxyamodimethicone
 fr: Trimethylsiloxyamodimethicone
 
-< en:Silicones
+< en: Silicones
 en: Dimethicone crosspolymer
 fr: Dimethicone crosspolymer
 
-< en:Silicones
+< en: Silicones
 en: Dimethicone
 fr: Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Amodimethicone
 fr: Amodimethicone
 
-< en:Silicones
+< en: Silicones
 en: Dimethiconol, Dihydroxypolydimethylsiloxane, Polyoxydimethylsilylene
 fr: Dimethiconol, Dihydroxypolydimethylsiloxane, Polyoxydimethylsilylene
 
-< en:Silicones
+< en: Silicones
 en: Cyclomethicone
 fr: Cyclomethicone
 
-< en:Silicones
+< en: Silicones
 en: Cyclopentasiloxane
 fr: Cyclopentasiloxane
 
-< en:Silicones
+< en: Silicones
 en: Cyclohexasiloxane
 fr: Cyclohexasiloxane
 
-< en:Silicones
+< en: Silicones
 en: Cetyl dimethicone copolyol, Cetyl dimethicone, dimethicone copolyol
 fr: Cetyl dimethicone copolyol, Cetyl dimethicone, dimethicone copolyol
 
-< en:Silicones
+< en: Silicones
 en: Phenyl trimethicone
 fr: Phenyl trimethicone
 
-< en:Silicones
+< en: Silicones
 en: Stearyl dimethicone
 fr: Stearyl dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Trimethylsilylamodimethicone
 fr: Trimethylsilylamodimethicone
 
-< en:Silicones
+< en: Silicones
 en: Amodimethicone Hydroxystearate
 fr: Amodimethicone Hydroxystearate
 
-< en:Silicones
+< en: Silicones
 en: Behenoxy Dimethicone
 fr: Behenoxy Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: C24-28 Alkyl Dimethicone
 fr: C24-28 Alkyl Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: C30-45 Alkyl Dimethicone
 fr: C30-45 Alkyl Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: C30-45 Alkyl Methicone
 fr: C30-45 Alkyl Methicone
 
-< en:Silicones
+< en: Silicones
 en: Stearamidopropyl Dimethicone
 fr: Stearamidopropyl Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Stearoxy Dimethicone
 fr: Stearoxy Dimethicone
 
-< en:Silicones
+< en: Silicones
 en: Trimethylsiloxysilicate
 
 en: ingredients from palm oil
@@ -228109,80 +228109,80 @@ fr: parfum, parfum / fragrance, fragrance / parfum
 en: phthalates
 fr: phtalates
 
-< en:phthalates
+< en: phthalates
 en: Dimethyl phthalate, DMP
 
-< en:phthalates
+< en: phthalates
 en: Diethyl phthalate, DEP
 
-< en:phthalates
+< en: phthalates
 en: Diallyl phthalate, 	DAP
 
-< en:phthalates
+< en: phthalates
 en: Di-n-propyl phthalate, 	DPP
 
-< en:phthalates
+< en: phthalates
 en: Di-n-butyl phthalate, 	DBP
 
-< en:phthalates
+< en: phthalates
 en: Diisobutyl phthalate, 	DIBP
 
-< en:phthalates
+< en: phthalates
 en: Butyl cyclohexyl phthalate, 	BCP
 
-< en:phthalates
+< en: phthalates
 en: Di-n-pentyl phthalate, 	DNPP
 
-< en:phthalates
+< en: phthalates
 en: Dicyclohexyl phthalate, 	DCP
 
-< en:phthalates
+< en: phthalates
 en: Butyl benzyl phthalate, 	BBP
 
-< en:phthalates
+< en: phthalates
 en: Di-n-hexyl phthalate, 	DNHP
 
-< en:phthalates
+< en: phthalates
 en: Diisohexyl phthalate, 	DIHxP
 
-< en:phthalates
+< en: phthalates
 en: Diisoheptyl phthalate, 	DIHpP
 
-< en:phthalates
+< en: phthalates
 en: Butyl decyl phthalate, 	BDP
 
-< en:phthalates
+< en: phthalates
 en: Di(2-ethylhexyl) phthalate, 	DEHP, DOP
 fr: di-2-éthylhexyle
 
-< en:phthalates
+< en: phthalates
 en: Di(n-octyl) phthalate, 	DNOP
 
-< en:phthalates
+< en: phthalates
 en: Diisooctyl phthalate, 	DIOP
 
-< en:phthalates
+< en: phthalates
 en: n-Octyl n-decyl phthalate, 	ODP
 
-< en:phthalates
+< en: phthalates
 en: Diisononyl phthalate, 	DINP
 
-< en:phthalates
+< en: phthalates
 en: Di(2-propylheptyl) phthalate, 	DPHP
 
-< en:phthalates
+< en: phthalates
 en: Diisodecyl phthalate, 	DIDP
 
-< en:phthalates
+< en: phthalates
 en: Diundecyl phthalate, 	DUP
 
-< en:phthalates
+< en: phthalates
 en: Diisoundecyl phthalate, 	DIUP
 
-< en:phthalates
+< en: phthalates
 en: Ditridecyl phthalate, 	DTDP
 
-< en:phthalates
+< en: phthalates
 en: Diisotridecyl phthalate, 	DIUP
 
 # http://www.oolution.com/bloog/blog/2014/09/19/les-6-conservateurs-cosmetique-dangereux-eviter-absolument/
@@ -228200,385 +228200,385 @@ fr: méthylisothiazolinone
 en: Aluminum salts, Aluminum and its salts
 fr: Sels d'aluminium, Aluminium et ses sels
 
-< en:Aluminum salts
+< en: Aluminum salts
 en: Aluminum Sulfate, Aluminium Sulfate
 fr: Sulfate d'Aluminium, Sulfate d'Alumine, E520
 
-< en:Aluminum salts
+< en: Aluminum salts
 en: Aluminum Chloride, Aluminium Chloride
 fr: Chlorure d'Aluminium, Trichloroalumane, Trichlorure d'aluminium
 
-< en:Aluminum salts
+< en: Aluminum salts
 en: Aluminum Chlorohydrate, Aluminium Chlorohydrate
 fr: Chlorohydrate d'Aluminium
 
-< en:Aluminum salts
+< en: Aluminum salts
 en: Aluminum Sesquichlorohydrate, Aluminium Sesquichlorohydrate
 fr: Hydroxychlorure d’Aluminium
 
-< en:Aluminum salts
+< en: Aluminum salts
 en: Aluminum Starch Octenylsuccinate, Aluminium Starch Octenylsuccinate
 fr: Aluminium Starch Octenylsuccinate
 
-< en:Aluminum salts
+< en: Aluminum salts
 en: Aluminum Zirconium Tetrachlorohydrex GLY, Aluminum Zirconium Tetrachlorohydrex, Aluminum Zirconium, Aluminum Zirconium Tetrachlorohydrex Glycine Complex
 fr: Aluminium Zirconium Tetrachlorohydrex GLY
 
-< en:Aluminum salts
+< en: Aluminum salts
 en: Aluminum Sucrose Octasulfate, Aluminium Sucrose Octasulfate
 fr: Aluminium Sucrose Octasulfate
 
-< en:Aluminum salts
+< en: Aluminum salts
 en: Aluminum Stearate, Aluminium Stearate
 fr: Stéarate d'aluminium
 
 en: polyquaternium
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-1
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-2
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-3
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-4
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-5
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-6
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-7
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-8
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-9
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-10
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-11
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-12
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-13
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-14
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-15
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-16
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-17
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-18
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-19
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-20
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-21
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-22
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-23
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-24
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-25
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-26
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-27
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-28
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-29
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-30
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-31
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-32
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-33
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-34
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-35
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-36
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-37
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-38
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-39
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-40
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-41
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-42
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-43
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-44
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-45
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-46
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-47
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-48
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-49
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-50
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-51
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-52
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-53
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-54
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-55
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-56
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-57
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-58
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-59
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-60
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-61
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-62
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-63
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-64
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-65
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-66
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-67
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-68
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-69
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-70
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-71
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-72
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-73
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-74
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-75
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-76
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-77
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-78
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-79
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-80
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-81
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-82
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-83
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-84
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-85
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-86
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-87
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-88
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-89
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-90
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-91
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-92
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-93
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-94
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-95
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-96
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-97
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-98
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-99
 
-< en:polyquaternium
+< en: polyquaternium
 en: Polyquaternium-100
 
 en: Colorants
 
-< en:Colorants
+< en: Colorants
 en: Bleu brillant FCF, CI 42090
 
-< en:Colorants
+< en: Colorants
 en: Tartrazine -Jaune, CI 19140
 
-< en:Colorants
+< en: Colorants
 en: CI 77891
 
-< en:Colorants
+< en: Colorants
 en: CI 17200
 
-< en:Colorants
+< en: Colorants
 en: CI 77491
 
-< en:Colorants
+< en: Colorants
 en: CI 47005
 
-< en:Colorants
+< en: Colorants
 en: CI 77492
 
-< en:Colorants
+< en: Colorants
 en: CI 14700
 
-< en:Colorants
+< en: Colorants
 en: CI 15985
 
-< en:Colorants
+< en: Colorants
 en: CI 16035
 
-< en:Colorants
+< en: Colorants
 en: CI 42051
 
-< en:Colorants
+< en: Colorants
 en: CI 77499
 
-< en:Colorants
+< en: Colorants
 en: CI 16255
 
-< en:Colorants
+< en: Colorants
 en: CI 15850
 
-< en:Colorants
+< en: Colorants
 en: CI 74160
 
 en: Glycerin
@@ -228633,188 +228633,188 @@ wikidata:en: Q410744
 en: Secret ingredients
 fr: Ingrédients secrets
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b159818/2
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b160303/5
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b173175/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b173588/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b30163/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b35849/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b36750/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b44107/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b4885/3
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. b49725/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c158168/2
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c161772/2
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c164325/2
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c167140/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c167146/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c170899/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c36038/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c44738/2
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c46984/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c51607/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c52087/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c52879/1
 
-< en:Secret ingredients
+< en: Secret ingredients
 en: F.I.L. c53020/1
 
 en: Laureth
 
-< en:Laureth
+< en: Laureth
 en: Laureth 2
 
-< en:Laureth
+< en: Laureth
 en: Laureth 3
 
-< en:Laureth
+< en: Laureth
 en: Laureth 4
 
-< en:Laureth
+< en: Laureth
 en: Laureth 7
 
-< en:Laureth
+< en: Laureth
 en: Laureth 10
 
-< en:Laureth
+< en: Laureth
 en: Laureth 23
 
 en: Polysorbate
 
-< en:Polysorbate
+< en: Polysorbate
 en: Polysorbate 20
 
-< en:Polysorbate
+< en: Polysorbate
 en: Polysorbate 60
 
-< en:Polysorbate
+< en: Polysorbate
 en: Polysorbate 80
 
 en: EDTA salts
 
-< en:EDTA
+< en: EDTA
 en: Tetrasodium EDTA
 
-< en:EDTA
+< en: EDTA
 en: Disodium EDTA
 
-< en:EDTA
+< en: EDTA
 en: Trisodium EDTA
 
 en: Mineral oils, Mineral oil huile minerale
 
-< en:Mineral oils
+< en: Mineral oils
 en: Paraffinum liquidum mineral oil, Parrafinum liquidum mineral oil, Paraffinum liquidum mineral oil huile minerale
 
 en: Vegetal oils
 
-< en:Vegetal oils
+< en: Vegetal oils
 en: leaf oils
 
-< en:Vegetal oils
+< en: Vegetal oils
 en: seed oils
 
-< en:Vegetal oils
+< en: Vegetal oils
 en: peel ols
 
 en: natural extracts
 fr: extraits naturels
 
-< en:natural extracts
+< en: natural extracts
 en: leaf extracts
 
-< en:leaf extracts
+< en: leaf extracts
 en: Camellia sinensis leaf extract
 
-< en:leaf extracts
+< en: leaf extracts
 en: Aloe barbadensis leaf extract
 
-< en:leaf extracts
+< en: leaf extracts
 en: Mentha piperita leaf extract
 
-< en:leaf extracts
+< en: leaf extracts
 en: Eucalyptus globulus leaf extract
 
-< en:leaf extracts
+< en: leaf extracts
 en: Salvia officinalis leaf extract
 
-< en:leaf extracts
+< en: leaf extracts
 en: Olea europaea leaf extract
 
-< en:natural extracts
+< en: natural extracts
 en: root extracts
 
-< en:root extracts
+< en: root extracts
 fr: Panax ginseng root extract
 
-< en:root extracts
+< en: root extracts
 de: Nymphaea alba root extract
 
-< en:natural extracts
+< en: natural extracts
 en: fruit extracts
 
-< en:natural extracts
+< en: natural extracts
 en: flower extracts
 
-< en:flower extracts
+< en: flower extracts
 en: Chamomilla recutita flower extract
 
-< en:flower extracts
+< en: flower extracts
 en: Calendula officinalis flower extract
 
-< en:flower extracts
+< en: flower extracts
 en: Tilia cordata flower extract
 
-< en:flower extracts
+< en: flower extracts
 en: Gardenia tahitensis flower extract
 
-< en:flower extracts
+< en: flower extracts
 en: Anthemis nobilis flower extract
 
-< en:flower extracts
+< en: flower extracts
 en: Hibiscus sabdariffa flower extract
 
 # Source : http://unep.org/gpa/documents/publications/PlasticinCosmetics2015Factsheet.pdf
@@ -228822,87 +228822,87 @@ en: Hibiscus sabdariffa flower extract
 en: Plastics
 fr: Ingrédients plastique
 
-< en:Plastics
+< en: Plastics
 en: Nylon-12
 fr: Nylon-12
 
-< en:Plastics
+< en: Plastics
 en: Polyamide-12
 fr: Polyamide-12
 
-< en:Plastics
+< en: Plastics
 en: Nylon-6
 fr: Nylon-6
 
-< en:Plastics
+< en: Plastics
 en: Polybutylene terephthalate, Poly-butylene terephthalate, PBT
 fr: Polytéréphtalate de butylène, polybutylène téréphtalate, Poly-butylene terephthalate, PBT
 
-< en:Plastics
+< en: Plastics
 en: Polyethylene isoterephthalate, Poly-ethylene isoterephthalate, Polyethylene iso-terephthalate
 fr: Polyethylene isoterephthalate, Poly-ethylene isoterephthalate, Polyethylene iso-terephthalate
 
-< en:Plastics
+< en: Plastics
 en: Polyethylene terephthalate, Poly-ethylene terephthalate, PET, PETE, PETP, PET-P, Dacron, Terylene, Lavsan, Poly-ethyl benzene-1,4-dicarboxylate
 fr: Polytéréphtalate d'éthylène, Poly-ethylene terephthalate, Polyethylene terephthalate, PET, PETE, Mylar, Lumirror
 
-< en:Plastics
+< en: Plastics
 en: Polymethyl methylacrylate, Poly-methyl methylacrylate
 fr: Polymethyl methylacrylate, Poly-methyl methylacrylate
 
-< en:Plastics
+< en: Plastics
 en: Polypentaerythrityl terephthalate, Poly-pentaerythrityl terephthalate
 fr: Polypentaerythrityl terephthalate, Poly-pentaerythrityl terephthalate
 
-< en:Plastics
+< en: Plastics
 en: Polypropylene terephthalate, Poly-propylene terephthalate
 fr: Polypropylene terephthalate, Poly-propylene terephthalate
 
-< en:Plastics
+< en: Plastics
 en: Polypropylene, polypropene, PP
 fr: Polypropylène, polypropène, Polypropylène isotactique
 
-< en:Plastics
+< en: Plastics
 en: Polystyrene
 fr: Polystyrène
 
-< en:Plastics
+< en: Plastics
 en: Polytetrafluoroethylene, Teflon, PTFE, Syncolon
 fr: Polytétrafluoroéthylène, Polytétrafluoroéthène, Téflon, PTFE
 
-< en:Plastics
+< en: Plastics
 en: Polyurethane
 fr: Polyuréthane, polyuréthanne
 
-< en:Plastics
+< en: Plastics
 en: Polyacrylate, Polyacrylates
 fr: Polyacrylate, Polyacrylates
 
-< en:Plastics
+< en: Plastics
 en: Acrylates copolymer
 fr: Acrylates copolymer
 
-< en:Plastics
+< en: Plastics
 en: Allyl stearate\/vinyl acetate copolymers
 fr: Allyl stearate\/vinyl acetate copolymers
 
-< en:Plastics
+< en: Plastics
 en: Ethylene\/propylene\/styrene copolymer
 fr: Ethylene\/propylene\/styrene copolymer
 
-< en:Plastics
+< en: Plastics
 en: Ethylene\/methylacrylate copolymer
 fr: Ethylene\/methylacrylate copolymer
 
-< en:Plastics
+< en: Plastics
 en: Ethylene\/acrylate copolymer
 fr: Ethylene\/acrylate copolymer
 
-< en:Plastics
+< en: Plastics
 en: Butylene\/ethylene\/styrene copolymer
 fr: Butylene\/ethylene\/styrene copolymer
 
-< en:Plastics
+< en: Plastics
 en: Styrene acrylates copolymer
 fr: Styrene acrylates copolymer
 

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -18097,8 +18097,7 @@ inci_description:en: 1-Propanaminium, 3-amino-N-ethyl-N,N-dimethyl-, N-apricot-o
 inci_functions:en: en:antistatic, en:hair-conditioning, en:skin-conditioning
 inci_update_date:en: 15/10/2010
 
-en: AQUA
-en: water, aqua / water, water / aqua, H2O, dihydrogen monoxide, Dihydrogen oxide
+en: AQUA, water, aqua / water, water / aqua, H2O, dihydrogen monoxide, Dihydrogen oxide
 de: wasser
 es: agua
 fr: eau, aqua / eau, aqua / water / eau

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -18099,10 +18099,16 @@ inci_functions:en: en:antistatic, en:hair-conditioning, en:skin-conditioning
 inci_update_date:en: 15/10/2010
 
 en: AQUA
-el: acqua
+en: water, aqua / water, water / aqua, H2O, dihydrogen monoxide, Dihydrogen oxide
+de: wasser
+es: agua
+fr: eau, aqua / eau, aqua / water / eau
+la: aqua
+xx: aqua
 cas:en: 7732-18-5
 cosing:en: 31959
 einecs:en: 231-791-2
+inci:en: AQUA
 inci_description:en: Water
 inci_description:da: vand
 inci_description:de: Wasser, destilliert
@@ -86709,7 +86715,6 @@ el: Γλουταμινικό Οξύ
 fr: Acide glutamique
 it: Glutamic Acid (acido glutammico)
 lt: Glutamo rūgšties
-lv: Fenilalanīns
 nl: Glutaminezuur
 pl: kwas glutaminowy
 sk: kyselina glutámová
@@ -151054,7 +151059,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-40 SORBITAN LAURATE
-nl: sorbitan, geëthoxyleerd, esters met lanolinevetzuren (40 mol EO gemiddelde molaire verhouding) Emulgator
 cas:en: 9005-64-5
 cosing:en: 76899
 inci_description:en: Sorbitan, monododecanoate, poly(oxy-1,2-ethanediyl) derivs. (40 mol EO average molar ratio)
@@ -151069,7 +151073,6 @@ inci_functions:en: en:cleansing, en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-40 SORBITAN PERISOSTEARATE
-nl: sorbitan, monododecanoaat, poly(oxy-1,2-ethaandiyl)derivaten
 cosing:en: 76900
 inci_description:en: 1,4-Anhydro-D-glucitol, ethoxylated, isooctadecanoates (1:4) (40 mol EO average molar ratio)
 inci_functions:en: en:emulsifying, en:surfactant
@@ -151091,7 +151094,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-40 SORBITAN TETRAOLEATE
-nl: sorbitan, monooctadecanoaat, poly(oxy-1,2-ethaandiyl)derivaten
 cosing:en: 76903
 inci_description:en: 1,4-Anhydro-D-glucitol, poly(oxy-1,2-ethanediyl) derivatives, tetraesters with 9-(Z)-octadecenoic acid (40 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
@@ -152638,7 +152640,6 @@ inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 BEHENATE
-pl: PEG-8 C12-18 ESTER
 cosing:en: 77305
 inci_description:en: Docosanoic acid, ethoxylated (8 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
@@ -152651,28 +152652,24 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 06/12/2011
 
 en: PEG-8 CAPRATE
-pl: PEG-8 CAPRYLATE
 cosing:en: 77307
 inci_description:en: Decanoic acid, ethoxylated (8 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 CAPRYLATE
-pl: PEG-8 CAPRYLATE/CAPRATE
 cosing:en: 77575
 inci_description:en: Octanoic acid, ethoxylated (8 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 CAPRYLATE/CAPRATE
-pl: PEG-8 CAPRYLIC/CAPRIC GLYCERIDES
 cosing:en: 77370
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-(1-oxo-C8-10-alkyl)-.omega.-hydroxy- (8 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 CASTOR OIL
-pl: 61791-12-6 Olej rycynowy, etoksylowany Emulgująca/środek powierzchniowo czynny
 cas:en: 61791-12-6
 cosing:en: 77372
 inci_description:en: Castor oil, ethoxylated (8 mol EO average molar ratio)
@@ -152756,7 +152753,6 @@ inci_functions:en: en:hair-conditioning
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 DITALLATE
-pl: 61791-01-3 Kwasy tłuszczowe, olej talowy, diester glikolu polietylenowego Emulgująca
 cas:en: 61791-01-3
 cosing:en: 77380
 inci_description:en: Fatty acids, tall-oil, diester with polyethylene glycol (8 mol EO average molar ratio)
@@ -152807,7 +152803,6 @@ inci_functions:en: en:emollient, en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 HYDROGENATED TALLOW AMINE
-pl: 61791-26-2 Aminy, alkil łojowy, etoksylowane Emulgująca
 cas:en: 61791-26-2
 cosing:en: 36385
 einecs:en: 500-153-8
@@ -152924,21 +152919,18 @@ inci_functions:en: en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 SESQUILAURATE
-pl: PEG-8 SESQUIOLEATE
 cosing:en: 77395
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-hydro-.omega.-hydroxy-, esters with dodecanoic acid (2 :3) (8 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 SESQUIOLEATE
-pl: PEG-8 SORBITAN BEESWAX
 cosing:en: 77396
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-hydro-.omega.-hydroxy-, esters with 9-(Z)-octadecenoic acid (2:3) (8 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 SOYAMINE
-pl: 61791-24-0 Aminy, alkil sojowy, etoksylowane Emulgująca/środek powierzchniowo czynny
 cas:en: 61791-24-0
 cosing:en: 77397
 inci_description:en: Amines, soya alkyl, ethoxylated (8 mol EO average molar ratio)
@@ -152946,7 +152938,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 TALLATE
-pl: 61791-00-2 Kwasy tłuszczowe, olej talowy, etoksylowane Emulgująca
 cas:en: 61791-00-2
 cosing:en: 77399
 inci_description:en: Fatty acids, tall-oil, ethoxylated (8 mol EO average molar ratio)
@@ -152954,7 +152945,6 @@ inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-8 TALLOW AMIDE
-pl: 68155-24-8 Amidy, łój, uwodornione, etoksylowane Emulgująca
 cosing:en: 77400
 inci_description:en: Amides, tallow, N-hydropoly(2-oxyethyl)- (8 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
@@ -157373,8 +157363,6 @@ inci_functions:en: en:astringent, en:skin-conditioning
 inci_update_date:en: 15/10/2010
 
 en: PETROLATUM
-fi: Ihoa hoitava aine
-sv: petrolatum, vaselin
 cas:en: 8009-03-8
 cosing:en: 79504
 einecs:en: 232-373-2
@@ -161998,7 +161986,6 @@ inci_update_date:en: 15/10/2010
 
 en: POLOXAMER 188
 el: πολυοξαμερές 188
-es: Fantome
 et: poloksameer 188
 fr: poloxamère 188
 lv: poloksamērs 188
@@ -162103,7 +162090,6 @@ inci_update_date:en: 15/10/2010
 
 en: POLOXAMER 338
 el: πολυοξαμερές 338
-es: Fantome
 et: poloksameer 338
 fr: poloxamère 338
 lv: poloksamērs 338
@@ -162138,7 +162124,6 @@ inci_update_date:en: 15/10/2010
 
 en: POLOXAMER 407
 el: πολυοξαμερές 407
-es: Fantome
 et: poloksameer 407
 fr: poloxamère 407
 lv: poloksamērs 407
@@ -166971,7 +166956,6 @@ inci_functions:en: en:skin-conditioning
 inci_update_date:en: 15/10/2010
 
 en: POLYSORBATE 20
-fi: Kalvonmuodostaja
 cas:en: 9005-64-5
 cosing:en: 79318
 inci_description:en: Sorbitan, monododecanoate, poly(oxy-1,2-ethanediyl) derivs.
@@ -166986,7 +166970,6 @@ inci_functions:en: en:emulsion-stabilising, en:surfactant
 inci_update_date:en: 20/06/2016
 
 en: POLYSORBATE 40
-fi: Emulgaattori
 cas:en: 9005-66-7
 cosing:en: 79320
 inci_description:en: Sorbitan, monohexadecanoate, poly(oxy-1,2-ethanediyl) derivs.
@@ -166995,7 +166978,6 @@ inci_update_date:en: 15/10/2010
 wikidata:en: Q1413823
 
 en: POLYSORBATE 60
-sv: Emulgerande/ytaktivt
 cas:en: 9005-67-8
 cosing:en: 79321
 inci_description:en: Sorbitan, monooctadecanoate, poly(oxy-1,2-ethanediyl) derivs.
@@ -167012,7 +166994,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: POLYSORBATE 65
-fi: Emulgaattori
 cas:en: 9005-71-4
 cosing:en: 79323
 inci_description:en: Sorbitan, trioctadecanoate, poly(oxy-1,2-ethanediyl) derivs.
@@ -167100,7 +167081,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: POLYSORBATE 85
-fi: Emulgaattori
 cas:en: 9005-70-3
 cosing:en: 79327
 inci_description:en: Sorbitan, tri-9-octadecenoate, poly(oxy-1,2-ethanediyl) derivs., (Z,Z,Z)-
@@ -182499,12 +182479,10 @@ inci_functions:en: en:emollient
 inci_update_date:en: 15/10/2010
 
 en: RIBOFLAVIN
-es: Tónico
 cas:en: 83-88-5
 cosing:en: 37498
 einecs:en: 201-507-1
 inci_description:en: Riboflavin
-inci_description:es: Tónico
 inci_functions:en: en:cosmetic-colorant, en:skin-conditioning
 inci_restriction:en: IV/145
 inci_update_date:en: 21/11/2016
@@ -192491,7 +192469,6 @@ inci_functions:en: en:cleansing, en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: SODIUM C12-15 PARETH-6 CARBOXYLATE
-es: 70632-06-3 Tensoactivo/limpiador/emulsificante
 cas:en: 70632-06-3
 cosing:en: 79160
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-(C12-15-alkyl)-.omega.-carboxymethoxy-, sodium salt (5 mol EO average molar ratio)
@@ -192499,7 +192476,6 @@ inci_functions:en: en:cleansing, en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: SODIUM C12-15 PARETH-7 CARBOXYLATE
-es: 70632-06-3 Tensoactivo/limpiador/emulsificante
 cas:en: 70632-06-3
 cosing:en: 79161
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-(C12-15-alkyl)-.omega.-carboxymethoxy-, sodium salt (6 mol EO average molar ratio)
@@ -192507,7 +192483,6 @@ inci_functions:en: en:cleansing, en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: SODIUM C12-15 PARETH-7 SULFONATE
-es: SODIUM C12-15 PARETH-8 CARBOXYLATE
 cosing:en: 79162
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-C12-15-alkyl-.omega.-sulfo-, sodium salt (7 mol EO average molar ratio)
 inci_functions:en: en:cleansing, en:emulsifying, en:surfactant
@@ -192535,7 +192510,6 @@ inci_functions:en: en:cleansing, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: SODIUM C13-15 PARETH-8 BUTYL PHOSPHATE
-es: SODIUM C13-15 PARETH-8 PHOSPHATE
 cosing:en: 79165
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-C13-15-alkyl-.omega.-hydroxy-, butyl hydrogen phosphates, sodium salts (8 mol EO average molar ratio)
 inci_functions:en: en:cleansing, en:emulsifying, en:foaming, en:surfactant
@@ -192994,7 +192968,6 @@ inci_functions:en: en:antimicrobial, en:oxidising
 inci_update_date:en: 15/10/2010
 
 en: SODIUM CAPRYLATE
-es: Emulsificante
 cas:en: 1984-06-1
 cosing:en: 37786
 einecs:en: 217-850-5
@@ -194960,7 +194933,6 @@ inci_update_date:en: 15/10/2010
 wikidata:en: Q139857
 
 en: SODIUM GLUCEPTATE
-es: Tamponante
 cas:en: 13007-85-7 / 31138-65-5
 cosing:en: 79484
 einecs:en: 235-849-8 / 250-480-2
@@ -196750,8 +196722,6 @@ inci_update_date:en: 15/10/2010
 wikidata:en: Q27291863
 
 en: SODIUM LIGNOSULFONATE
-el: Περιποίηση δέρματος
-es: Acondicionador de la piel
 cas:en: 8061-51-6
 cosing:en: 37949
 inci_description:en: Lignosulfonic acid, sodium salt
@@ -208127,7 +208097,7 @@ en: SULFUR
 da: svovl
 de: Schwefel
 el: θείο
-es: azufre, precipitado, sublimado o coloidal
+es: azufre
 et: väävel
 fi: rikki
 fr: soufre
@@ -222507,7 +222477,6 @@ el: ενδεκυλενικό οξύ
 es: ácido undec-10-enoico
 et: undetsüleenhape
 fi: undekyleenihappo
-fr: acide undécanoïque
 hu: Undecilén-sav
 it: Acido undecilenico
 lv: undecilēnskābe
@@ -225715,7 +225684,7 @@ cs: xylen
 da: xylen
 de: Xylol
 el: ξυλόλιο
-es: xileno(??)
+es: xileno
 et: ksüleen
 fi: ksyleeni
 fr: Xylène
@@ -228071,21 +228040,6 @@ fr: ingrédients issus de l'huile de palme
 
 en: ingredients that may be from palm oil
 fr: ingrédients qui peuvent être issus de l'huile de palme
-
-en: water, aqua / water, water / aqua, H2O, dihydrogen monoxide, Dihydrogen oxide
-de: wasser
-es: agua
-fr: eau, aqua / eau, aqua / water / eau
-la: aqua
-cas:en: 7732-18-5
-einecs:en: 231-791-2
-function:en: Solvent
-inci:en: AQUA
-inn:en: water
-iupac:en: Water
-pheur:la: aqua
-unii:en: 059QF0KO0R
-wikidata:en: Q283
 
 en: fragrance
 de: parfum

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -1628,7 +1628,7 @@ fr: 2-amino-6-chloro-4-nitrophénol
 hu: 2-Amino-6-klór-4-nitrofenol
 it: 2-ammino-6-cloro-4-nitrofenolo
 lt: 2-amino-6-chlor-4-nitrofenolis
-lv: 2-amino-6-hlor-4-nitrofenols III/2, 56
+lv: 2-amino-6-hlor-4-nitrofenols III/2,56
 nl: 2-amino-6-chloor-4-nitrofenol
 pl: 2-amino-6-chloro-4-nitrofenol
 pt: 2-amino-6-cloro-4-nitrofenol
@@ -5529,7 +5529,7 @@ inci_functions:en: en:astringent, en:humectant
 inci_update_date:en: 24/05/2016
 
 en: ABIETIC ACID
-cs: 13-isopropylpodokarpa-7,13-dien-15-ová kyselina/(1R)(1,4a, 4b, 10a)-7-isopropyl-1,4a-dimethyl-1,2, 3,4, 4a, 4b, 5,6, 10,10adekahydrofenanthren-1-karboxylová kyselina/abietová kyselina
+cs: 13-isopropylpodokarpa-7,13-dien-15-ová kyselina/(1R)(1,4a,4b,10a)-7-isopropyl-1,4a-dimethyl-1,2,3,4,4a,4b,5,6,10,10adekahydrofenanthren-1-karboxylová kyselina/abietová kyselina
 da: abietinsyre
 de: Abietinsäure
 el: αβιετικό οξύ
@@ -83589,7 +83589,7 @@ wikidata:en: Q418384
 en: FISH CARTILAGE EXTRACT
 cs: Výtažek z rybích chrupavek
 da: fiskebrusk-ekstrakt
-de: 1-Hydroxy-4-methyl-6-(2,4, 4-trimethylpentyl)pyridin-2(1H)-on, Verbindung mit 2-Aminoethanol (1:1)
+de: 1-Hydroxy-4-methyl-6-(2,4,4-trimethylpentyl)pyridin-2(1H)-on, Verbindung mit 2-Aminoethanol (1:1)
 el: εκχύλισμα χόνδρων ιχθύων
 es: Extracto de cartílago de pescado
 et: kala kõhrest saadud ekstrakt
@@ -84881,7 +84881,7 @@ inci_update_date:en: 15/10/2010
 
 en: GALLIC ACID
 da: gallinsyre
-de: 3,4, 5-Trihydroxybenzoesäure
+de: 3,4,5-Trihydroxybenzoesäure
 el: γαλλικό οξύ
 es: Ácido gálico
 et: gallushape
@@ -116542,7 +116542,7 @@ inci_functions:en: en:cleansing, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: LAURETH-7 PHOSPHATE
-hu: LAURETH-7 PHOSPHATE 3,6, 9,12,15,18, 21 tetraoxitritrioctanol
+hu: LAURETH-7 PHOSPHATE 3,6,9,12,15,18,21 tetraoxitritrioctanol
 cas:en: 39464-66-9
 cosing:en: 76964
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-hydro-.omega.-dodecyloxy-, dihydrogen phosphates (7 mol EO average molar ratio)
@@ -149270,7 +149270,7 @@ inci_functions:en: en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 GLYCERYL LAURATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-, eter z 1,2, 3-propantriol mono(16-metilheptadekanoatom) (2:1) Površinsko aktivna snov
+sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-, eter z 1,2,3-propantriol mono(16-metilheptadekanoatom) (2:1) Površinsko aktivna snov
 cas:en: 59070-56-3
 cosing:en: 77952
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.,.alpha.',.alpha.''-1,2,3-propanetriyltris-.omega.-hydroxy-, monododecanoate (20 mol EO average molar ratio)
@@ -149278,14 +149278,14 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 GLYCERYL OLEATE
-sl: Poli(oksi-1,2-etandiil), .alfa., .alfa.', .alfa.''-1,2, 3-propantriiltris-.omega.-hidroksi-, monododekanoat Emulgator
+sl: Poli(oksi-1,2-etandiil), .alfa., .alfa.', .alfa.''-1,2,3-propantriiltris-.omega.-hidroksi-, monododekanoat Emulgator
 cosing:en: 77953
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.,.alpha.',.alpha.''-1,2,3-propanetriyltris-.omega.-hydroxy-, mono-9-(Z)-octadecenoate (20 mol EO average molar ratio)
 inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 GLYCERYL RICINOLEATE
-sl: 9-oktadecenojska kislina (Z)-, 1,2, 3-propantriil ester, polimer z .alfa.-hidro-.omega.-hidroksipoli(oksi-1,2-etandiilom) Emulgator
+sl: 9-oktadecenojska kislina (Z)-, 1,2,3-propantriil ester, polimer z .alfa.-hidro-.omega.-hidroksipoli(oksi-1,2-etandiilom) Emulgator
 cas:en: 51142-51-9
 cosing:en: 77954
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.,.alpha.',.alpha.''-1,2,3-propanetriyltris-.omega.-hydroxy-, [R-(Z)]-12-hydroxy-9-octadecenoate (20 mol EO average molar ratio)
@@ -149293,7 +149293,7 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 GLYCERYL STEARATE
-sl: Poli(oksi-1,2-etandiil), .alfa., .alfa.', .alfa.''-1,2, 3-propantriiltris-.omega.-hidroksi-, [r-(Z)]-12-hidroksi-9-oktadecenoat Emulgator
+sl: Poli(oksi-1,2-etandiil), .alfa., .alfa.', .alfa.''-1,2,3-propantriiltris-.omega.-hidroksi-, [r-(Z)]-12-hidroksi-9-oktadecenoat Emulgator
 cosing:en: 77955
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.,.alpha.',.alpha.''-1,2,3-propanetriyltris-.omega.-hydroxy-, monooctadecanoate (10mol EO average molar ratio)
 inci_functions:en: en:emulsifying
@@ -149320,7 +149320,7 @@ inci_functions:en: en:emollient, en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 HEXADECENYLSUCCINATE
-sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-, eter z 1,2, 3-propantriol monooktadekanoatom (2:1) Emulgator
+sl: Poli(oksi-1,2-etandiil), .alfa.-hidro-.omega.-hidroksi-, eter z 1,2,3-propantriol monooktadekanoatom (2:1) Emulgator
 cas:en: 178254-04-1
 cosing:en: 36066
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-hydro-.omega.-hydroxy-, monoester with 2-hexadecenylbutanedioic acid (20 mol EO average molar ratio)
@@ -152171,7 +152171,7 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: PEG-60 LANOLIN
-sv: poly(oxi-1,2-etandiyl), α-hydro-ω-hydroxi-, eter med 1,2, 3-propantriolmono(16-metylheptadekanoat) (2:1) Ytaktivt
+sv: poly(oxi-1,2-etandiyl), α-hydro-ω-hydroxi-, eter med 1,2,3-propantriolmono(16-metylheptadekanoat) (2:1) Ytaktivt
 cas:en: 61790-81-6
 cosing:en: 77220
 inci_description:en: Lanolin, ethoxylated (60 mol EO average molar ratio)
@@ -175553,9 +175553,9 @@ inci_update_date:en: 15/10/2010
 
 en: PROPYL GALLATE
 da: propylgallat
-de: Propyl-3,4, 5-trihydroxybenzoat
+de: Propyl-3,4,5-trihydroxybenzoat
 el: γαλλικό προπύλιο
-es: 3,4, 5-trihidroxibenzoato de propilo
+es: 3,4,5-trihidroxibenzoato de propilo
 et: propüülgallaat
 fi: propyyligallaatti
 fr: gallate de propyle
@@ -203479,7 +203479,7 @@ wikidata:en: Q54222196
 
 en: SQUALANE
 da: squalan
-de: 2,6, 10,15,19,23-Hexamethyltetracosan
+de: 2,6,10,15,19,23-Hexamethyltetracosan
 el: σκουαλάνιο
 es: escualano
 et: skvalaan
@@ -218855,7 +218855,7 @@ inci_update_date:en: 15/10/2010
 wikidata:en: Q27272284
 
 en: TRILANETH-4 PHOSPHATE
-hu: TRILANETH-4 PHOSPHATE Poli(oxi- 1, 2- ethanediil), a, a', a''- phosphinilidintris- ?- (dodeciloxi)-
+hu: TRILANETH-4 PHOSPHATE Poli(oxi- 1,2- ethanediil), a, a', a''- phosphinilidintris- ?- (dodeciloxi)-
 cosing:en: 80377
 inci_description:en: Lanolin alcohols, ethoxylated (4 mol EO average molar ratio), phosphates (3:1)
 inci_functions:en: en:emulsifying, en:surfactant, en:viscosity-controlling
@@ -222850,7 +222850,7 @@ inci_update_date:en: 15/10/2010
 wikidata:en: Q423237
 
 en: URIC ACID
-cs: Močová kyselina/7H-purin-2,6, 8(1H, 3H, 9H)-trion
+cs: Močová kyselina/7H-purin-2,6,8(1H,3H,9H)-trion
 da: urinsyre
 de: Harnsäure
 el: ουρικό οξύ

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -900,7 +900,7 @@ inci_description:en: 2,4,6-Trimethylcyclohex-3-enecarbaldehyde
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,4,6-TRIMETHYL-3-CYCLOHEXENYL-4-PENTEN-3-ONE
+en: 2\,4\,6-TRIMETHYL-3-CYCLOHEXENYL-4-PENTEN-3-ONE
 cas:en: 67801-30-3
 cosing:en: 41202
 einecs:en: 267-150-9
@@ -3008,7 +3008,7 @@ inci_description:en: 3,5,6-Trimethylcyclohex-3-ene-1-carbaldehyde
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 3,5,6-TRIMETHYL-3-CYCLOHEXENYL-4-PENTEN-3-ONE
+en: 3\,5\,6-TRIMETHYL-3-CYCLOHEXENYL-4-PENTEN-3-ONE
 cas:en: 67801-32-5
 cosing:en: 41203
 einecs:en: 267-153-5
@@ -86751,7 +86751,6 @@ cs: Glutamin
 el: Γλουταμίνη
 it: Glycine (glicina)
 lt: Glutamino
-lv: Glicīns
 pl: glutamina
 sk: glutamín
 sl: glutamin
@@ -143801,7 +143800,6 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
 en: P-CHLOROPHENOL
-fi: Säilöntäaine
 cas:en: 106-48-9
 cosing:en: 35871
 einecs:en: 203-402-6
@@ -149186,7 +149184,6 @@ inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 CASTOR OIL
-sl: PEG-20 BEESWAX Emulgator
 cas:en: 61791-12-6
 cosing:en: 77943
 inci_description:en: Castor oil, ethoxylated (20 mol EO average molar ratio)
@@ -149194,7 +149191,6 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 COCAMIDE
-sl: 61791-12-6 Ricinusovo olje, etoksilirano Emulgator/površinsko aktivna snov
 cas:en: 68425-44-5
 cosing:en: 77944
 inci_description:en: Amides, coco alkyl, N-(hydroxyethyl), ethoxylated (19 mol EO average molar ratio)
@@ -149209,7 +149205,6 @@ inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 COCAMINE
-sl: 61791-08-0 Maščobne kisline, kokosove, reakcijski produkti z etanolaminom, etoksilirane Emulgator
 cas:en: 61791-14-8
 cosing:en: 77945
 inci_description:en: Amines, coco alkyl, ethoxylated (20 mol EO average molar ratio)
@@ -149217,14 +149212,12 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-20 CORN GLYCERIDES
-sl: 61791-14-8 Amini, alkil maščobnih kislin kokosovega olja, etoksilirani
 cosing:en: 77946
 inci_description:en: Mono- and diglycerides, corn (Zea mays) oil, ethoxylated (20 mol EO average molar ratio)
 inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-20 DILAURATE
-sl: PEG-20 CORN GLYCERIDES Emulgator
 cas:en: 9005-02-1
 cosing:en: 77947
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-(1-oxododecyl)-.omega.-[(1-oxododecyl)oxy]- (20 mol EO average molar ratio)
@@ -150969,7 +150962,6 @@ inci_functions:en: en:emulsifying, en:hair-conditioning
 inci_update_date:en: 15/10/2010
 
 en: PEG-40 HYDROGENATED TALLOW AMINE
-nl: PEG-40 HYDROGENATED CASTOR OIL PCA ISOSTEARATE Emulgator
 cas:en: 61791-26-2
 cosing:en: 36207
 einecs:en: 500-153-8
@@ -150985,21 +150977,18 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: PEG-40 JOJOBA ACID
-nl: 61791-26-2 aminen, talk-alkyl-, geëthoxyleerd
 cosing:en: 78455
 inci_description:en: Fatty acids, jojoba (Simmondsia chinensis), ethoxylated (40 mol EO average molar ratio)
 inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-40 JOJOBA ALCOHOL
-nl: PEG-40 JOJOBA ACID
 cosing:en: 78456
 inci_description:en: Alcohols, jojoba (Simmondsia chinensis), ethoxylated (40 mol EO average molar ratio)
 inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-40 LANOLIN
-nl: PEG-40 JOJOBA ALCOHOL Emulgator
 cas:en: 61790-81-6
 cosing:en: 76894
 inci_description:en: Lanolin, ethoxylated (40 mol EO average molar ratio)
@@ -151013,7 +151002,6 @@ inci_functions:en: en:solvent
 inci_update_date:en: 23/05/2014
 
 en: PEG-40 OLIVE GLYCERIDES
-nl: 61790-81-6 lanoline, geëthoxyleerd
 cas:en: 103819-46-1
 cosing:en: 76895
 inci_description:en: Glycerides, olive oil (Olea europea) mono- and di-, ethoxylated (40 mol EO average molar ratio)
@@ -151021,21 +151009,18 @@ inci_functions:en: en:emulsifying
 inci_update_date:en: 15/10/2010
 
 en: PEG-40 RICINOLEAMIDE
-nl: PEG-40 OLIVE GLYCERIDES
 cosing:en: 76896
 inci_description:en: Poly(oxy-1,2-ethanediyl), .alpha.-hydroxy-.omega.-[(12-hydroxy-1-oxo-9-(Z)-octadecenyl)amino]- (40 mol EO average molar ratio)
 inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-40 SORBITAN DIISOSTEARATE
-nl: PEG-40 RICINOLEAMIDE
 cosing:en: 76897
 inci_description:en: 1,4-Anhydro-D-glucitol, diisooctadecanoates, ethoxylated (40 mol EO average molar ratio)
 inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-40 SORBITAN LANOLATE
-nl: PEG-40 SORBITAN DIISOSTEARATE Emulgator/oppervlakteactieve stof
 cosing:en: 76898
 inci_description:en: Sorbitan, ethoxylated, esters with lanolin fatty acids (40 mol EO average molar ratio)
 inci_description:cs: Estery ethoxylovaného sorbitolu s mastnými kyselinami lanolinu (40 mol EO průměrný molární poměr)
@@ -151079,14 +151064,12 @@ inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 15/10/2010
 
 en: PEG-40 SORBITAN PEROLEATE
-nl: PEG-40 SORBITAN PERISOSTEARATE
 cosing:en: 76901
 inci_description:en: 1,4-Anhydro-D-glucitol, ethoxylated, 9-(Z)-octadecenoates (1:4) (40 mol EO average molar ratio)
 inci_functions:en: en:emulsifying, en:surfactant
 inci_update_date:en: 24/01/2011
 
 en: PEG-40 SORBITAN STEARATE
-nl: PEG-40 SORBITAN PEROLEATE Emulgator/oppervlakteactieve stof
 cas:en: 9005-67-8
 cosing:en: 76902
 inci_description:en: Sorbitan, monooctadecanoate, poly(oxy-1,2-ethanediyl) derivs. (40 mol EO average molar ratio)
@@ -159097,7 +159080,6 @@ inci_update_date:en: 15/10/2010
 wikidata:en: Q27255925
 
 en: PHOSPHORIC ACID
-fi: Ihoa hoitava aine
 cas:en: 7664-38-2
 cosing:en: 36546
 einecs:en: 231-633-2
@@ -162657,7 +162639,6 @@ inci_functions:en: en:viscosity-controlling
 inci_update_date:en: 18/04/2018
 
 en: POLYACRYLIC ACID
-fi: Kalvonmuodostaja
 cas:en: 9003-01-4
 cosing:en: 78561
 inci_description:en: 2-Propenoic acid, homopolymer
@@ -168130,7 +168111,6 @@ inci_update_date:en: 16/10/2010
 wikidata:en: Q413611
 
 en: POTASSIUM BICARBONATE
-fi: Säilöntäaine
 cas:en: 298-14-6
 cosing:en: 36935
 einecs:en: 206-059-0
@@ -169189,7 +169169,6 @@ inci_description:en: Potassium Hydrolyzed Polygamma-Glutamate is the hydrolysate
 inci_update_date:en: 24/07/2012
 
 en: POTASSIUM HYDROXIDE
-fi: Kalvonmuodostaja
 cas:en: 1310-58-3
 cosing:en: 36981
 einecs:en: 215-181-3
@@ -169234,8 +169213,6 @@ inci_update_date:en: 15/10/2010
 wikidata:en: Q27253545
 
 en: POTASSIUM IODIDE
-fi: Ihoa hoitava aine
-it: Condizionante cutaneo
 cas:en: 7681-11-0
 cosing:en: 36983
 einecs:en: 231-659-4
@@ -195637,7 +195614,6 @@ inci_update_date:en: 15/10/2010
 wikidata:en: Q407204
 
 en: SODIUM IODIDE
-fi: Säilöntäaine
 cas:en: 7681-82-5
 cosing:en: 37895
 einecs:en: 231-679-3

--- a/taxonomies/beauty/ingredients-cosing-obf.txt
+++ b/taxonomies/beauty/ingredients-cosing-obf.txt
@@ -795,7 +795,7 @@ inci_description:en: 2,3,4,4a,5,6,7,8-Octahydro-2,5,5-trimethyl-2-naphthol
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,3,6-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
+en: 2\,3\,6-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
 cas:en: 67801-27-8
 cosing:en: 41205
 einecs:en: 267-147-2
@@ -917,7 +917,7 @@ inci_description:en: 2,4,6-Trimethyl-4-phenyl-1,3-dioxane
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: 2,4,6-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
+en: 2\,4\,6-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
 cas:en: 67634-05-3
 cosing:en: 41206
 einecs:en: 266-808-2
@@ -7744,7 +7744,6 @@ inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
 en: ACETYLMETHIONYL METHYLSILANOL ELASTINATE
-sk: ACETYLMETHIONYL METYLSILANOL ELASTINATE
 cas:en: 227200-23-9
 cosing:en: 31604
 inci_description:en: Elastin, reaction products with N-acetyl-L-methionine and methylsilanetriol
@@ -12022,7 +12021,7 @@ inci_description:en: alpha, gamma, gamma-Trimethylcyclohexylpropyl Acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ALPHA\,3,3-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
+en: ALPHA\,3\,3-TRIMETHYLCYCLOHEXYLMETHYL ACETATE
 cas:en: 25225-10-9
 cosing:en: 41207
 einecs:en: 246-737-3
@@ -12030,7 +12029,7 @@ inci_description:en: alpha,3,3-Trimethylcyclohexylmethyl Acetate
 inci_functions:en: en:perfuming
 inci_update_date:en: 02/03/2011
 
-en: ALPHA\,3,3-TRIMETHYLCYCLOHEXYLMETHYL FORMATE
+en: ALPHA\,3\,3-TRIMETHYLCYCLOHEXYLMETHYL FORMATE
 cas:en: 25225-08-5
 cosing:en: 41208
 einecs:en: 246-735-2
@@ -127094,7 +127093,6 @@ el: Μεθειονίνη
 fr: Méthionine
 it: Methionine (metionina)
 lt: Metionino
-lv: Lizīns
 pl: metionina
 sk: metionín
 sl: metionin


### PR DESCRIPTION
The OBF ingredients taxonomy has broken entries (commas followed by spaces inside a chemical name) which makes it impossible to build. This PR removes the space after a comma between 2 digits.

sed -i '/^en: /s/, \([0-9]\)/,\1/g' taxonomies/beauty/ingredients-cosing-obf.txt

+ lint