### PR TITLE
taxonomy(food): chervil/cicely edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -74554,7 +74554,7 @@ wikidata:en: Q139678670
 en: Chervils and their products
 da: Kørvel og kørvelprodukter
 es: Productos del perifollo
-fr: Produits de le cerfeuil
+fr: Produits de cerfeuil
 nl: Kervelproducten
 sv: Körvel och körvelprodukter
 agribalyse_proxy_food_code:en: 11002
@@ -74606,7 +74606,7 @@ nl: Kervelbladeren
 
 < en: Chervils and their products
 en: Garden chervils and their products, Garden chervil products
-fr: Produits de le cerfeuil commun
+fr: Produits de cerfeuil commun
 
 < en: Chervils
 < en: Garden chervils and their products
@@ -74714,7 +74714,7 @@ de: Süßdolde
 et: Mesiputk
 fa: چتردار شیرین
 fi: Saksankirveli
-fr: Cerfeuil musque, Cerfeuil anisé, Cerfeuil d'Espagne
+fr: Cerfeuil musqué, Cerfeuil anisé, Cerfeuil d'Espagne
 ga: Lus áinleoige
 hr: Čehulja
 id: Seledri melur

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -74551,46 +74551,198 @@ ciqual_proxy_food_name:en: Caraway, seed
 wikidata:en: Q139678670
 
 < en: Plant-based foods
-en: Fresh chervil, Garden chervil products, Garden chervil, Chervil
-bg: Керевиз
-de: Kerbel
-es: Productos del perifollo, Perifollo, Cerefolio, Perifolio
-fr: Cerfeuil, Cerfeuil frais, Produits de le cerfeuil commun, Cerfeuil commun
-hr: Prave krasuljice, čerfoli
-ja: チャービル
-la: Anthriscus cerefolium
+en: Chervils and their products
+da: Kørvel og kørvelprodukter
+es: Productos del perifollo
+fr: Produits de le cerfeuil
 nl: Kervelproducten
-pl: Trybula ogrodowa
+sv: Körvel och körvelprodukter
+agribalyse_proxy_food_code:en: 11002
+ciqual_proxy_food_code:en: 11002
+ciqual_proxy_food_name:en: Chervil, raw
+comment:en: While “chervil” in English pretty much exclusively refers to the garden chervil variety, other languages have multiple different kinds of “chervils”.
+
+< en: Chervils and their products
+en: Chervils, Chervil
+bg: Керевиз
+da: Kørvel
+de: Kerbel
+es: Perifollo, Cerefolio, Perifolio
+fr: Cerfeuil
+hr: Krasuljica, Čerfoli
+ja: チャービル
+pl: Trybuli, Trybula
+sv: Körvel
 agribalyse_food_code:en: 11002
 ciqual_food_code:en: 11002
-ciqual_food_name:en: Chervil, fresh
-ciqual_food_name:fr: Cerfeuil, frais
+ciqual_food_name:en: Chervil, raw
+#wikidata:en: Q21281535 - this is for the spice “chervil”, and while the WD page suggests this is a product of garden chervils, in reality it isn’t used for only that
+
+< en: Chervils
+en: Fresh chervils, Fresh chervil
+da: Friske kørvel
+fr: Cerfeuil frais
+it: Cerfoglio fresco
+nl: Verse kervel
+sv: Färska körvel
+
+< en: Chervils and their products
+< en: Spices
+en: Chervil seeds
+de: Kerbelsamen
+es: Semillas de perifollo, Semillas de perifolio
+fr: Graines de cerfeuil
+hr: Sjeme vrtnog češnjevka
+nl: Kervelzaden
+
+< en: Aromatic herbs
+< en: Chervils and their products
+en: Chervil leaves
+de: Kerbelblätter
+es: Hojas de perifollo, Hojas de cerefolio, Hojas de perifolio
+fr: Feuilles de cerfeuil
+hr: Lišće vrtnog češnjevka
+nl: Kervelbladeren
+
+< en: Chervils and their products
+en: Garden chervils and their products, Garden chervil products
+fr: Produits de le cerfeuil commun
+
+< en: Chervils
+< en: Garden chervils and their products
+en: Garden chervils, Garden chervil, French chervils, French parsley
+ar: سرفيل بستاني
+be: Маркоўнік цмяналісты
+bg: Див керевиз
+br: Serfilh
+ca: Cerfull
+co: Pedi puddinu
+cs: Kerblík třebule
+cy: Gorthyfail y gerddi
+da: Havekørvel, Dansk kørvel, Have-kørvel
+de: Echter Kerbel
+el: Μυρώνι
+eo: Cerefolioj
+et: Aed-harakputk
+eu: Apoperrexil
+fa: جعفری فرنگی
+fi: Maustekirveli
+fr: Cerfeuil commun
+ga: Costóg
+gl: Cerefolio
+hi: चेवील
+hr: Prave krasuljice
+hu: Zamatos turbolya
+hy: Կերբելուկ մոմատերև
+id: Cerwil
+io: Cerfolio
+is: Kerfill
+ka: Ჭყიმამხალი
+ko: 처빌
+kw: Serfel
+la: Anthriscus cerefolium
+lb: Kierwel
+lt: Daržinis builis
+mk: Крбулица
+ms: Cervil
+nb: Hagekjørvel
+nl: Echte kervel
+nn: Hagekjørvel
+oc: Cerfuèlh
+os: Гæнгæлы
+pl: Trybula ogrodowa
+pt: Cerefólio
+ro: Hasmațuchi
+ru: Кервель ажурный
+sk: Trebuľka voňavá
+sl: Prava krebuljica
+sr: Krbuljica
+sv: Trädgårdskörvel, Dansk körvel
+ta: தோட்டப் பூண்டு
+th: เชอร์วิล
+tr: Frenk maydanozu
+uk: Кервель
+zh: 法國芫荽
 wikidata:en: Q218462
 
