### PR TITLE
taxonomy(food): juniper berry edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -10037,16 +10037,11 @@ nl: Honeybush
 wikidata:en: Q1627092
 
 < en: Herbal teas
-en: Juniper berries
-de: Wacholderbeere
-es: Bayas de enebro
-fr: Baies de genévrier
-hr: Bobice kleke
-hu: Borókabogyó
-la: Juniperus communis
-lt: Kadagio uogos
-nl: Jeneverbes, Jeneverbessen
-wikidata:en: Q3251025
+en: Juniper berry teas
+da: Enebærsteer
+nb: Einebærteer, Einerbærteer
+nn: Einebærtear, Einerbærtear
+sv: Enbärsteer
 
 < en: Herbal teas
 en: Lavender
@@ -10060,7 +10055,7 @@ ja: ラベンダー
 la: Lavandula spica, Lavandula angustifolia
 lt: Levanda
 nl: Lavendel
-pl: Jałowiec, Owoce jałowca
+pl: Lawenda
 ro: Levănțică, Lavandă
 wikidata:en: Q42081
 
@@ -74586,6 +74581,60 @@ lt: Isopas, juozažolė
 nl: Hyssoppen
 pl: Hyzop lekarski
 wikidata:en: Q137931
+
+< en: Aromatic plants
+en: Juniper berries
+af: Jenewerbessie
+ar: توت العرعر
+be: Ядловец
+br: Jenevra
+bs: Juniper
+ca: Ginebró
+cs: Jalovčinka
+da: Enebær
+de: Wacholderbeeren
+es: Bayas de enebro
+et: Marikäbi
+fa: جونیپر بری
+fi: Katajanmarjat, Katajanmarja
+fr: Baies de genévrier
+hr: Bobice kleke, Bobica kleke
+hu: Borókabogyó
+hy: Գիհու հատապտուղ
+id: Juniper beri
+it: Coccola di ginepro
+ja: 杜松果
+jv: Bèri juniper
+ko: 두송자
+la: Juniperi pseudo-fructus, Juniperus communis
+lt: Kadagio uogos
+lv: Čiekuroga
+mk: Смрекинка
+ml: ജൂനിപ്പർ കായ
+mt: Frotta tal-ġnibru
+nb: Einebær, Einerbær
+nl: Jeneverbes, Jeneverbessen, Bessen van de jeneverbes
+nn: Einebær, Einerbær
+pl: Owoce jałowca, Owoc jałowca, Jałowiec
+pt: Semente de zimbro, Baga de zimbro
+ro: Boabă de ienupăr
+ru: Можжевельник
+sl: Brinova jagoda
+sv: Enbär
+tw: Juniper nnuaba a wɔfrɛ no berry
+uk: Ялівець
+uz: Archa mevasi
+vi: Bách xù
+zh: 杜松子
+description:en: A JUNIPER BERRY is the female seed cone produced by the various species of junipers. Juniper berries are used in northern European and particularly Scandinavian cuisine to "impart a sharp, clear flavor" to meat dishes. Besides Norwegian and Swedish dishes, juniper berries are also sometimes used in German, Austrian, Czech, Polish and Hungarian cuisine, often with roasts (such as German sauerbraten). Northern Italian cuisine, especially that of the South Tyrol, also incorporates juniper berries.
+wikidata:en: Q3251025
+
+< en: Dried aromatic plants
+< en: Juniper berries
+< en: Spices
+en: Dried juniper berries
+da: Tørrede enebær
+sv: Torkade enbär
 
 < en: Aromatic herbs
 en: Marjoram

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -72223,107 +72223,134 @@ en: jasmine petals
 fr: pétales de jasmin
 it: petali di gelsomino
 
-# description:en:JUNIPERS are coniferous plants in the genus Juniperus of the cypress family Cupressaceae. Juniper berries are a spice used in a wide variety of culinary dishes and best known for the primary flavoring in gin. Juniper berry sauce is often a popular flavoring choice for quail, pheasant, veal, rabbit, venison and other game dishes.
-# comment:en:Juniper as an ingredient most certainly implies a juniper berry.
-
 < en: plant
 en: juniper
 ar: عرعر شائع
