### PR TITLE
taxonomy(food): caraway (seed) edits

### DIFF
--- a/.test_groups_cache/unit_groups.mk
+++ b/.test_groups_cache/unit_groups.mk
@@ -6,12 +6,3 @@ UNIT_GROUP_3_TESTS := all_pod_correct.t auth_oidc_cache.t convert_gs1_xml_to_jso
 UNIT_GROUP_4_TESTS := allergens.t auth_oidc_state_validation.t cursor.t display.t forest_footprint_2026.t import_gs1.t ingredients_nesting.t ingredients_tags.t nova.t nutrition_estimation.t paths.t products_comparison.t send_image_to_cloud_vision.t taxonomies.t texts.t
 UNIT_GROUP_5_TESTS := allergens_tags.t booleans.t data_quality_tags_panel.t environmental_impact.t health.t ingredients.t ingredients_nutriscore.t knowledge_panels.t numbers.t packager_codes.t process_product_edit_rules.t products_tags.t spam_user.t taxonomies_enhancer.t units.t
 UNIT_GROUP_6_TESTS := analyze_and_enrich_product_data.t brevo.t dataquality.t environmental_score.t i18n.t ingredients_analysis.t ingredients_parsing_todo.t lang.t nutrient_levels.t packaging.t producers.t recipes.t storage_conditions.t taxonomy_suggestions.t vitamins.t
-
-# Group Statistics:
-# Group 1: 15 tests, 7m 30s
-# Group 2: 15 tests, 7m 30s
-# Group 3: 15 tests, 7m 30s
-# Group 4: 15 tests, 7m 30s
-# Group 5: 15 tests, 7m 30s
-# Group 6: 15 tests, 7m 30s
-# Max group time: 8m, Min: 8m, Avg: 8m

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -76521,7 +76521,7 @@ ar: كمون
 bg: Кимион
 ca: Comí, Comí castellà
 da: Spidskommen
-de: Kümmel, Kreuzkümmel
+de: Kreuzkümmel
 eo: Oficina kuminoj
 es: Comino
 fi: juustokumina
@@ -76582,17 +76582,65 @@ ciqual_food_name:fr: Cumin, graine
 wikidata:en: Q57328174
 
 < en: Aromatic herbs
+< en: Spices
 en: Caraway seeds
-es: semillas de alcaravea
-fr: Graines de carvi
+ca: Llavors d'alcaravia
+cs: Kmín
+da: Kommenfrø, Kommen
+de: Kümmelsamen, Kümmel
+es: Semillas de alcaravea
+et: Köömned
+fi: Kumina
+fr: Carvi
 hr: Sjemenke kima
+id: Jintan
+it: Seme di cumino dei prati
+ja: キャラウェイシード
+la: Carvi fructus
 lt: Kmynų sėklos
+lv: Ķimeņu sēklas
+nl: Karwijzaad
 pl: Kminek
+ro: Semințe de chimen
+ru: Семена тмина
+sl: Seme navadne kumine
+sv: Kumminfrön, Kummin
+yi: קימל זוימען
+zh: 葛缕子, 葛缕子籽, 葛縷子, 葛縷子籽
 agribalyse_food_code:en: 11064
 ciqual_food_code:en: 11064
 ciqual_food_name:en: Caraway, seed
 ciqual_food_name:fr: Carvi, graine
+comment:en: Caraway “seeds” are actually the fruits of the caraway plant.
 wikidata:en: Q21155816
+
+< en: Caraway seeds
+en: Whole caraway seeds
+da: Hele kommenfrø
+de: Ganze Kümmelsamen
+es: Semillas de alcaravea en grano
+fr: Graines de carvi
+hr: Cijele sjemenke kima
+nl: Grove karwijzaden
+sv: Hela kumminfrön
+
+< en: Caraway seeds
+< en: Ground dried aromatic plants
+en: Ground caraway seeds, Ground dried caraway seeds
+da: Malede kommenfrø, Malet kommen
+es: Semillas de alcaravea molido
+fr: Graines de carvi moulu
+hr: Mljevene sjemenke kima
+lt: Maltos kmynų sėklos
+nl: Gemalen karwijzaad
+sv: Malna kumminfrön, Malen kummin, Kummin malen
+
+< en: Ground caraway seeds
+en: Caraway seed powders, Caraway powders
+da: Kommenfrøpulvere, Kommenpulvere
+es: Semillas de alcaravea en polvo
+fr: Carvi en poudre
+sv: Kumminfrönpulver, Kumminpulver
 
 < en: Plant-based foods
 en: Fenugreek products, Fenugreek

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -67430,8 +67430,8 @@ comment:en: The wikidata entry is a mix of plant, seed and latin name.
 description:en: CARAWAY (Carum carvi), is a biennial plant in the family Apiaceae. The fruits, usually used whole, have a pungent, anise-like flavor. Caraway is used as a spice in breads, especially rye bread. Caraway is also used in desserts, liquors, casseroles, and other foods.
 usda_ndb_proxy_code:en: 2005
 usda_ndb_proxy_name:en: Spices, caraway seed