-< en: Plant-based foods
-fr: Cerfeuil tubéreux, Cerfeuil bulbeux
+< en: Chervil leaves
+< en: Garden chervils and their products
+en: Garden chervil leaves
+fr: Feuilles de cerfeuil commun
+
+< en: Chervil seeds
+< en: Garden chervils and their products
+en: Garden chervil seeds
+fr: Graines de cerfeuil commun
+
+< en: Chervils
+en: Bulbous chervils, Turnip-rooted chervils, Tuberous-rooted chervils, Parsnip chervils
+ar: سرفل بصيلي
+be: Цьмянец клубняносны
+bg: Грудков балдаран
+cs: Krabilice hlíznatá
 de: Knolliger Kälberkropf, Knollenkerbel, Rüben-Kälberkropf, Kerbelrübe, Knollen-Kälberkropf
+eo: Tubera kerofiloj
+et: Mugul-varesputk
+fi: Mukulakirveli
+fr: Cerfeuil tubéreux, Cerfeuil bulbeux
+hu: Csemegebaraboly
+hy: Շուշանաբանջար սոխուկավոր
+la: Chaerophyllum bulbosum
+lt: Gumbuotasis gurgždis
+nb: Knollkjeks
+nl: Knolribzaad
+pl: Świerząbek bulwiasty
+ro: Baraboi
+ru: Бутень клубненосный
+sk: Krkoška hľuznatá
+sl: Gomoljasto trebelje
+sv: Rotkörvel
 agribalyse_proxy_food_code:en: 20181
 agribalyse_proxy_food_name:fr: Panais, cru
 wikidata:en: Q1777420
 
-< en: Aromatic herbs
-< en: Garden chervil products
-en: Garden chervil leaves, Chervil leaves
-de: Kerbelblätter
-es: Hojas de perifollo, Hojas de cerefolio, Hojas de perifolio
-fr: Feuilles de cerfeuil, Feuilles de cerfeuil commun
-hr: Lišće vrtnog češnjevka
-nl: Kervelbladeren
+< en: Chervils
+en: Cicelies, Cicely, Sweet cicely, Myrrh, Garden myrrh, Sweet chervils, Spanish chervils
+ar: بقدونس إفرنجي
+bg: Смирна
+ca: Mirris
+cs: Čechřice vonná
+cy: Creithig bêr
+da: Spanske kørvel, Spansk kørvel, Sødskærme, Anis-kål
+de: Süßdolde
+et: Mesiputk
+fa: چتردار شیرین
+fi: Saksankirveli
+fr: Cerfeuil musque, Cerfeuil anisé, Cerfeuil d'Espagne
+ga: Lus áinleoige
+hr: Čehulja
+id: Seledri melur
+is: Spánarkerfill
+it: Mirride odorosa
+ja: スイートシスリー
+kk: Миррис
+ko: 시슬리
+la: Myrrhis odorata
+lt: Garduoklė
+nb: Spansk kjørvel
+nl: Roomse kervel
+nn: Spansk kjørvel
+pl: Marchewnik anyżowy
+sl: Dišeči kromač
+sv: Spanska körvel, Spansk körvel
+uk: Мірис запашний
+vi: Myrrhis
+wa: Cierfouy di pidjon
+zh: 欧洲没药, 甜芹, 茉莉芹, 歐洲沒藥
+wikidata:en: Q1137175
 
-< en: Garden chervil products
+< en: Cicelies
 < en: Spices
