### PR TITLE
taxonomy: Add some german spellings/syns

### DIFF
--- a/taxonomies/additives.txt
+++ b/taxonomies/additives.txt
@@ -23336,7 +23336,7 @@ bn: E954, স্যাকারিন
 ca: E954, sacarina i les seves sals de sodi potassi i calci, sacarina
 cs: E954, sacharin a jeho sodná draselná a vápenatá sůl, sacharin, cukerín, zuckerin
 da: E954, saccharin and its na. k and ca salts, sakkarin, saccharin
-de: E954, Saccharin, Benzoesäuresulfimid, Saccharin-Natrium
+de: E954, Saccharin, Benzoesäuresulfimid, Natriumsaccharin, Saccharin-Natrium
 el: E954, σακχαρινες
 eo: E954, sakarino
 es: E954, sacarina, Sacarina y sus sales de sodio potasio y calcio, sacarinas, sacarina sódica

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -529,7 +529,7 @@ bg: слънчогледов лецитин
 ca: lecitina de gira-sol, lecitines de gira-sol
 cs: slunečnicový lecitin, slunečnicové lecitiny
 da: solsikkelecithin
-de: Sonnenblumenlecithine, Sonnenblumenlecithin, Sonnenblumen-Lecithine
+de: Sonnenblumenlecithine, Sonnenblumenlecithin, Sonnenblumen-Lecithine, Sonnenblumen-Lecithin
 el: λεκιθίνες ηλιστροπιου
 es: lecitina de girasol, lecitinas de girasol
 et: päevalilleletsitiin, päevalille letsitiin
@@ -33229,7 +33229,7 @@ xx: FOS
 ar: قليل السكاريد الفركتوزي
 bg: Фруктоолигозахарид
 ca: Fructooligosacàrid
-de: Fructooligosaccharid
+de: Fructooligosaccharid, Fructooligosaccharide
 el: Φρουκτοολιγοσακχαρίτες
 es: Fructooligosacárido, Fructoligosacáridos
 et: Frukto-oligosahhariidid, Fruktooligosahhariidid
@@ -34139,7 +34139,7 @@ nova:en: 4
 
 < en: whey protein
 en: whey protein isolate, whey isolate
-de: Molkenprotein-Isolat , Whey Protein Isolat, Whey Isolat
+de: Molkenprotein-Isolat , Whey Protein Isolat, Whey Isolat, Molkenproteinisolat
 es: Proteína de suero aislada
 fi: heraproteiini-isolaatti
 fr: Isolat de protéine de lactosérum
@@ -61617,7 +61617,7 @@ eurocode_2_group_4:en: 7.10.30.20
 en: red bean, red beans, red kidney beans
 bg: червен боб
 da: Røde kidneybønner, kidneybønner
-de: Rote Bohnen, Kidneybohnen
+de: Rote Bohnen, Kidneybohnen, Kidney-Bohnen
 es: Alubias rojas, judias rojas
 fi: punaiset kidneypavut, kidneypapu
 fr: haricot rouge, haricots rouges

--- a/taxonomies/vitamins.txt
+++ b/taxonomies/vitamins.txt
@@ -1396,7 +1396,7 @@ bs: vitamin B2
 ca: riboflavina, vitamina B2
 cs: riboflavin, vitamín B2
 cy: ribofflafin, fitamin B2
-de: Riboflavin, Vitamin B2
+de: Riboflavin, Riboflavine, Vitamin B2
 dv: ވިޓަމިން ބީ2
 el: ριβοφλαβίνη, βιταμίνη Β2
 eo: riboflavino, vitamino B2


### PR DESCRIPTION
[Molkenproteinisolat](https://de.openfoodfacts.org/facets/zutaten/molkenproteinisolat) used by 50 products
[Kidney-Bohnen](https://de.openfoodfacts.org/facets/zutaten/kidney-bohnen) used by 46 products
[Sonnenblumen-Lecithin](https://de.openfoodfacts.org/facets/zutaten/sonnenblumen-lecithin) used by 31 products
[Riboflavine](https://de.openfoodfacts.org/facets/zutaten/riboflavine) used by 114 products
[Fructooligosaccharide](https://de.openfoodfacts.org/facets/zutaten/fructooligosaccharide) used by 47 products
[Natriumsaccharin](https://de.openfoodfacts.org/facets/zutaten/natriumsaccharin) used by 173 products
