### PR TITLE
taxonomy(additives): Add Swedish variant of E425(i)

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -12074,7 +12074,7 @@ ro: E425(i), Gumă konjac
 ru: E425(i), загуститель конжаковая камедь
 sk: E425(i), Konjaková guma
 sl: E425(i), Konjac gumi
-sv: E425(i), Konjakgummi
+sv: E425(i), Konjakgummi, Konjaksgummi
 additives_classes:en: en:carrier, en:emulsifier, en:humectant, en:stabiliser, en:thickener
 e_number:en: 425
 


### PR DESCRIPTION
I think this producer adds a binding 's' here for some reason.

Needed-for: https://se.openfoodfacts.org/product/7350037192548/chorizo-peas-of-heaven