-az: Adi ardıc
-ba: Артыш
-be: Ядловец звычайны
+az: adi ardıc
+ba: артыш
+be: ядловец звычайны
 bg: обикновена хвойна
-br: Jenevreg-boutin
-bs: Smreka
+br: jenevreg-boutin
+bs: smreka
 ca: ginebre comú
+co: ghjinepara
 cs: jalovec obecný
-cy: Merywen
-da: almindelig ene
-de: Wacholder, Wachholder
+cv: уртăш йывăççи
+cy: merywen
+da: enebærbusk, almindelig ene
+de: Wacholder, Wachholder, Gemeiner Wacholder
 el: άρκευθος
-eo: Ordinara junipero
-es: enebro
+eo: ordinara junipero
+es: enebro, enebro común
 et: kadakas, harilik kadakas
-eu: Ipar-ipuru
+eu: ipar-ipuru
 fa: پیرو
 fi: kataja
-fo: Baraldur
-fr: genièvre
+fo: baraldur
+fr: genièvre, genévrier commun
 ga: aiteal
-gl: Xenebreiro
+gl: xenebreiro
 he: ערער מצוי
 hr: obična borovica, borovica
 hu: közönséges boróka
 hy: գիհի ցածրաաճ
-is: Einir
+is: einir
 it: ginepro
 ja: セイヨウネズ
-kl: Kakillarnaq
+ka: ჩვეულებრივი ღვია
+kl: kakillarnaq
+ko: 두송
 la: Juniperus communis
-lt: Paprastasis kadagys
-lv: Parastais kadiķis
+lb: Wakelter
+lt: paprastasis kadagys
+lv: parastais kadiķis
 mk: обична смрека
-nb: einer
-nl: Jeneverbes
-nn: eine
-pl: jałowiec, jałowca, jałowcowy, jałowcowa, jałowcowe
-pt: zimbro
+nb: einerbusk, einebusk, einer
+nl: jeneverbes
+nn: einebusk, einerbusk, eine
+os: хуымæтæджы æхсæлы
+pl: jałowiec, jałowca, jałowcowy, jałowcowa, jałowcowe, jałowiec pospolity
+pt: zimbro, zimbro-rasteiro
+rm: ginaiver cumin
 ro: ienupăr
-ru: Можжевельник обыкновенный
-se: Reatká
-sh: Kleka
-sk: Borievka obyčajná
-sl: Navadni brin
-sq: Dëllinja
-sr: Клека
-sv: En
-tr: Adi ardıç
-tt: Артыш
-uk: Ялівець звичайний
+ru: можжевельник обыкновенный
+se: reatká
+sh: kleka
+sk: borievka obyčajná
+sl: navadni brin
+sq: dëllinja
+sr: клека
+su: juniper beri
+sv: enbuske
+tr: adi ardıç
+tt: артыш
+uk: ялівець звичайний
+wa: franc pectî
 zh: 刺柏
-# azb:عادی آردیج
-# bar:Kranawitt
-# be-tarask:Ядловец звычайны
-# csb:Zwëczajny jałówc
-# frr:Algemian wacholder
-# hsb:Holanski jałorc
-# koi:Верӧс
-# nap:Inipr
-# nds-nl:Jeneverbees
-# pnb:عام صنوبر
-# sgs:Ieglis
-# stq:Wacholder
-# vro:Katai
-# war:Franc pectî
+#azb: عادی آردیج
+#bar: Kranawitt
+#be-tarask: Ядловец звычайны
+#csb: Zwëczajny jałówc
+#frr: Algemian wacholder
+#hsb: Holanski jałorc
+#koi: Верӧс
+#nap: Inipr
+#nds-nl: Jeneverbees
+#pnb: عام صنوبر
+#sgs: Ieglis
+#stq: Wacholder
+#vro: Katai
+#war: Franc pectî
+comment:en: Juniper as an ingredient most certainly implies a juniper berry.
+description:en: JUNIPERS are coniferous plants in the genus Juniperus of the cypress family Cupressaceae. Juniper berries are a spice used in a wide variety of culinary dishes and best known for the primary flavoring in gin. Juniper berry sauce is often a popular flavoring choice for quail, pheasant, veal, rabbit, venison and other game dishes.
 wikidata:en: Q26325
 wikipedia:en: https://en.wikipedia.org/wiki/Juniper
 
