### PR TITLE
taxonomy: translate HBT additive

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -26136,41 +26136,6 @@ sv: metylsulfonylmetan
 wikidata:en: Q423842
 wikipedia:en: https://en.wikipedia.org/wiki/Methylsulfonylmethane
 
-en: hydroxymethylbutyrate, HMB
-xx: hydroxymethylbutyrate, HMB
-bg: хидроксиметилбутирова киселина, HMB
-ca: hidroximetilbutirat, HMB
-cs: hydroxymethylbutyrát, HMB
-da: hydroxymethylbutyrat, HMB
-de: Hydroxymethylbutyrat, HMB
-el: υδροξυμεθυλοβουτυρικό, HMB
-es: hidroximetilbutirato, HMB
-et: hüdroksümetüülbutüraat, HMB
-fi: hydroksimetyylibutyraatti, HMB
-fr: hydroxy-méthylbutyrate, HMB
-hu: hidroximetil-butirát, HMB
-it: idrossimetilbutirrato, HMB
-ja: ヒドロキシメチルブチレート, HMB
-ko: 하이드록시메틸부티레이트, HMB
-lt: hidroksimetilbutiratas, HMB
-lv: hidroksimetilbutirāts, HMB
-mk: хидроксиметилбутирична киселина, HMB
-nl: hydroxymethylbutyraat, HMB
-pl: hydroksymetylobutyrat, HMB
-pt: hidroximetilbutirato, HMB
-ro: hidroximetilbutirat, HMB
-ru: гидроксиметилбутират, HMB
-sk: hydroxymetylbutyrát, HMB
-sl: hidroksimetilbutirat, HMB
-sq: hidroksimetilbutirat, HMB
-sr: хидроксиметилбутирична киселина, HMB
-sv: hydroxymetylbutyrat, HMB
-tr: hidroksimetilbütirat, HMB
-uk: гідроксиметилбутират, HMB
-wikidata:en: Q223081
-
-< en: hydroxymethylbutyrate
-en: calcium beta-hydroxy beta-methyl butyrate
 
 # Japanese additives can be listed only with their type (e.g. amino acids), without the specific additive name
 

--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -26138,6 +26138,35 @@ wikipedia:en: https://en.wikipedia.org/wiki/Methylsulfonylmethane
 
 en: hydroxymethylbutyrate, HMB
 xx: hydroxymethylbutyrate, HMB
+bg: хидроксиметилбутирова киселина, HMB
+ca: hidroximetilbutirat, HMB
+cs: hydroxymethylbutyrát, HMB
+da: hydroxymethylbutyrat, HMB
+de: Hydroxymethylbutyrat, HMB
+el: υδροξυμεθυλοβουτυρικό, HMB
+es: hidroximetilbutirato, HMB
+et: hüdroksümetüülbutüraat, HMB
+fi: hydroksimetyylibutyraatti, HMB
+fr: hydroxy-méthylbutyrate, HMB
+hu: hidroximetil-butirát, HMB
+it: idrossimetilbutirrato, HMB
+ja: ヒドロキシメチルブチレート, HMB
+ko: 하이드록시메틸부티레이트, HMB
+lt: hidroksimetilbutiratas, HMB
+lv: hidroksimetilbutirāts, HMB
+mk: хидроксиметилбутирична киселина, HMB
+nl: hydroxymethylbutyraat, HMB
+pl: hydroksymetylobutyrat, HMB
+pt: hidroximetilbutirato, HMB
+ro: hidroximetilbutirat, HMB
+ru: гидроксиметилбутират, HMB
+sk: hydroxymetylbutyrát, HMB
+sl: hidroksimetilbutirat, HMB
+sq: hidroksimetilbutirat, HMB
+sr: хидроксиметилбутирична киселина, HMB
+sv: hydroxymetylbutyrat, HMB
+tr: hidroksimetilbütirat, HMB
+uk: гідроксиметилбутират, HMB
 wikidata:en: Q223081
 
 < en: hydroxymethylbutyrate

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -97079,35 +97079,35 @@ en: French toast
 
 en: hydroxymethylbutyrate, HMB
 xx: hydroxymethylbutyrate, HMB
