### PR TITLE
feat: Add support for Amazon FNSKU barcode

### DIFF
--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -581,6 +581,10 @@ sub normalize_code_with_gs1_ai ($code) {
 
 	my $ai_data_str;
 	if (defined $code) {
+		# Keep Amazon FNSKUs unchanged
+        return ($code, undef) if $code =~ /^X00[A-Z0-9]{7}$/;
+		return ($code, undef) if $code =~ /^X/ && $code !~ /^X00[A-Z0-9]{7}$/;
+
 		my ($gs1_code, $gs1_ai_data_str) = &_try_normalize_code_gs1($code);
 		if ($gs1_code and $gs1_ai_data_str) {
 			$code = $gs1_code;
@@ -675,6 +679,10 @@ Boolean value indicating if the code is valid or not.
 sub is_valid_code ($code) {
 	# Return an empty string if $code is undef
 	return '' if !defined $code;
+
+	# Amazon FNSKU
+    return 1 if $code =~ /^X00[A-Z0-9]{7}$/;
+
 	my $code_without_leading_zeroes = $code;
 	# Remove leading zeroes
 	$code_without_leading_zeroes =~ s/^0+//;

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -346,6 +346,12 @@ is(is_valid_code('123'), '', '3 digit code');
 is(is_valid_code('00000123'), '', '3 digit code with leading 0s');
 is(is_valid_code('1234567890123456789012345678901234567890123456789012345678901234567890'), '', 'too long code');
 is(is_valid_code(undef), '', 'undefined code');
+is(is_valid_code('X001ABCDEF'), 1, 'valid Amazon FNSKU');
+is(is_valid_code('X002TJHLPN'), 1, 'valid Amazon FNSKU');
+is(is_valid_code('X001UVTA2F'), 1, 'valid Amazon FNSKU');
+is(is_valid_code('X101UVTA2F'), '', 'invalid Amazon FNSKU - wrong prefix');
+is(is_valid_code('X001UVTA2'), '', 'invalid Amazon FNSKU - too short');
+is(is_valid_code('X001UVTA2FF'), '', 'invalid Amazon FNSKU - too long');
 
 my @tests = (
 	[


### PR DESCRIPTION
### What
Adds support for Amazon FNSKU barcodes such as X001UVTA2F.

### Changes
Recognize Amazon FNSKUs using the X00 alphanumeric format and Prevent invalid barcodes like  X101UVTA2F from being converted into numeric barcodes.

### Testing
Manually tested and numeric barcodes continue to work.

Fixes: #11038
