### PR TITLE
taxonomy: candy chocolate bars

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -39059,7 +39059,7 @@ bg: Шоколадови барове
 ca: Barretes de xocolata
 de: Schokoriegel, Schokoladenriegel
 es: Barritas de chocolate
-fi: suklaapatukat
+fi: Suklaapatukat
 fr: Barres chocolatées, barres au chocolat
 he: חטיפי שוקולד
 hr: čokoladice, čokoladica
@@ -39067,7 +39067,7 @@ hu: Csokoládés szelet, Csoki
 it: Barrette di cioccolato
 ja: チョコレートバー, チョコバー
 lt: Šokoladiniai batonėliai
-nl: Snoeprepen
+nl: Chocoladesnackrepen
 pl: Batony czekoladowe
 pt: Barras de chocolate
 ro: Batoane de ciocolată
@@ -39082,7 +39082,7 @@ de: Schokoriegel mit Keksfüllung
 fi: Keksisuklaapatukat
 fr: Barres chocolatées biscuitées
 hr: Čokoladni biskvit
-it: Barrette biscottate al cioccolato
+it: Barrette di cioccolato con biscotto
 lt: Šokoladiniai batonėliai su sausainiais
 nl: Chocorepen met biscuit
 agribalyse_food_code:en: 31000
@@ -39102,7 +39102,7 @@ fr: Barres chocolatées biscuitées au caramel
 hr: Čokoladice punjene biskvitom i karamelom
 it: Barrette di cioccolato ripiene di biscotto e caramello
 lt: Šokoladiniai batonėliai su karamele ir sausainiais
-nl: Koekjesrepen met caramel en chocola
+nl: Chocorepen gevuld met koekje en karamel
 
 # Bounty-style bars
 < en: Candy chocolate bars

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -38015,7 +38015,7 @@ da: Chokolader, chokolade
 de: Schokoladen, Schokolade
 es: Chocolates
 fi: suklaat
-fr: Chocolats, chocolat
+fr: Chocolats, chocolat, Chocolat en tablette
 he: שוקולדים
 hr: čokolade, čokolada
 hu: Csokoládék
@@ -39060,16 +39060,17 @@ ca: Barretes de xocolata
 de: Schokoriegel, Schokoladenriegel
 es: Barritas de chocolate
 fi: suklaapatukat
-fr: Barres chocolatées, barres au chocolat, Chocolat en tablette
+fr: Barres chocolatées, barres au chocolat
 he: חטיפי שוקולד
 hr: čokoladice, čokoladica
 hu: Csokoládés szelet, Csoki
 it: Barrette di cioccolato
 ja: チョコレートバー, チョコバー
 lt: Šokoladiniai batonėliai
-nl: Chocolade repen
+nl: Snoeprepen
+pl: Batony czekoladowe
 pt: Barras de chocolate
-ro: Paleuri de ciocolată
+ro: Batoane de ciocolată
 ru: Шоколадные плитки, плитки шоколада, шоколадная плитка, плитка шоколада
 zh: 巧克力棒
 wikidata:en: Q1361086
@@ -39152,10 +39153,10 @@ lt: Šokoladiniai batonėliai su riešutais ir sausainiais
 nl: Chocorepen met noten en biscuit
 
 < en: Candy chocolate bars
-en: Chocolate confectionery with dairy filling, Chocolate bar with dairy filling
+en: Candy chocolate bars filled with a dairy cream, Chocolate confectionery with dairy filling, Chocolate bar with dairy filling
 fr: Barres chocolatées au lait, Confiserie chocolatées au lait, Barres chocolatées au lait, Barre chocolatée au lait, Barres chocolatées au lait type Kinder Maxi, Kinder Maxi
 hr: Čokoladni slatkiši s mliječnim punjenjem
-ro: Miniprajituri pe baza de lapte
+ro: Batoane de ciocolată cu lapte
 agribalyse_food_code:en: 31012
 ciqual_food_code:en: 31012
 ciqual_food_name:en: Chocolate confectionery or bar, with dairy filling
