### PR TITLE
feat: add misc tags for the number of uploaded images

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -1836,13 +1836,43 @@ sub compute_completeness_and_missing_tags ($product_ref, $current_ref, $previous
 	my @states_tags = ();
 
 	# Images
+	my $uploaded_images_n
+		= defined $current_ref->{uploaded_images} ? scalar keys %{$current_ref->{uploaded_images}} : 0;
+
+	# Add misc tags for ranges of uploaded images. Unlike states tags, misc tags are
+	# searchable but are not displayed in the product page footer.
+	if (defined $product_ref->{misc_tags}) {
+		$product_ref->{misc_tags}
+			= [grep {$_ !~ /^en:number-of-uploaded-images-/} @{$product_ref->{misc_tags}}];
+	}
+
+	if ($uploaded_images_n > 0) {
+		if ($uploaded_images_n <= 3) {
+			add_tag($product_ref, "misc", "en:number-of-uploaded-images-1-to-3");
+		}
+		elsif ($uploaded_images_n <= 6) {
+			add_tag($product_ref, "misc", "en:number-of-uploaded-images-4-to-6");
+		}
+		elsif ($uploaded_images_n <= 10) {
+			add_tag($product_ref, "misc", "en:number-of-uploaded-images-7-to-10");
+		}
+		elsif ($uploaded_images_n <= 50) {
+			add_tag($product_ref, "misc", "en:number-of-uploaded-images-11-to-50");
+		}
+		elsif ($uploaded_images_n <= 100) {
+			add_tag($product_ref, "misc", "en:number-of-uploaded-images-51-to-100");
+		}
+		else {
+			add_tag($product_ref, "misc", "en:number-of-uploaded-images-more-than-100");
+		}
+	}
 
 	my $complete = 1;
 	my $notempty = 0;
 	my $step = 1.0 / 10.0;    # Currently, we check for 10 items.
 	my $completeness = 0.0;
 
-	if (scalar keys %{$current_ref->{uploaded_images}} < 1) {
+	if ($uploaded_images_n < 1) {
 		push @states_tags, "en:photos-to-be-uploaded";
 		$complete = 0;
 	}

--- a/taxonomies/misc.txt
+++ b/taxonomies/misc.txt
@@ -1462,3 +1462,20 @@ uk: NutriScore - 2021 гірше - ніж 2023
 vi: NutriScore - 2021 tệ hơn 2023
 zh: NutriScore - 2021 比 2023 更差
 
+en: Number of uploaded images - 1 to 3
+fr: Nombre d'images téléversées - 1 à 3
+
+en: Number of uploaded images - 4 to 6
+fr: Nombre d'images téléversées - 4 à 6
+
+en: Number of uploaded images - 7 to 10
+fr: Nombre d'images téléversées - 7 à 10
+
+en: Number of uploaded images - 11 to 50
+fr: Nombre d'images téléversées - 11 à 50
+
+en: Number of uploaded images - 51 to 100
+fr: Nombre d'images téléversées - 51 à 100
+
+en: Number of uploaded images - More than 100
+fr: Nombre d'images téléversées - Plus de 100

--- a/tests/integration/expected_test_results/api_v3_product_images_selected/get-product-image-crop.json
+++ b/tests/integration/expected_test_results/api_v3_product_images_selected/get-product-image-crop.json
@@ -543,6 +543,7 @@
          "en:packagings-not-complete",
          "en:packagings-number-of-components-0",
          "en:storage-conditions-not-set",
+         "en:number-of-uploaded-images-1-to-3",
          "en:main-countries-new-product"
       ],
       "nova_group_debug" : "no nova group when the product does not have ingredients",

--- a/tests/integration/expected_test_results/api_v3_product_images_upload/get-product-images-after-deletion.json
+++ b/tests/integration/expected_test_results/api_v3_product_images_upload/get-product-images-after-deletion.json
@@ -75,6 +75,7 @@
       "main_countries_tags" : [],
       "max_imgid" : 2,
       "misc_tags" : [
+         "en:number-of-uploaded-images-1-to-3",
          "en:main-countries-new-product"
       ],
       "photographers_tags" : [

--- a/tests/integration/expected_test_results/api_v3_product_images_upload/get-product-images.json
+++ b/tests/integration/expected_test_results/api_v3_product_images_upload/get-product-images.json
@@ -126,6 +126,7 @@
       "main_countries_tags" : [],
       "max_imgid" : 2,
       "misc_tags" : [
+         "en:number-of-uploaded-images-1-to-3",
          "en:main-countries-new-product"
       ],
       "photographers_tags" : [

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/carrefour-images/products/3560070167470.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/carrefour-images/products/3560070167470.json
@@ -493,6 +493,7 @@
       "en:packagings-not-complete",
       "en:packagings-number-of-components-0",
       "en:storage-conditions-not-set",
+      "en:number-of-uploaded-images-1-to-3",
       "en:main-countries-new-product"
    ],
    "nova_group_debug" : "no nova group when the product does not have ingredients",

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/carrefour-images/products/3560070815746.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/carrefour-images/products/3560070815746.json
@@ -529,6 +529,7 @@
       "en:packagings-not-complete",
       "en:packagings-number-of-components-0",
       "en:storage-conditions-not-set",
+      "en:number-of-uploaded-images-4-to-6",
       "en:main-countries-new-product"
    ],
    "nova_group_debug" : "no nova group when the product does not have ingredients",

--- a/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/3270190128403.json
+++ b/tests/integration/expected_test_results/convert_and_import_excel_file/test/products/3270190128403.json
@@ -769,6 +769,7 @@
       "en:packagings-not-empty-but-not-complete",
       "en:packagings-number-of-components-1",
       "en:storage-conditions-not-set",
+      "en:number-of-uploaded-images-1-to-3",
       "en:main-countries-new-product"
    ],
    "nova_group" : 1,

