### PR TITLE
taxonomy(labels): Add alder wood smoking, Swedish variants

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -20890,7 +20890,11 @@ he: מעושן עם עץ אשור
 hu: Bükkfán füstölt
 it: Affumicato con legno di faggio
 pt: Defumado em madeira de faia, defumada em madeira de faia, fumado em madeira de faia, fumada em madeira de faia
-sv: Bokspånsrökt
+sv: bokspånsrökt, bokspånsrökta, rökt med bokspån, rökta med bokspån
+
+< en: Smoked with beech wood
+en: Smoked with Swedish beech wood
+sv: rökt med svenskt bokspån, rökta med svenskt bokspån
 
 en: Smoked with oak wood
 fi: savustettu tammella, tammella savustettu
@@ -20898,6 +20902,18 @@ fr: Fumé au bois de chêne, fumage au bois de chêne
 he: מעושן בעץ אלון
 hu: Tölgyfán füstölt
 pt: Defumado em madeira de carvalho, defumada em madeira de carvalho, fumado em madeira de carvalho, fumada em madeira de carvalho
+sv: ekspånsrökt, ekspånsrökta, rökt med ekspån, rökta med ekspån
+
+< en: Smoked with oak wood
+en: Smoked with Swedish oak wood
+sv: rökt med svenskt ekspån, rökta med svenskt ekspån
+
+en: Smoked with alder wood
+sv: alspånsrökt, alspånsrökta, rökt med alspån, rökta med alspån
+
+< en: Smoked with alder wood
+en: Smoked with Swedish alder wood
+sv: rökt med svenskt alspån, rökta med svenskt alspån
 
 fr: Fumage naturel, fumé naturellement
 pt: Defumado natural, fumado natural, naturalmente defumado, naturalmente fumado


### PR DESCRIPTION
Swedish labels often specify that something is smoked using Swedish wood.

Needed-for: https://se.openfoodfacts.org/product/7332040302114/ekologisk-tofu-alsp%C3%A5nsr%C3%B6kt-yipin