-wikipedia:en: https://en.wikipedia.org/wiki/Caraway
 wikidata:en: Q26811
+wikipedia:en: https://en.wikipedia.org/wiki/Caraway
 
 < en: caraway
 en: caraway seed

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -67339,11 +67339,14 @@ en: caraway
 af: karwy
 ar: كروياء
 az: adi zirə
+be: кмен звычайны
 bg: ким
+bn: কারোয়া
 bo: གོ་སྙོད།
 bs: kim
 ca: alcaravia
-cs: kmín
+cs: kmín, kmín kořenný
+cv: ахаль çерçи кĕпçи
 cy: carwy
 da: kommen
 de: Kümmel
@@ -67362,19 +67365,23 @@ he: כרוויה תרבותית
 hi: शाहजीरा
 hr: kim
 hu: fűszerkömény
-hy: քիմիոն
+hy: քիմիոն, քիմոն սովորական
 id: jintan
+ig: cara way
 is: kúmen
 it: carvi
 ja: キャラウェイ
+jv: caraway
 ka: ძირა
 ko: 캐러웨이
 ku: jaj
-la: careum
-lt: kmynas
-lv: ķimenes
+la: Carum carvi, Careum
+lb: Kimmel
+lt: kmynas, paprastasis kmynas
+lv: ķimenes, pļavas ķimene
 mk: ким
 ml: കരിഞ്ചീരകം
+mn: гоньд
 mr: शहाजिरे
 ms: jintan
 mt: karwija
@@ -67382,21 +67389,26 @@ my: ကရဝေး
 nb: karve
 nl: karwij
 nn: karve
+os: хуымæтæджы фыдхос
 pa: زيره
-pl: kminek
+pl: kminek, kminek zwyczajny
+ps: زيره
 pt: alcaravia
 ro: chimen
+ru: тмин обыкновенный
 sh: kim
-sk: kmín
-sl: kumina
+sk: kmín, rasca lúčna
+sl: kumina, navadna kumina
 sq: qimnoni
 sr: ким, kim
 sv: kummin
 te: కరం కరవే
 tg: карвиё
 th: เทียนตากบ
-uk: кмин
-zh: 葛縷子
+tt: ак әнис
+uk: кмин, кмин звичайний
+uz: zira urug'lari
+zh: 葛缕子, 葛縷子
 # azb:عادی زیره
 # bar:kimme
 # dsb:garba
@@ -67419,29 +67431,39 @@ description:en: CARAWAY (Carum carvi), is a biennial plant in the family Apiacea
 usda_ndb_proxy_code:en: 2005
 usda_ndb_proxy_name:en: Spices, caraway seed
 wikipedia:en: https://en.wikipedia.org/wiki/Caraway
-# wikidata:en:Q26811 for the plant
-# wikidata:en:Q61670763 for the seed
+wikidata:en: Q26811
 
 < en: caraway
 en: caraway seed
+ca: llavors d'alcaravia
+da: kommenfrø
 de: Kümmelsamen
 el: σπόρος κύμινου
-es: semilla de alcaravea
-fr: graine de carvi
-hr: sjeme kima
-it: seme di cumino, seme di carvi
+es: semilla de alcaravea, semillas de alcaravea
+et: köömned
+fr: graine de carvi, graines de carvi
+hr: sjeme kima, sjemenke kima
+it: seme di cumino, seme di carvi, seme di cumino dei prati
+ja: キャラウェイシード
+la: Carvi fructus
+lt: kmynų sėklos
+lv: ķimeņu sēklas
 nl: karwijzaad
 pl: nasiona kminku
 pt: semente de cominho, semente de alcaravia
 ro: semințe de chimen, seminte de chimen
 ru: семена тмина
+sl: seme navadne kumine
+sv: kumminfrön
+yi: קימל זוימען
+zh: 葛缕子籽, 葛縷子籽
 #ltg:čymynu sāklys
 ciqual_food_code:en: 11064
 ciqual_food_name:en: Caraway, seed
 ciqual_food_name:fr: Carvi, graine
 usda_ndb_code:en: 2005
 usda_ndb_name:en: Spices, caraway seed
-#498 @2021-09-19
+wikidata:en: Q61670763
 
 ###################################################################################################
 #


### PR DESCRIPTION
- Adds caraway seeds category as a child of spices.
- Adds whole, ground, and powder caraway seeds categories.
- Adds da and sv translations + some imports from Wikidata + some derived translations from existing translations.
  - Synchronises translations between categories and ingredients.
- Does some normalisation of case and singular/plural forms.
- Adds `wikidata` property on ingredient.

Needed-for: https://se.openfoodfacts.org/product/7350046460522/kummin-malen-kockens