### PR TITLE
chore(taxonomy): drop `simple` language lines

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -11369,7 +11369,6 @@ nutriscore_red_meat:en: yes
 # sat:ᱥᱟᱫᱚᱢ
 # scn:cavaddu
 # sco:horse
-# simple:horse
 # srn:asi (pardi)
 # stq:hoangst (suugediert)
 # szl:kůń
@@ -20070,7 +20069,6 @@ ur: شیری
 vi: sherry
 zh: 雪利酒
 # frr:sherry
-# simple:sherry
 # zh_yue:些厘酒
 wikidata:en: Q16398
 wikipedia:en: https://en.wikipedia.org/wiki/Sherry
@@ -43709,7 +43707,6 @@ eurocode_2_group_3:en: 9.30.28
 # hsb:žołty ćernjowc
 # olo:muur'oi
 # sah:бөллөхүнэ
-# simple:cloudberry
 # species:rubus chamaemorus
 # vep:murašk
 # war:rubus chamaemorus
@@ -87285,7 +87282,6 @@ vegan:en: maybe
 vegetarian:en: maybe
 # ast:creatina
 # azb:کراتین فوسفات
-# simple:creatine
 wikidata:en: Q223600
 wikipedia:en: https://en.wikipedia.org/wiki/Creatine
 
@@ -91667,7 +91663,6 @@ ru: лингуине
 sv: linguine, linguini, linguinipasta
 th: ลิงกวีเน
 uk: лінґвіне
-# simple:linguine
 # zh_yue:扁意粉
 wikidata:en: Q20035
 wikipedia:en: https://en.wikipedia.org/wiki/Linguine
@@ -92088,7 +92083,6 @@ uk: начос
 vi: nacho
 zh: 烤乾酪辣味玉米片
 # be_x_old:начас
-# simple:nachos
 wikidata:en: Q466430
 wikipedia:en: https://en.wikipedia.org/wiki/Nachos
 
@@ -92614,7 +92608,6 @@ vi: bánh mì pháp
 zh: 法式长棍面包
 # arz:عيش فرنسى
 # lfn:bagete
-# simple:baguette
 # zh_yue:百吉包
 wikidata:en: Q208172
 wikipedia:en: https://en.wikipedia.org/wiki/Baguette
@@ -96596,7 +96589,6 @@ description:es: La salsa bearnesa es una salsa emulsionada a base de mantequilla
 description:fr: La sauce béarnaise, ou la béarnaise, est une sauce émulsifiée chaude à base de beurre clarifié, de jaune d'œuf, d'échalote, d'estragon et de cerfeuil, servie pour relever les viandes.
 description:it: La salsa bernese o salsa bearnaise o semplicemente la bernese, è una salsa di condimento.
 description:nl: Bearnaisesaus is een saus gemaakt van opgeklopte boter en eigeel met toevoeging van een gastrique, bestaande uit wijn, azijn, dragon, mignonettes, kervel, bouquet garni en sjalotten.
-# simple:béarnaise sauce
 # zh_yue:賓利士汁
 wikidata:en: Q58265
 wikipedia:en: https://en.wikipedia.org/wiki/B%C3%A9arnaise_sauce
@@ -96645,7 +96637,6 @@ description:pt: Pesto é um molho italiano composto tradicionalmente de folhas d
 # lij:pesto
 # nap:pisto
 # sco:pesto
-# simple:pesto
 # zh_yue:羅勒醬
 wikidata:en: Q9896
 wikipedia:en: https://en.wikipedia.org/wiki/Pesto


### PR DESCRIPTION
I previously removed all not-commented-out `simple` language lines, but just found that there are still a few commented-out `simple` language statements. From the previous PR/commit:

> The `simple` language entries are probably a remnant from a Wikipedia/Wikidata import, as `simple` is a Wikimedia language code used for “simplified English”. We don’t use that in OFF, so let’s drop them.

Command-used: `sed --follow-symlinks -u -i -E '/^#\\s*simple:/d' taxonomies/**.txt`
Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/12503
Follow-up-to: 57d30f74009f43616344e3f4cd87e7ee6bf02262