@@ -121124,7 +121125,7 @@ hu: Müzliszelet
 it: Barrette di cereali
 ja: シリアルバー, グラノーラバー
 nl: Graanrepen, Mueslirepen
-pl: Batoniki zbożowe
+pl: Batony zbożowe, Batoniki zbożowe
 pt: Barras de cereais
 ru: Мюсли-батончики
 google_product_taxonomy_id:en: 543651

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -36178,15 +36178,16 @@ zh: 早餐
 en: Cocoa and its products
 bg: Какаови изделия, какаови продукти
 ca: Cacau i derivats
-de: Kakao und Kakaoprodukte
+de: Kakao und Kakaoprodukte, Schokoladenprodukte
 es: Cacao y sus productos
-fr: Cacao et dérivés
-hr: Kakao i njegovi proizvodi
+fr: Cacao et dérivés, produits chocolatés, produits au chocolat
+hr: Kakao i njegovi proizvodi, csokoládé termékek
 it: Cacao e i suoi derivati
-lt: Kakava ir jos produktai
-nl: Cacao en afgeleide producten
-pl: Kakao i produkty na bazie kakao
-pt: Cacau e derivados
+lt: Kakava ir jos produktai, Šokoladiniai gaminiai
+nl: Cacao en afgeleide producten, Chocoladeproducten
+pl: Kakao i produkty na bazie kakao, Produkty czekoladowe
+pt: Cacau e derivados, produtos com chocolate
+sv: Kakao och produkter därav, Chokladprodukter
 tr: Kakao ve kakao ürünleri
 
 < en: Cocoa and its products
@@ -38006,27 +38007,27 @@ wikidata:en: Q34674117
 
 < en: Cocoa and its products
 < en: Sweet snacks
-en: Chocolates, chocolate products
+en: Chocolates
 bg: Шоколади
 ca: Xocolata
 cs: Čokolády
 da: Chokolader, chokolade
-de: Schokoladen, Schokolade, Schokoladenprodukte
+de: Schokoladen, Schokolade
 es: Chocolates
 fi: suklaat
-fr: Chocolats, chocolat, produits chocolatés, produits au chocolat
+fr: Chocolats, chocolat
 he: שוקולדים
 hr: čokolade, čokolada
-hu: Csokoládék, csokoládé termékek
+hu: Csokoládék
 it: Cioccolato
 ja: チョコレート
-lt: Šokoladai, Šokoladiniai gaminiai
-nl: Chocoladeproducten
-pl: Czekolada, Produkty czekoladowe
-pt: Chocolates, produtos com chocolate
+lt: Šokoladai
+nl: Chocolade
+pl: Czekolada
+pt: Chocolates
 ro: Ciocolată, ciocolata
 ru: Шоколад, шоколадные продукты
-sv: Choklad, Chokladprodukter
+sv: Choklad
 th: ช็อกโกแลต
 tr: Çikolatalar, Çikolatalı ürünler
 zh: 巧克力
@@ -39076,7 +39077,7 @@ wikidata:en: Q1361086
 
 < en: Candy chocolate bars
 en: Candy chocolate bars filled with biscuit, Chocolate biscuity bars
-de: Schokoladenbiscuits
+de: Schokoriegel mit Keksfüllung
 fi: Keksisuklaapatukat
 fr: Barres chocolatées biscuitées
 hr: Čokoladni biskvit
@@ -39088,22 +39089,24 @@ agribalyse_food_code:en: 31000
 # Kitkat
 < en: Candy chocolate bars filled with biscuit
 en: Candy chocolate bars filled with wafer
+de: Schokoriegel mit Waffelfüllung
 fr: Barres chocolatées aux gaufrettes, Barre chocolatée biscuitée type KitKat, Barre chocolatée biscuitée, Kitkat
 # Q367251
 
 # Twix and Lion type bars
 < en: Candy chocolate bars filled with biscuit
 en: Candy chocolate bars filled with biscuit and caramel, Caramel chocolate cookie bars
