### PR TITLE
taxonomy(food): chopped/dried garlic categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -112966,6 +112966,32 @@ gpc_category_description:en: Definition: Includes any product that can be descri
 gpc_category_name:en: Garlic
 season_in_country_fr:en: 7,8,9,10,11,12
 
+< en: Dried vegetables
+< en: Garlics
+en: Dried garlics
+da: Tørrede hvidløg
+sv: Torkade vitlökar
+ciqual_proxy_food_code:en: 11023
+ciqual_proxy_food_name:en: Garlic, dried, powder
+
+< en: Garlics
+en: Chopped garlics
+da: Hakkede hvidløg
+sv: Hackade vitlökar
+
+< en: Chopped garlics
+< en: Dried garlics
+en: Dried chopped garlics
+da: Tørrede hakkede hvidløg
+sv: Torkade hackade vitlökar
+ciqual_proxy_food_code:en: 11023
+ciqual_proxy_food_name:en: Garlic, dried, powder
+
+< en: Dried chopped garlics
+en: Dried finely chopped dried garlics, Dried fine chopped garlics
+da: Tørrede finthakkede hvidløg
+sv: Torkade finhackade vitlökar
+
 < en: Garlics
 en: Allium neapolitanum, Naples garlic
 de: Neapolitanischer Lauch
@@ -120205,8 +120231,8 @@ en: Frozen chopped shallots
 da: Frosne hakkede skalotteløg
 sv: Frysta hackade schalottenlökar
 
+< en: Chopped garlics
 < en: Frozen vegetables
-< en: Garlics
 en: Frozen chopped garlic
 de: Tiefgefrorener gehackter Knoblauch
 es: Ajos troceados congelados, Ajos congelados troceados


### PR DESCRIPTION
Adds some chopped and/or dried garlic categories.

Needed-for: https://se.openfoodfacts.org/product/7310394002676/vitl%C3%B6k-finhackad-kockens