### PR TITLE
fix: render EAN barcodes with the correct format

### DIFF
--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -180,7 +180,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="[% IF code.length == 13 %]EAN13[% ELSIF code.length == 8 %]EAN8[% ELSE %]CODE128[% END %]"
                                         jsbarcode-value="[% code %]"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">

--- a/templates/web/pages/product/product_page.tt.html
+++ b/templates/web/pages/product/product_page.tt.html
@@ -187,7 +187,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="[% code %]" datatype="xsd:string"></div>
                         [% ELSE %]
                          [%# put in DOM for folksonomy %]

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -589,7 +589,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="EAN13"
                                         jsbarcode-value="0200000000235"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -596,7 +596,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="0200000000235" datatype="xsd:string"></div>
                         
 

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -589,7 +589,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="EAN13"
                                         jsbarcode-value="0200000000235"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -596,7 +596,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="0200000000235" datatype="xsd:string"></div>
                         
 

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -596,7 +596,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="3300000000002" datatype="xsd:string"></div>
                         
 

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -589,7 +589,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="EAN13"
                                         jsbarcode-value="3300000000002"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">

--- a/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
@@ -598,7 +598,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="3300000000002" datatype="xsd:string"></div>
                         
 

--- a/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
@@ -591,7 +591,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="EAN13"
                                         jsbarcode-value="3300000000002"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -596,7 +596,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="3300000000001" datatype="xsd:string"></div>
                         
 

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -589,7 +589,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="EAN13"
                                         jsbarcode-value="3300000000001"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">

--- a/tests/integration/expected_test_results/web_html/world-product-content-only.html
+++ b/tests/integration/expected_test_results/web_html/world-product-content-only.html
@@ -297,7 +297,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="EAN13"
                                         jsbarcode-value="3300000000001"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">

--- a/tests/integration/expected_test_results/web_html/world-product-content-only.html
+++ b/tests/integration/expected_test_results/web_html/world-product-content-only.html
@@ -304,7 +304,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="3300000000001" datatype="xsd:string"></div>
                         
 

--- a/tests/integration/expected_test_results/web_html/world-product-smoothie.html
+++ b/tests/integration/expected_test_results/web_html/world-product-smoothie.html
@@ -297,7 +297,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="EAN13"
                                         jsbarcode-value="3300000000001"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">

--- a/tests/integration/expected_test_results/web_html/world-product-smoothie.html
+++ b/tests/integration/expected_test_results/web_html/world-product-smoothie.html
@@ -304,7 +304,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="3300000000001" datatype="xsd:string"></div>
                         
 

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -596,7 +596,24 @@
                                     </svg>
                                 </div>
                             </div>
-                            <script>if (screen && screen.width >= 600) JsBarcode("#barcode_svg").init()</script>
+                            <script>
+                            if (screen && screen.width >= 600) {
+                                var barcodeSvg = document.getElementById("barcode_svg");
+                                try {
+                                    JsBarcode(barcodeSvg).init();
+                                }
+                                catch (e) {
+                                    // JsBarcode refuses to render EAN13/EAN8 values with an invalid
+                                    // check digit (internal codes assigned by assign_new_code(), typos...),
+                                    // fall back to CODE128 so that the barcode is still displayed.
+                                    JsBarcode(barcodeSvg, barcodeSvg.getAttribute("jsbarcode-value"), {
+                                        format: "CODE128",
+                                        displayValue: false,
+                                        height: 40
+                                    });
+                                }
+                            }
+                            </script>
                             <div property="gr:hasEAN_UCC-13" content="3300000000001" datatype="xsd:string"></div>
                         
 

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -589,7 +589,7 @@
                                 <!-- Display with SVG if not mobile -->
                                 <div id="barcode_div_svg">
                                     <svg id="barcode_svg"
-                                        jsbarcode-format="auto"
+                                        jsbarcode-format="EAN13"
                                         jsbarcode-value="3300000000001"
                                         jsbarcode-displayValue="false"
                                         jsbarcode-height="40">


### PR DESCRIPTION
## Summary

- render 13-digit product codes as EAN-13;
- render 8-digit product codes as EAN-8;
- keep Code 128 as the fallback for non-standard or internal product codes;
- update the affected HTML integration snapshots.

## Context

The product page currently uses JsBarcode with the `auto` format. JsBarcode does not detect EAN formats automatically: when Code 128 is available, `auto` selects it. As a result, a product such as [3600542656733](https://fr.openbeautyfacts.org/produit/3600542656733) is labelled as EAN-13 but displayed as Code 128.

The barcode is generated as an SVG in the browser, so this change does not require any product recomputation or data migration.

## Tests

- `git diff --check`
- verified that JsBarcode 3.12.3 accepts `3600542656733` as EAN-13 and produces the expected 95-module encoding;
- updated the expected HTML integration results.