-bg: хидроксиметилбутирова киселина, HMB
-ca: hidroximetilbutirat, HMB
-cs: hydroxymethylbutyrát, HMB
-da: hydroxymethylbutyrat, HMB
-de: Hydroxymethylbutyrat, HMB
-el: υδροξυμεθυλοβουτυρικό, HMB
-es: hidroximetilbutirato, HMB
-et: hüdroksümetüülbutüraat, HMB
-fi: hydroksimetyylibutyraatti, HMB
-fr: hydroxy-méthylbutyrate, HMB
-hu: hidroximetil-butirát, HMB
-it: idrossimetilbutirrato, HMB
-ja: ヒドロキシメチルブチレート, HMB
-ko: 하이드록시메틸부티레이트, HMB
-lt: hidroksimetilbutiratas, HMB
-lv: hidroksimetilbutirāts, HMB
-mk: хидроксиметилбутирична киселина, HMB
-nl: hydroxymethylbutyraat, HMB
-pl: hydroksymetylobutyrat, HMB
-pt: hidroximetilbutirato, HMB
-ro: hidroximetilbutirat, HMB
-ru: гидроксиметилбутират, HMB
-sk: hydroxymetylbutyrát, HMB
-sl: hidroksimetilbutirat, HMB
-sq: hidroksimetilbutirat, HMB
-sr: хидроксиметилбутирична киселина, HMB
-sv: hydroxymetylbutyrat, HMB
-tr: hidroksimetilbütirat, HMB
-uk: гідроксиметилбутират, HMB
+bg: хидроксиметилбутирова киселина
+ca: hidroximetilbutirat
+cs: hydroxymethylbutyrát
+da: hydroxymethylbutyrat
+de: Hydroxymethylbutyrat
+el: υδροξυμεθυλοβουτυρικό
+es: hidroximetilbutirato
+et: hüdroksümetüülbutüraat
+fi: hydroksimetyylibutyraatti
+fr: hydroxy-méthylbutyrate
+hu: hidroximetil-butirát
+it: idrossimetilbutirrato
+ja: ヒドロキシメチルブチレート
+ko: 하이드록시메틸부티레이트
+lt: hidroksimetilbutiratas
+lv: hidroksimetilbutirāts
+mk: хидроксиметилбутирична киселина
+nl: hydroxymethylbutyraat
+pl: hydroksymetylobutyrat
+pt: hidroximetilbutirato
+ro: hidroximetilbutirat
+ru: гидроксиметилбутират
+sk: hydroxymetylbutyrát
+sl: hidroksimetilbutirat
+sq: hidroksimetilbutirat
+sr: хидроксиметилбутирична киселина
+sv: hydroxymetylbutyrat
+tr: hidroksimetilbütirat
+uk: гідроксиметилбутират
 wikidata:en: Q223081
 
 < en: hydroxymethylbutyrate

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -97077,3 +97077,38 @@ en: French custard base
 #< en: compound
 en: French toast
 
+en: hydroxymethylbutyrate, HMB
+xx: hydroxymethylbutyrate, HMB
+bg: хидроксиметилбутирова киселина, HMB
+ca: hidroximetilbutirat, HMB
+cs: hydroxymethylbutyrát, HMB
+da: hydroxymethylbutyrat, HMB
+de: Hydroxymethylbutyrat, HMB
+el: υδροξυμεθυλοβουτυρικό, HMB
+es: hidroximetilbutirato, HMB
+et: hüdroksümetüülbutüraat, HMB
+fi: hydroksimetyylibutyraatti, HMB
+fr: hydroxy-méthylbutyrate, HMB
+hu: hidroximetil-butirát, HMB
+it: idrossimetilbutirrato, HMB
+ja: ヒドロキシメチルブチレート, HMB
+ko: 하이드록시메틸부티레이트, HMB
+lt: hidroksimetilbutiratas, HMB
+lv: hidroksimetilbutirāts, HMB
+mk: хидроксиметилбутирична киселина, HMB
+nl: hydroxymethylbutyraat, HMB
+pl: hydroksymetylobutyrat, HMB
+pt: hidroximetilbutirato, HMB
+ro: hidroximetilbutirat, HMB
+ru: гидроксиметилбутират, HMB
+sk: hydroxymetylbutyrát, HMB
+sl: hidroksimetilbutirat, HMB
+sq: hidroksimetilbutirat, HMB
+sr: хидроксиметилбутирична киселина, HMB
+sv: hydroxymetylbutyrat, HMB
+tr: hidroksimetilbütirat, HMB
+uk: гідроксиметилбутират, HMB
+wikidata:en: Q223081
+
+< en: hydroxymethylbutyrate
+en: calcium beta-hydroxy beta-methyl butyrate


### PR DESCRIPTION
taxonomy: translate HBT additive
does not have e E number, only 3 products with it: https://world.openfoodfacts.org/facets/ingredients/hydroxymethylbutyrate
current additive parsing does not work well : https://world.openfoodfacts.org/facets/additives/hydroxymethylbutyrate%20-%20HMB