### PR TITLE
fix: count individual polyols (isomalt, maltitol, sorbitol) in energy computation

### DIFF
--- a/lib/ProductOpener/Nutrition.pm
+++ b/lib/ProductOpener/Nutrition.pm
@@ -2584,6 +2584,11 @@ sub convert_salt_to_sodium ($salt_value) {
 	},
 );
 
+# Polyols that can be entered individually in the nutrition facts, without a value for the
+# aggregate "polyols" nutrient. Erythritol is listed here too, but it is handled separately
+# above as it does not contribute any energy, unlike the other polyols.
+my @individual_polyols_nids = ("erythritol", "isomalt", "maltitol", "sorbitol");
+
 =head2 compute_energy_from_nutrients_for_nutrients_set ( $nutrients_ref, $unit )
 
 Computes the energy from other nutrients for a given input set.
@@ -2618,6 +2623,20 @@ sub compute_energy_from_nutrients_for_nutrients_set ($nutrients_ref, $unit) {
 		and (defined $proteins_value))
 	{
 
+		# If we do not have a value for the aggregate "polyols" nutrient, but we have values for
+		# individual polyols (e.g. isomalt, maltitol, sorbitol, erythritol), compute the polyols
+		# value as the sum of the individual polyols values, so that they are taken into account
+		# in the energy computation below (instead of being counted as regular carbohydrates).
+		my $polyols_value = deep_get($nutrients_ref, "polyols", "value");
+		if (not defined $polyols_value) {
+			foreach my $individual_polyol_nid (@individual_polyols_nids) {
+				my $individual_polyol_value = deep_get($nutrients_ref, $individual_polyol_nid, "value");
+				if (defined $individual_polyol_value) {
+					$polyols_value += $individual_polyol_value;
+				}
+			}
+		}
+
 		foreach my $nid (keys %{$energy_from_nutrients{europe}}) {
 
 			my $energy_per_gram = $energy_from_nutrients{europe}{$nid}{$lc_unit};
@@ -2627,19 +2646,19 @@ sub compute_energy_from_nutrients_for_nutrients_set ($nutrients_ref, $unit) {
 				my $nid_minus = $';
 				$nid = $`;
 
-				# If we are computing carbohydrates minus polyols, and we do not have a value for polyols
-				# but we have a value for erythritol (which is a polyol), then we need to remove erythritol
-				if (($nid_minus eq "polyols") and (not deep_exists($nutrients_ref, $nid_minus, "value"))) {
-					$nid_minus = "erythritol";
+				if ($nid_minus eq "polyols") {
+					$grams -= $polyols_value || 0;
 				}
-				# Similarly for polyols minus erythritol
-				if (($nid eq "polyols") and (not deep_exists($nutrients_ref, $nid, "value"))) {
-					$nid = "erythritol";
+				else {
+					$grams -= deep_get($nutrients_ref, $nid_minus, "value") || 0;
 				}
-
-				$grams -= deep_get($nutrients_ref, $nid_minus, "value") || 0;
 			}
-			$grams += deep_get($nutrients_ref, $nid, "value") || 0;
+			if ($nid eq "polyols") {
+				$grams += $polyols_value || 0;
+			}
+			else {
+				$grams += deep_get($nutrients_ref, $nid, "value") || 0;
+			}
 			$computed_energy += $grams * $energy_per_gram;
 		}
 

--- a/tests/unit/dataqualityfood.t
+++ b/tests/unit/dataqualityfood.t
@@ -621,6 +621,63 @@ check_quality_and_test_product_has_quality_tag(
 	'energy not matching nutrient', 0
 );
 
+# Isomalt is a polyol which contributes energy at the general polyols rate (10 kj / 2.4 kcal per g)
+# If we do not have a value for polyols but we have a value for isomalt, we should assume that
+# polyols are equal to isomalt when we check the nutrients to energy computation.
+# (100 g carbohydrates, all of it isomalt -> 100 g * 10 kj/g = 1000 kj)
+$product_ref = {
+	nutrition => {
+		input_sets => [
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "100g",
+				nutrients => {
+					"energy-kj" => {value => 1000, unit => "kj"},
+					"carbohydrates" => {value => 100, unit => "g"},
+					"isomalt" => {value => 100, unit => "g"},
+					"fat" => {value => 0, unit => "g"},
+					"proteins" => {value => 0, unit => "g"},
+					"fiber" => {value => 0, unit => "g"},
+				}
+			}
+		]
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-producer-as-sold-100g-energy-value-in-kj-does-not-match-value-computed-from-other-nutrients',
+	'energy matching nutrient - isomalt without polyols', 0
+);
+
+# Individual polyols values (isomalt and maltitol) should be summed when there is no value for polyols
+# (100 g carbohydrates, 60 g isomalt + 40 g maltitol -> 100 g * 10 kj/g = 1000 kj)
+$product_ref = {
+	nutrition => {
+		input_sets => [
+			{
+				source => "producer",
+				preparation => "as_sold",
+				per => "100g",
+				nutrients => {
+					"energy-kj" => {value => 1000, unit => "kj"},
+					"carbohydrates" => {value => 100, unit => "g"},
+					"isomalt" => {value => 60, unit => "g"},
+					"maltitol" => {value => 40, unit => "g"},
+					"fat" => {value => 0, unit => "g"},
+					"proteins" => {value => 0, unit => "g"},
+					"fiber" => {value => 0, unit => "g"},
+				}
+			}
+		]
+	}
+};
+check_quality_and_test_product_has_quality_tag(
+	$product_ref,
+	'en:nutrition-producer-as-sold-100g-energy-value-in-kj-does-not-match-value-computed-from-other-nutrients',
+	'energy matching nutrient - isomalt and maltitol without polyols', 0
+);
+
 # en:nutrition-value-negative-$nid should be raised - for nutrients below 0
 $product_ref = {
 	nutrition => {


### PR DESCRIPTION
## What
Products that enter individual polyols (isomalt, maltitol, sorbitol) instead of the
aggregate "polyols" nutrient had those grams counted as regular carbohydrate
(4 kcal/g) instead of the polyols rate (2.4 kcal/g) when computing energy from
nutrients. This produced an inflated computed energy value and a false
"energy does not match nutrients" data quality warning, as reported for
[Pulmoll Eukalyptus Menthol Zuckerfrei](https://world.openfoodfacts.org/product/4002590140940/pulmoll-eukalyptus-menthol-zuckerfrei),
which lists isomalt but no aggregate polyols value.

## How
- `compute_energy_from_nutrients_for_nutrients_set` in `Nutrition.pm` only ever
  fell back to `erythritol` when the aggregate `polyols` value was missing.
- When `polyols` isn't set, sum whichever individual polyols
  (`erythritol`, `isomalt`, `maltitol`, `sorbitol`) are present and use that sum
  as the effective polyols value in the energy formula, instead of only checking
  erythritol.
- `erythritol` keeps contributing 0 kcal/g as before; the other individual polyols
  now correctly contribute at the general polyols rate (2.4 kcal/g / 10 kJ/g)
  instead of being silently treated as plain carbohydrate.

## Testing
- Added two unit tests to `tests/unit/dataqualityfood.t`: isomalt alone, and
  isomalt + maltitol summed, both without an aggregate `polyols` value. Verified
  they fail against the old code (computed energy off by 700 kJ) and pass against
  the fix.
- `make test-unit test="dataqualityfood.t"` passes (196 assertions).
- Ran related suites (`nutrition.t`, `nutriscore.t`, `nutrition_estimation.t`,
  `nutrient_levels.t`, `nutrition_ciqual.t`, `ingredients_nutriscore.t`) — all pass.
- `make checks` (perltidy, perlcritic, syntax, taxonomy lint) — clean.

Fixes #14344