-de: Kekse mit Karamellschokolade
+de: Schokoriegel mit Keks- und Karamellfüllung
 fr: Barres chocolatées biscuitées au caramel
-hr: Karamel čokoladne keksiće
-it: Barrette biscottate al cioccolato e caramello
+hr: Čokoladice punjene biskvitom i karamelom
+it: Barrette di cioccolato ripiene di biscotto e caramello
 lt: Šokoladiniai batonėliai su karamele ir sausainiais
 nl: Koekjesrepen met caramel en chocola
 
 # Bounty-style bars
 < en: Candy chocolate bars
 en: Candy chocolate bars filled with coconut
+de: Schokoriegel mit Kokosfüllung
 fr: Barres chocolatées à la noix de coco, barre chocolatée à la noix de coco type Bounty, Bounty
 nl: Chocorepen met kokosvulling
 agribalyse_food_code:en: 31002
@@ -39121,6 +39124,7 @@ ciqual_food_name:en: Milky cereal breakfast bar, with chocolate or not, fortifie
 
 < en: Candy chocolate bars
 en: Candy chocolate bars filled with caramel and peanuts
+de: Schokoriegel mit Karamell- und Erdnussfüllung
 fr: Barres chocolatées au caramel et cacahuètes, Barres chocolatées aux fruits oléagineux, barre chocolatée aux fruits oléagineux type Snickers, Snickers
 #Q714179
 
@@ -39132,7 +39136,7 @@ en: Candy chocolate bars filled with caramel, Caramel chocolate bars
 de: Schokoriegel mit Karamell, Schokoriegel mit Karamellüberzug, Schokoriegel mit Karamellfüllung
 fi: Toffee-suklaapatukat
 fr: Barres chocolatées au caramel
-hr: Karamel čokoladne pločice
+hr: Čokoladice punjene karamelom
 it: Barrette di cioccolato al caramello
 lt: Šokoladiniai batonėliai su karamele
 nl: Chococaramelrepen, Chocolade-caramelrepen

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -36178,6 +36178,7 @@ zh: 早餐
 en: Cocoa and its products
 bg: Какаови изделия, какаови продукти
 ca: Cacau i derivats
+da: Kakao og kakaoprodukter, Chokoladeprodukter
 de: Kakao und Kakaoprodukte, Schokoladenprodukte
 es: Cacao y sus productos
 fr: Cacao et dérivés, produits chocolatés, produits au chocolat
@@ -36187,7 +36188,7 @@ lt: Kakava ir jos produktai, Šokoladiniai gaminiai
 nl: Cacao en afgeleide producten, Chocoladeproducten
 pl: Kakao i produkty na bazie kakao, Produkty czekoladowe
 pt: Cacau e derivados, produtos com chocolate
-sv: Kakao och produkter därav, Chokladprodukter
+sv: Kakao och kakaoprodukter, Kakao och produkter därav, Chokladprodukter
 tr: Kakao ve kakao ürünleri
 
 < en: Cocoa and its products

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -39060,7 +39060,7 @@ ca: Barretes de xocolata
 de: Schokoriegel, Schokoladenriegel
 es: Barritas de chocolate
 fi: Suklaapatukat
-fr: Barres chocolatées, barres au chocolat
+fr: Barres chocolatées, barres au chocolat, Barre chocolatée non biscuitée enrobée, Barre au chocolat sans biscuit
 he: חטיפי שוקולד
 hr: čokoladice, čokoladica
 hu: Csokoládés szelet, Csoki
@@ -39073,8 +39073,11 @@ pt: Barras de chocolate
 ro: Batoane de ciocolată
 ru: Шоколадные плитки, плитки шоколада, шоколадная плитка, плитка шоколада
 zh: 巧克力棒
+agribalyse_proxy_food_code:en: 31001
+ciqual_proxy_food_code:en: 31001
+ciqual_proxy_food_name:en: Chocolate bar, chocolate-coated, without biscuit
+ciqual_proxy_food_name:fr: Barre chocolatée non biscuitée enrobée
 wikidata:en: Q1361086
