### PR TITLE
taxonomy(food): tapenade category edits

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -108806,26 +108806,37 @@ hr: Namazi od artičoke
 < en: Salted spreads
 nl: Mierikswortelspreads
 
+< en: Condiments
 < en: Salted spreads
-en: Tapenades, tapenade, Puree of capers pitted black olives anchovy and herbs with olive oil and lemon juice
-bg: Маслинова паста
+en: Tapenades
+xx: Tapenade
+bg: Маслинова паста, Тапенада
+bn: ট্যাপেনড
 ca: Tapenada
-de: Tapenade
-eo: Tapenado
-es: Tapenade
-fi: Tapenade
-fr: Tapenades, tapenade, ttapenades
+cs: Tapenáda
+cy: Tapenâd
+da: Tapenader
+eo: Tapenadoj
+fr: Tapenades
 he: ממרח זיתים
-it: Tapenade
+hi: तापानेड
+hy: Տապենադա
 ja: タプナード
+ka: Ტაპენადა
+ko: 타프나드
+mk: Тапенада
+ml: ടാപ്പനഡ്
+nb: Tapenader
 nl: Tapenades
 nl_be: Tapenades
+nn: Tapenadar
 oc: Tapenada
 pl: Tapenada
-pms: Tapenades, tapenade
-pt: Tapenade
+pms: Tapenades
 ru: Тапенада
-sv: Tapenade
+sv: Tapenader
+uk: Тапенада
+zh: 橄榄酱, 橄欖醬
 agribalyse_food_code:en: 11043
 ciqual_food_code:en: 11043
 ciqual_food_name:en: Tapenade (a puree of capers, pitted black olives, anchovy and herbs, with olive oil and lemon juice)


### PR DESCRIPTION
Tapenade is both a condiment and a salty/savory spread.

- Adds tapenades to condiments.
- Adds da/sv/nb/nn + Wikidata translations.
- Adds `xx` entry and cleans up translations.