### PR TITLE
feat(lint_taxonomy): catch “comment” typos

### DIFF
--- a/scripts/taxonomies/lint_taxonomy.pl
+++ b/scripts/taxonomies/lint_taxonomy.pl
@@ -210,6 +210,22 @@ sub iter_taxonomy_entries ($lines_iter) {
 						}
 					);
 				}
+				# detect “comment” typos
+				if ($prop =~ /^[coment]{6,8}$/ && $prop ne "comment") {
+					push(
+						@errors,
+						{
+							severity => "Warning",
+							type => "Correctness",
+							line => $line_num,
+							message => (
+									  "\"$prop\" might be a typo of \"comment\":\n" . "- "
+									. $props{"$prop:$lc"}->{line}
+									. "\n- $line"
+							)
+						}
+					);
+				}
 				# override to continue
 				$props{"$prop:$lc"}
 					= {line => $line, previous => [@previous_lines], line_num => $line_num, type => "property"};


### PR DESCRIPTION
I’ve seen `comment` taxonomy properties being typo’d a few times by now, sometimes even making it past review. It would be nice to catch them when linting. :)

This looks at property names between 6 and 8 characters (in case a character was added (“commentt”) or missed (“coment”) by mistake) and if it consists of the same letters as “comment” but doesn’t equal `comment`, then push a warning to notify about this.

As of this commit, there are 61 lines matching the regular expression, 0 of which are not “comment”:
```sh
$ rg -e '^[coment]{6,8}:' taxonomies/*.txt|wc -l
61
$ rg -I -e '^[coment]{6,8}:' taxonomies/*.txt|rg -v -e '^comment:' -|wc -l
0
```