### PR TITLE
feat(lint_taxonomy): “comment” typo check, round 2

### DIFF
--- a/scripts/taxonomies/lint_taxonomy.pl
+++ b/scripts/taxonomies/lint_taxonomy.pl
@@ -215,12 +215,12 @@ sub iter_taxonomy_entries ($lines_iter) {
 					push(
 						@errors,
 						{
-							severity => "Warning",
+							# demote severity to Warning if this begins returning false positives
+							severity => "Error",
 							type => "Correctness",
 							line => $line_num,
 							message => (
-									  "\"$prop\" might be a typo of \"comment\":\n" . "- "
-									. $props{"$prop:$lc"}->{line}
+									  "\"$prop\" might be a typo of \"comment\":"
 									. "\n- $line"
 							)
 						}

--- a/scripts/taxonomies/lint_taxonomy.pl
+++ b/scripts/taxonomies/lint_taxonomy.pl
@@ -219,10 +219,7 @@ sub iter_taxonomy_entries ($lines_iter) {
 							severity => "Error",
 							type => "Correctness",
 							line => $line_num,
-							message => (
-									  "\"$prop\" might be a typo of \"comment\":"
-									. "\n- $line"
-							)
+							message => ("\"$prop\" might be a typo of \"comment\":" . "\n- $line")
 						}
 					);
 				}


### PR DESCRIPTION
Bumps severity to `Error` until we actually have properties that are not “comment” typos, and cleans up the output.

Follow-up-to: https://github.com/openfoodfacts/openfoodfacts-server/pull/14317
Follow-up-to: 9d5ff10c1f40a464f9064892ef9fff4cf35ccda2