-#, barre chocolatée, barre au chocolat, barres au chocolat
 
 < en: Candy chocolate bars
 en: Candy chocolate bars filled with biscuit, Chocolate biscuity bars
@@ -100252,18 +100255,6 @@ agribalyse_food_code:en: 24030
 ciqual_food_code:en: 24030
 ciqual_food_name:en: Biscuit (cookie), with milk
 ciqual_food_name:fr: Biscuit sec au lait
-
-< en: Biscuits and cakes
-en: Coated chocolate bar without biscuit
-de: Schokoladenriegel ohne Keks
-es: Barra de chocolate sin galleta
-fr: Barre au chocolat sans biscuit
-hr: Obložena čokoladica bez keksa
-it: Barretta di cioccolato senza biscotto
-nl: Chocoladereep zonder biscuit
-agribalyse_food_code:en: 31001
-ciqual_food_code:en: 31001
-ciqual_food_name:en: Coated chocolate bar without biscuit
 
 < en: Filled biscuits
 en: Biscuits with nuts

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -39053,7 +39053,7 @@ nl: Chocolade dinosauriërs
 
 < en: Bars
 < en: Chocolate candies
-en: Candy chocolate bars, Bars covered with chocolate, Chocolate bars
+en: Candy chocolate bars, Bars covered with chocolate
 bg: Шоколадови барове
 ca: Barretes de xocolata
 de: Schokoriegel, Schokoladenriegel
@@ -39074,8 +39074,8 @@ zh: 巧克力棒
 wikidata:en: Q1361086
 #, barre chocolatée, barre au chocolat, barres au chocolat
 
-< en: Bars covered with chocolate
-en: Chocolate biscuity bars
+< en: Candy chocolate bars
+en: Candy chocolate bars filled with biscuit, Chocolate biscuity bars
 de: Schokoladenbiscuits
 fi: Keksisuklaapatukat
 fr: Barres chocolatées biscuitées
@@ -39086,13 +39086,24 @@ nl: Chocorepen met biscuit
 agribalyse_food_code:en: 31000
 
 # Kitkat
-< en: Chocolate biscuity bars
-fr: Barre chocolatée biscuitée type KitKat, Barre chocolatée biscuitée, Kitkat
+< en: Candy chocolate bars filled with biscuit
+en: Candy chocolate bars filled with wafer
+fr: Barres chocolatées aux gaufrettes, Barre chocolatée biscuitée type KitKat, Barre chocolatée biscuitée, Kitkat
 # Q367251
 
+# Twix and Lion type bars
+< en: Candy chocolate bars filled with biscuit
+en: Candy chocolate bars filled with biscuit and caramel, Caramel chocolate cookie bars
+de: Kekse mit Karamellschokolade
+fr: Barres chocolatées biscuitées au caramel
+hr: Karamel čokoladne keksiće
+it: Barrette biscottate al cioccolato e caramello
+lt: Šokoladiniai batonėliai su karamele ir sausainiais
+nl: Koekjesrepen met caramel en chocola
+
 # Bounty-style bars
-< en: Bars covered with chocolate
-< en: Coconuts and their products
+< en: Candy chocolate bars
+en: Candy chocolate bars filled with coconut
 fr: Barres chocolatées à la noix de coco, barre chocolatée à la noix de coco type Bounty, Bounty
 nl: Chocorepen met kokosvulling
 agribalyse_food_code:en: 31002
@@ -39100,23 +39111,24 @@ ciqual_food_code:en: 31002
 ciqual_food_name:en: Coconut bar, with chocolate coating
 
 # Kinder country style bars
-< en: Bars covered with chocolate
-en: Chocolate covered bars with milk and cereals, Milky cereal breakfast bar with chocolate fortified with vitamins and minerals, Milky cereal breakfast bar fortified with vitamins and minerals
+< en: Candy chocolate bars
+en: Candy chocolate bars filled with milk and cereals, Chocolate covered bars with milk and cereals, Milky cereal breakfast bar with chocolate fortified with vitamins and minerals, Milky cereal breakfast bar fortified with vitamins and minerals
 fr: Barres chocolatées au lait et aux céréales, barre chocolatée au lait et aux céréales type Kinder Country, Kinder Country, barre de céréales au lait et au chocolat
 #Q3815377
 agribalyse_food_code:en: 31100
 ciqual_food_code:en: 31100
 ciqual_food_name:en: Milky cereal breakfast bar, with chocolate or not, fortified with vitamins and minerals
 
