### PR TITLE
taxonomy(food): dill seed edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -74531,6 +74531,21 @@ agribalyse_proxy_food_code:en: 11060
 agribalyse_proxy_food_name:en: Provence herbs, dried
 agribalyse_proxy_food_name:fr: Herbes de Provence, séchées
 
+< en: Seeds
+< en: Spices
+en: Dill seeds
+da: Dildfrø
+de: Dillsaat
+es: Semillas de eneldo
+fr: Graines d'aneth
+hr: Sjeme kopra
+it: Semi di aneto
+nb: Dillfrø
+nl: Dillezaad
+nn: Dillfrø
+sv: Dillfrön
+wikidata:en: Q139678670
+
 < en: Plant-based foods
 en: Fresh chervil, Garden chervil products, Garden chervil, Chervil
 bg: Керевиз

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -74545,6 +74545,8 @@ nb: Dillfrø
 nl: Dillezaad
 nn: Dillfrø
 sv: Dillfrön
+ciqual_proxy_food_code:en: 11064
+ciqual_proxy_food_name:en: Caraway, seed
 wikidata:en: Q139678670
 
 < en: Plant-based foods

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -74537,6 +74537,7 @@ en: Dill seeds
 da: Dildfrø
 de: Dillsaat
 es: Semillas de eneldo
+fi: Tillinsiemen
 fr: Graines d'aneth
 hr: Sjeme kopra
 it: Semi di aneto

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -69541,20 +69541,19 @@ usda_ndb_name:en: Spices, dill weed, dried
 
 < en: dill
 en: dill seed, dill seeds
+da: dildfrø
 de: Dillsaat
 es: semillas de eneldo
-fr: Graines d'aneth
+fr: graines d'aneth
 hr: sjeme kopra
 it: semi di aneto
+nb: dillfrø
 nl: dillezaad
+nn: dillfrø
+sv: dillfrö, dillfrön
 usda_ndb_code:en: 2016
 usda_ndb_name:en: Spices, dill seed
-#184 @2021-09-16
-
-#<en:dill
-#en:organic dill seed
-#fi:luomu tillinsiemen
-#nl:biologisch dillezaad
+wikidata:en: Q139678670
 
 #processing:en: en:dried
 #<en:dill

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -69552,6 +69552,8 @@ nb: dillfrø
 nl: dillezaad
 nn: dillfrø
 sv: dillfrö, dillfrön
+ciqual_proxy_food_code:en: 11064
+ciqual_proxy_food_name:en: Caraway, seed
 usda_ndb_code:en: 2016
 usda_ndb_name:en: Spices, dill seed
 wikidata:en: Q139678670

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -69544,6 +69544,7 @@ en: dill seed, dill seeds
 da: dildfrø
 de: Dillsaat
 es: semillas de eneldo
+fi: tillinsiemen
 fr: graines d'aneth
 hr: sjeme kopra
 it: semi di aneto


### PR DESCRIPTION
- Adds dill seeds category.
- Adds da, sv, nb/nn translations.
- Synchronises translations between ingredient and category.
- Normalises ingredients towards lower-case forms.
- Adds `wikidata` property.
- Removes some comment lines.
  - Adds Finnish translation into the taxons.
- Adds `ciqual_proxy_food_*` properties

Re: the `ciqual_proxy_food_*` properties:
Caraway seeds seem to be one of the closest nutrition-wise to dill seeds, based on comparing https://foodnutrients.org/nutrients/dill-seed/ and https://foodnutrients.org/nutrients/caraway-seed/ – with the caveat that I have only done superficial visual analysis and I don’t know the reliability of the source website (though it claims to use USDA data).

It might be possible to get a better match by running an actual analysis on the USDA data and see what gets “closest” to dill seeds and also exists in Ciqual.

Needed-for: https://se.openfoodfacts.org/product/7350046460508/dillfr%C3%B6n-kockens