### PR TITLE
taxonomy(food): allspice edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -76329,6 +76329,69 @@ ciqual_food_name:fr: Epice (aliment moyen)
 intake24_category_code:en: SPCE
 wikidata:en: Q42527
 
+< en: Spices
+en: Allspices, All spices, Allspice, Jamaica pepper, Myrtle pepper
+af: Wonderpeper
+ar: فلفل إفرنجي
+az: İkievli pimenta
+be: Ангельскае зелле, Пімента лекавая
+bg: Бахар
+bn: কাবাব চিনি
+ca: Pebrer de Jamaica, Pebre de Jamaica
+cs: Nové koření, Pimentovník pravý
+da: Allehånde
+de: Jamaikapfeffer, Piment, Allgewürz, Viergewürz
+el: Μπαχάρι
+eo: Dioika pimentoj
+es: Pimientas de Jamaica
+et: Vürtspipar, Harilik pimendipuu
+fa: فلفل فرنگی
+fi: Maustepippuri
+fr: Piments de la Jamaïque, Piment de la Jamaïque, Piment de Jamaïque
+ga: Ilspíosra
+hr: Pimen
+ht: Malagèt
+hu: Szegfűbors
+hy: Բուրավետ պղպեղ
+id: Merica Jamaika
+is: Allrahanda
+it: Pepe di Giamaica, Pepe garofanato, Pimenteira
+ja: オールスパイス
+ko: 올스파이스나무
+la: Pimenta dioica
+lt: Kvapusis pipiras
+ml: സർവ സുഗന്ധി
+ms: Rempah tiga rasa
+nb: Allehånder
+nl: Piment, Jamaicaanse peper
+nn: Allehandar
+pl: Ziele angielskie, Ziela angielskiego, Pieprz z Jamajki, Korzennik lekarski
+pt: Pimenta da jamaica
+ro: Ienibahar
+ru: Душистый перец, Перец душистый, Перец душистый молотый, Пимента лекарственная
+sl: Piment, Pimentovec
+sr: Најгвирц
+sv: Kryddpeppar
+ta: ஆல்ஸ்பைஸ்
+th: ออลสไปซ์
+to: Sipaisi
+tr: Yeni bahar
+uk: Духмяний перець, Перець духмяний
+ur: سیتل چینی
+zh: 多香果
+description:en: ALLSPICE, also known as Jamaica pepper, myrtle pepper, pimenta, or pimento, is the dried unripe berry of Pimenta dioica, a midcanopy tree native to the Greater Antilles, southern Mexico, and Central America, now cultivated in many warm parts of the world.
+wikidata:en: Q1963621
+wikipedia:en: https://en.wikipedia.org/wiki/Allspice
+
+< en: Allspices
+en: Whole allspices, Allspice peppercorns
+da: Hele allehånde
+sv: Kryddpepparkorn, Hela kryddpeppar
+
+< en: Allspices
+en: Ground allspices
+sv: Malen kryddpeppar, Malna kryddpepparkorn
+
 < en: Herbal teas
 < en: Spices
 en: Anise, Aniseed, Green anise

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -59099,22 +59099,56 @@ vi: ớt hiểm
 wikidata:en: Q432426
 wikipedia:en: https://en.wikipedia.org/wiki/Bird%27s_eye_chili
 
-< en: chili pepper
-en: allspice, all spice, jamaica pepper, myrtle pepper
+< en: spice
+en: allspice, all spice, Jamaica pepper, myrtle pepper
+af: wonderpeper
+ar: فلفل إفرنجي
+az: ikievli pimenta
+be: ангельскае зелле, пімента лекавая
 bg: бахар
-cs: nové koření
-de: Jamaikapfeffer, Piment
+bn: কাবাব চিনি
+ca: pebrer de Jamaica, pebre de Jamaica
+cs: nové koření, pimentovník pravý
+da: allehånde
+de: Jamaikapfeffer, Piment, Allgewürz, Viergewürz
+el: μπαχάρι
+eo: dioika pimento
 es: pimienta de Jamaica
+et: vürtspipar, harilik pimendipuu
+fa: فلفل فرنگی
 fi: maustepippuri
-fr: piment de la jamaïque, piment de jamaïque
+fr: piment de la Jamaïque, piment de Jamaïque
+ga: ilspíosra
 hr: pimen
-it: Pepe di Giamaica, pepe garofanato, pimenteira
+ht: malagèt
+hu: szegfűbors
+hy: բուրավետ պղպեղ
+id: merica Jamaika
+is: allrahanda
+it: pepe di Giamaica, pepe garofanato, pimenteira
+ja: オールスパイス
+ko: 올스파이스나무
+la: Pimenta dioica
+lt: kvapusis pipiras
+ml: സർവ സുഗന്ധി
+ms: rempah tiga rasa
 nb: allehånde
 nl: Jamaicaanse peper
-pl: ziele angielskie, ziela angielskiego
-ru: перец душистый, перец душистый молотый, душистый перец
+nn: allehande
+pl: ziele angielskie, ziela angielskiego, pieprz z Jamajki, korzennik lekarski
+pt: pimenta da Jamaica
+ro: ienibahar
+ru: перец душистый, перец душистый молотый, душистый перец, пимента лекарственная
+sl: piment, pimentovec
+sr: најгвирц
 sv: kryddpeppar
-uk: перець духмяний
+ta: ஆல்ஸ்பைஸ்
+th: ออลสไปซ์
+to: sipaisi
+tr: yeni bahar
+uk: перець духмяний, духмяний перець
+ur: سیتل چینی
+zh: 多香果
 description:en: ALLSPICE, also known as Jamaica pepper, myrtle pepper, pimenta, or pimento, is the dried unripe berry of Pimenta dioica, a midcanopy tree native to the Greater Antilles, southern Mexico, and Central America, now cultivated in many warm parts of the world.
 usda_ndb_code:en: 2001
 usda_ndb_name:en: Spices, allspice, ground


### PR DESCRIPTION
Allspices seem to not actually be biologically related to peppers, but maybe they are even if they’re not part of the Piper genus? They seem to colloquially be referred to as such anyway, and do have some visual resemblance to peppers.

- Adds allspice categories.
- Adds translations for allspice ingredient.
  - da/sv/nb/nn + from Wikidata.
- Normalises case and singular/plural forms.

Needed-for: https://se.openfoodfacts.org/product/7311041034293/hel-kryddpeppar-eldorado
Needed-for: https://world.openfoodfacts.org/facets/categories/allspice