-< en: Bars covered with chocolate
-fr: Barres chocolatées aux fruits oléagineux, barre chocolatée aux fruits oléagineux type Snickers, Snickers
+< en: Candy chocolate bars
+en: Candy chocolate bars filled with caramel and peanuts
+fr: Barres chocolatées au caramel et cacahuètes, Barres chocolatées aux fruits oléagineux, barre chocolatée aux fruits oléagineux type Snickers, Snickers
 #Q714179
 
-< en: Bars covered with chocolate
+< en: Candy chocolate bars
 fr: Barres chocolatées fourrées aux fruits, barre chocolatée fourrée aux fruits
 
-< en: Bars covered with chocolate
-en: Caramel chocolate bars
+< en: Candy chocolate bars
+en: Candy chocolate bars filled with caramel, Caramel chocolate bars
 de: Schokoriegel mit Karamell, Schokoriegel mit Karamellüberzug, Schokoriegel mit Karamellfüllung
 fi: Toffee-suklaapatukat
 fr: Barres chocolatées au caramel
@@ -39126,7 +39138,7 @@ lt: Šokoladiniai batonėliai su karamele
 nl: Chococaramelrepen, Chocolade-caramelrepen
 pt: Barras de chocolate caramelo
 
-< en: Bars covered with chocolate
+< en: Candy chocolate bars
 en: Chocolate nuts cookie bars
 de: Schokoladenkekse mit Nüssen
 fr: Barres chocolatées biscuitées aux noisettes
@@ -39135,16 +39147,7 @@ it: Barrette biscottate alle noci e cioccolato
 lt: Šokoladiniai batonėliai su riešutais ir sausainiais
 nl: Chocorepen met noten en biscuit
 
-< en: Bars covered with chocolate
-en: Caramel chocolate cookie bars
-de: Kekse mit Karamellschokolade
-fr: Barres chocolatées biscuitées au caramel
-hr: Karamel čokoladne keksiće
-it: Barrette biscottate al cioccolato e caramello
-lt: Šokoladiniai batonėliai su karamele ir sausainiais
-nl: Koekjesrepen met caramel en chocola
-
-< en: Bars covered with chocolate
+< en: Candy chocolate bars
 en: Chocolate confectionery with dairy filling, Chocolate bar with dairy filling
 fr: Barres chocolatées au lait, Confiserie chocolatées au lait, Barres chocolatées au lait, Barre chocolatée au lait, Barres chocolatées au lait type Kinder Maxi, Kinder Maxi
 hr: Čokoladni slatkiši s mliječnim punjenjem
@@ -39153,14 +39156,14 @@ agribalyse_food_code:en: 31012
 ciqual_food_code:en: 31012
 ciqual_food_name:en: Chocolate confectionery or bar, with dairy filling
 
-< en: Bars covered with chocolate
+< en: Candy chocolate bars
 en: Chocolate snack bar dairy filling
 fr: Barre de chocolat au lait frais
 agribalyse_food_code:en: 31073
 ciqual_food_code:en: 31073
 ciqual_food_name:en: Chocolate snack bar, dairy filling
 
-< en: Bars covered with chocolate
+< en: Candy chocolate bars
 en: Chocolate snack bar dairy filling with sponge cake
 fr: barre de chocolat au lait frais avec génoise
 agribalyse_food_code:en: 31099


### PR DESCRIPTION
* rewrote names of candy chocolate bars in English to improve clarity and corrected the translation in other languages
* removed "Candy chocolate bars filled with coconut" from "Coconuts and their products". This type of products contains to little coconut to be considered coconut-based