-# description:en:A JUNIPER BERRY is the female seed cone produced by the various species of junipers. Juniper berries are used in northern European and particularly Scandinavian cuisine to "impart a sharp, clear flavor" to meat dishes. Besides Norwegian and Swedish dishes, juniper berries are also sometimes used in German, Austrian, Czech, Polish and Hungarian cuisine, often with roasts (such as German sauerbraten). Northern Italian cuisine, especially that of the South Tyrol, also incorporates juniper berries.
-
 < en: juniper
 en: juniper berry, juniper berries
-af: Jenewerbessie
-be: Ядловец
+af: jenewerbessie
+ar: توت العرعر
+be: ядловец
+br: jenevra
+bs: juniper
+ca: ginebró
+cs: jalovčinka
 da: enebær
 de: Wacholderbeere, Wacholderbeeren
-es: baya de enebro
+es: baya de enebro, bayas de enebro
+et: marikäbi
 fa: جونیپر بری
 fi: katajanmarja, katajanmarjat
-fr: baies de genièvre
-hr: bobica kleke
+fr: baies de genièvre, baies de genévrier
+hr: bobica kleke, bobice kleke
+hu: borókabogyó
+hy: գիհու հատապտուղ
+id: juniper beri
 it: coccola di ginepro
+ja: 杜松果
+jv: bèri juniper
 ko: 두송자
-lv: Čiekuroga
+la: Juniperi pseudo-fructus
+lt: kadagio uogos
+lv: čiekuroga
 mk: смрекинка
 ml: ജൂനിപ്പർ കായ
 mt: frotta tal-ġnibru
-nl: bessen van de jeneverbes
+nb: einebær, einerbær
+nl: bessen van de jeneverbes, jeneverbessen
+nn: einebær, einerbær
 pl: owoc jałowca, owoce jałowca
-pt: semente de zimbro, Baga de zimbro
-ru: Можжевельник
+pt: semente de zimbro, baga de zimbro
+ro: boabă de ienupăr
+ru: можжевельник
+sl: brinova jagoda
 sv: enbär
-uk: Ялівець
+tw: juniper nnuaba a wɔfrɛ no berry
+uk: ялівець
+uz: archa mevasi
+vi: bách xù
 zh: 杜松子
+description:en: A JUNIPER BERRY is the female seed cone produced by the various species of junipers. Juniper berries are used in northern European and particularly Scandinavian cuisine to "impart a sharp, clear flavor" to meat dishes. Besides Norwegian and Swedish dishes, juniper berries are also sometimes used in German, Austrian, Czech, Polish and Hungarian cuisine, often with roasts (such as German sauerbraten). Northern Italian cuisine, especially that of the South Tyrol, also incorporates juniper berries.
 wikidata:en: Q3251025
 wikipedia:en: https://en.wikipedia.org/wiki/Juniper_berry
 


### PR DESCRIPTION
The juniper berries category is currently under herbal teas, even if they are (probably more) commonly used as a spice.

- Adds new juniper berry teas category.
- Adds new dried juniper berries category.
- Moves juniper berries category to be a child of aromatic plants.
- Adds da, sv, nb/nn translations.
- Imports some ingredient translations from Wikidata.
- Normalises ingredients towards lower-case singular forms.
- Moves commented-out properties into proper properties.
- Synchronises translations and other properties between ingredients and categories.

Needed-for: https://se.openfoodfacts.org/product/7310394002218/enb%C3%A4r-kockens