-en: Garden chervil seeds, Chervil seeds
-de: Kerbelsamen
-es: Semillas de perifollo, Semillas de perifolio
-fr: Graines de cerfeuil, Graines de cerfeuil commun
-hr: Sjeme vrtnog češnjevka
-nl: Kervelzaden
+en: Cicely powders
+da: Spanske kørvelpulvere
+sv: Spanska körvelpulver
+comment:en: Unclear what part of the plant is used to make the powder.
 
 < en: Aromatic herbs
 < en: Herbal teas

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -70819,13 +70819,12 @@ wikipedia:en: https://en.wikipedia.org/wiki/Thai_basil
 #                                Chervil
 #
 ###################################################################################################
-# description:en:CHERVIL is a delicate annual herb related to parsley. It is commonly used to season mild-flavoured dishes and is a constituent of the French herb mixture fines herbes.
-# comment:en:The wikidata entries describe the plant. Not used. IATE has been used.
 
-#category/fresh-chervil
 < en: herb
 en: chervil
 bg: керевиз
+br: serfilh
+ca: cerfull
 da: kørvel
 de: Kerbel
 el: σκαντζίκι
@@ -70835,22 +70834,30 @@ et: aed, harakputk
 fi: kirveli
 fr: cerfeuil
 ga: costóg
+gl: cerefolio
 hr: krasuljica
 hu: turbolya
+id: cerwil
+io: cerfolio
+is: kerfill
 it: cerfoglio
-la: Anthriscus cerefolium
+kw: serfel
+lb: Kierwel
 lv: kārvele
+ms: cervil
 mt: sorfolja
 nl: kervel
-pl: trybula, trybuli, Trybula ogrodowa
+oc: cerfuèlh
+pl: trybula, trybuli
 pt: cerefólio
 ro: asmățui
+ru: кервель
 sk: trebuľka voňavá
 sl: krebuljica
 sv: körvel
-ciqual_proxy_food_code:en: 11002
-ciqual_proxy_food_name:en: Chervil, fresh
-ciqual_proxy_food_name:fr: Cerfeuil, frais
+ciqual_food_code:en: 11002
+ciqual_food_name:en: Chervil, raw
+description:en: CHERVIL is a delicate annual herb related to parsley. It is commonly used to season mild-flavoured dishes and is a constituent of the French herb mixture fines herbes.
 eurocode_2_group_2:en: 12.20
 eurocode_2_group_3:en: 12.20.22
 usda_ndb_proxy_code:en: 2008
@@ -70859,12 +70866,49 @@ wikidata:en: Q21281535
 wikipedia:en: https://en.wikipedia.org/wiki/Chervil
 
 < en: chervil
-en: fresh chervil
-it: cerfoglio fresco
-nl: verse kervel
-ciqual_food_code:en: 11002
-ciqual_food_name:en: Chervil, fresh
-ciqual_food_name:fr: Cerfeuil, frais
+en: garden chervil, French parsley
+ar: سرفيل بستاني
+be: маркоўнік цмяналісты
+bg: див керевиз
+co: pedi puddinu
+cs: kerblík třebule
+cy: gorthyfail y gerddi
+da: havekørvel, have-kørvel, dansk kørvel
+de: Echter Kerbel
+el: μυρώνι
+eo: cerefolio
+es: perejil francés
+et: aed-harakputk
+eu: apoperrexil
+fa: جعفری فرنگی
+fi: maustekirveli
+fr: cerfeuil commun
+hi: चेवील
+hu: zamatos turbolya
+hy: կերբելուկ մոմատերև
+is: garðakerfill
+ja: チャービル
+ka: ჭყიმამხალი
+ko: 처빌
+la: Anthriscus cerefolium
+lt: daržinis builis
+mk: крбулица
+nb: hagekjørvel
+nl: echte kervel
+nn: hagekjørvel
+os: гæнгæлы
+pl: trybula ogrodowa
+ro: hasmațuchi
+ru: кервель ажурный
+sl: prava krebuljica
+sr: krbuljica
+sv: trädgårdskörvel, dansk körvel
+ta: தோட்டப் பூண்டு
+th: เชอร์วิล
+tr: frenk maydanozu
+uk: кервель
+zh: 雪维菜, 法國芫荽, 蜡叶峨参
+wikidata:en: Q218462
 
 < en: chervil
 en: dried chervil


### PR DESCRIPTION
English “chervil” may more-or-less exclusively refer to garden chervils, but it seems like other languages use “chervil” interchangeably for multiple different plants/herbs/spices, so trying to make this clear here with some reorganising of the categories (and ingredients).

- Splits out some of the combined chervil categories into discrete ones.
- Adds new cicely and cicely powder categories.
- Adds translations (incl. from Wikidata).
- Updates some `ciqual` properties.
  - Looks like it previously used “fresh” where it now uses “raw”, so moved the non-proxy up a level.
- Cleans up some comments.
- Removes “fresh chervil” ingredient.
  - As far as I can tell, there are 0 products with it.
- Splits out “garden chervil” ingredient.

Needed-for: https://se.openfoodfacts.org/product/7310394002362/k%C3%B6rvel-kockens