### PR TITLE
ci: disable some actions on forks

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   ShowAndLabelTopIssues:
     name: Display and label top issues.
+    if: github.repository == 'openfoodfacts/openfoodfacts-server'
     runs-on: ubuntu-latest
     steps:
     - name: Run top issues action


### PR DESCRIPTION
Some actions have no point running on forks where things like issues are disabled, and can lead to : 
- useless compute
- notification spam