--- a/tests/integration/expected_test_results/upload_images/get-product-image-crop.json
+++ b/tests/integration/expected_test_results/upload_images/get-product-image-crop.json
@@ -165,6 +165,7 @@
       "main_countries_tags" : [],
       "max_imgid" : 1,
       "misc_tags" : [
+         "en:number-of-uploaded-images-1-to-3",
          "en:main-countries-new-product"
       ],
       "photographers_tags" : [

--- a/tests/integration/expected_test_results/upload_images/get-product-image-new-structure.json
+++ b/tests/integration/expected_test_results/upload_images/get-product-image-new-structure.json
@@ -112,6 +112,7 @@
       "main_countries_tags" : [],
       "max_imgid" : 1,
       "misc_tags" : [
+         "en:number-of-uploaded-images-1-to-3",
          "en:main-countries-new-product"
       ],
       "photographers_tags" : [

--- a/tests/integration/expected_test_results/upload_images/get-product-image.json
+++ b/tests/integration/expected_test_results/upload_images/get-product-image.json
@@ -104,6 +104,7 @@
       "main_countries_tags" : [],
       "max_imgid" : 1,
       "misc_tags" : [
+         "en:number-of-uploaded-images-1-to-3",
          "en:main-countries-new-product"
       ],
       "photographers_tags" : [

--- a/tests/integration/expected_test_results/upload_images/get-same-image-twice.json
+++ b/tests/integration/expected_test_results/upload_images/get-same-image-twice.json
@@ -104,6 +104,7 @@
       "main_countries_tags" : [],
       "max_imgid" : 1,
       "misc_tags" : [
+         "en:number-of-uploaded-images-1-to-3",
          "en:main-countries-new-product"
       ],
       "photographers_tags" : [

--- a/tests/unit/expected_test_results/products/compute_completeness_and_missing_tags_beauty.json
+++ b/tests/unit/expected_test_results/products/compute_completeness_and_missing_tags_beauty.json
@@ -14,6 +14,9 @@
    "ingredients_text" : "Aqua, Sodium Laureth Sulfate",
    "lang" : "en",
    "lc" : "en",
+   "misc_tags" : [
+      "en:number-of-uploaded-images-1-to-3"
+   ],
    "origins" : "France",
    "origins_tags" : [
       "en:france"

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -403,4 +403,42 @@ my $beauty_product_ref = $tests[1][1];
 is([grep {/^en:nutrition/} @{$beauty_product_ref->{states_tags}}], [], 'beauty products do not have nutrition states');
 is($beauty_product_ref->{complete}, 1, 'beauty products can be complete without nutrition facts and photo');
 
+my @uploaded_images_misc_tags_tests = (
+	[0, []],
+	[1, ['en:number-of-uploaded-images-1-to-3']],
+	[3, ['en:number-of-uploaded-images-1-to-3']],
+	[4, ['en:number-of-uploaded-images-4-to-6']],
+	[6, ['en:number-of-uploaded-images-4-to-6']],
+	[7, ['en:number-of-uploaded-images-7-to-10']],
+	[10, ['en:number-of-uploaded-images-7-to-10']],
+	[11, ['en:number-of-uploaded-images-11-to-50']],
+	[50, ['en:number-of-uploaded-images-11-to-50']],
+	[51, ['en:number-of-uploaded-images-51-to-100']],
+	[100, ['en:number-of-uploaded-images-51-to-100']],
+	[101, ['en:number-of-uploaded-images-more-than-100']],
+);
+
+foreach my $test_ref (@uploaded_images_misc_tags_tests) {
+	my ($uploaded_images_n, $expected_tags_ref) = @$test_ref;
+	my %uploaded_images = ();
+	foreach my $imgid (1 .. $uploaded_images_n) {
+		$uploaded_images{$imgid} = 1;
+	}
+	my $product_ref = {misc_tags => ['en:unrelated-tag', 'en:number-of-uploaded-images-4-to-6'],};
+	my $current_ref = {
+		uploaded_images => \%uploaded_images,
+		selected_images => {},
+	};
+
+	compute_completeness_and_missing_tags($product_ref, $current_ref, {});
+
+	is(
+		$product_ref->{misc_tags},
+		['en:unrelated-tag', @$expected_tags_ref],
+		"misc tags for $uploaded_images_n uploaded images preserve unrelated tag order"
+	);
+	is([grep {/^en:number-of-uploaded-images-/} @{$product_ref->{states_tags}}],
+		[], 'uploaded image count tags are not exposed as product states');
+}
+
 done_testing();


### PR DESCRIPTION
### What

- Add searchable `misc` tags to filter products by the number of uploaded photos, e.g. `/misc/number-of-uploaded-images-1-to-3`.
- One exclusive range tag per product, computed in `compute_completeness_and_missing_tags()`: `1-to-3`, `4-to-6`, `7-to-10`, `11-to-50`, `51-to-100`, `more-than-100`. Previous `en:number-of-uploaded-images-*` tags are removed before adding the new one, so the tag stays correct when images are added or deleted.
- Add `en`/`fr` entries for the 6 tags to the misc taxonomy (other languages to come via Crowdin).
- Unit tests cover all bucket boundaries, removal of stale tags, and preservation of unrelated misc tags.

_Existing products get the tag when they are next saved. To backfill all products, update_all_products.pl must be run with --compute-history; --analyze-and-enrich-product-data alone does not compute this tag._

### Related issue(s) and discussion

- Fixes: #302
