### PR TITLE
taxonomy: Add more Canadian cities to origins.txt

### DIFF
--- a/taxonomies/origins.txt
+++ b/taxonomies/origins.txt
@@ -5579,91 +5579,238 @@ en: French Guyana
 < en: canada
 en: Alberta
 xx: Alberta
+fr: Alberta
 iso:en: CA-AB
 wikipedia:en: https://en.wikipedia.org/wiki/Alberta
+
+< en: alberta
+en: Calgary
+xx: Calgary
+fr: Calgary
+wikipedia:en: https://en.wikipedia.org/wiki/Calgary
+
+< en: alberta
+en: Edmonton
+xx: Edmonton
+fr: Edmonton
+wikipedia:en: https://en.wikipedia.org/wiki/Edmonton
 
 < en: canada
 en: British Columbia
 xx: British Columbia
+fr: Colombie-Britannique
 iso:en: CA-BC
 wikipedia:en: https://en.wikipedia.org/wiki/British_Columbia
+
+< en: british columbia
+en: Vancouver
+xx: Vancouver
+fr: Vancouver
+wikipedia:en: https://en.wikipedia.org/wiki/Vancouver
+
+< en: british columbia
+en: Surrey
+xx: Surrey
+fr: Surrey
+wikipedia:en: https://en.wikipedia.org/wiki/Surrey,_British_Columbia
+
+< en: british columbia
+en: Victoria
+xx: Victoria
+fr: Victoria
+wikipedia:en: https://en.wikipedia.org/wiki/Victoria,_British_Columbia
 
 < en: canada
 en: Manitoba
 xx: Manitoba
+fr: Manitoba
 iso:en: CA-MB
 wikipedia:en: https://en.wikipedia.org/wiki/Manitoba
+
+< en: manitoba
+en: Winnipeg
+xx: Winnipeg
+fr: Winnipeg
+wikipedia:en: https://en.wikipedia.org/wiki/Winnipeg
+
+< en: manitoba
+en: Brandon
+xx: Brandon
+fr: Brandon
+wikipedia:en: https://en.wikipedia.org/wiki/Brandon,_Manitoba
 
 < en: canada
 en: New Brunswick
 xx: New Brunswick
+fr: Nouveau-Brunswick
 iso:en: CA-NB
 wikipedia:en: https://en.wikipedia.org/wiki/New_Brunswick
+
+< en: new brunswick
+en: Saint John
+xx: Saint John
+fr: Saint John
+wikipedia:en: https://en.wikipedia.org/wiki/Saint_John,_New_Brunswick
+
+< en: new brunswick
+en: Moncton
+xx: Moncton
+fr: Moncton
+wikipedia:en: https://en.wikipedia.org/wiki/Moncton
 
 < en: canada
 en: Newfoundland and Labrador
 xx: Newfoundland and Labrador
+fr: Terre-Neuve-et-Labrador
 iso:en: CA-NL
 wikipedia:en: https://en.wikipedia.org/wiki/Newfoundland_and_Labrador
+
+< en: newfoundland and labrador
+en: St. John's
+xx: St. John's
+fr: St. John's
+wikipedia:en: https://en.wikipedia.org/wiki/St._John%27s,_Newfoundland_and_Labrador
 
 < en: canada
 en: Northwest Territories
 xx: Northwest Territories
+fr: Territoires du Nord-Ouest
 iso:en: CA-NT
 wikipedia:en: https://en.wikipedia.org/wiki/Northwest_Territories
+
+< en: northwest territories
+en: Yellowknife
+xx: Yellowknife
+fr: Yellowknife
+wikipedia:en: https://en.wikipedia.org/wiki/Yellowknife
 
 < en: canada
 en: Nova Scotia
 xx: Nova Scotia
+fr: Nouvelle-Écosse
 iso:en: CA-NS
 wikipedia:en: https://en.wikipedia.org/wiki/Nova_Scotia
+
+< en: nova scotia
+en: Halifax
+xx: Halifax
+fr: Halifax
+wikipedia:en: https://en.wikipedia.org/wiki/Halifax,_Nova_Scotia
+
+< en: nova scotia
+en: Sydney
+xx: Sydney
+fr: Sydney
+wikipedia:en: https://en.wikipedia.org/wiki/Sydney,_Nova_Scotia
 
 < en: canada
 en: Nunavut
 xx: Nunavut
+fr: Nunavut
 iso:en: CA-NU
 wikipedia:en: https://en.wikipedia.org/wiki/Nunavut
+
+< en: nunavut
+en: Iqaluit
+xx: Iqaluit
+fr: Iqaluit
+wikipedia:en: https://en.wikipedia.org/wiki/Iqaluit
 
 < en: canada
 en: Ontario
 xx: Ontario
+fr: Ontario
 iso:en: CA-ON
 wikipedia:en: https://en.wikipedia.org/wiki/Ontario
 
 < en: ontario
 en: Toronto
 xx: Toronto
+fr: Toronto
 wikipedia:en: https://en.wikipedia.org/wiki/Toronto
+
+< en: ontario
+en: Ottawa
+xx: Ottawa
+fr: Ottawa
+wikipedia:en: https://en.wikipedia.org/wiki/Ottawa
+
+< en: ontario
+en: Mississauga
+xx: Mississauga
+fr: Mississauga
+wikipedia:en: https://en.wikipedia.org/wiki/Mississauga
 
 < en: canada
 en: Prince Edward Island
 xx: Prince Edward Island
+fr: Île-du-Prince-Édouard
 iso:en: CA-PE
 wikipedia:en: https://en.wikipedia.org/wiki/Prince_Edward_Island
+
+< en: prince edward island
+en: Charlottetown
+xx: Charlottetown
+fr: Charlottetown
+wikipedia:en: https://en.wikipedia.org/wiki/Charlottetown
 
 < en: canada
 en: Québec
 xx: Québec
+fr: Québec
 iso:en: CA-QC
 wikipedia:en: https://en.wikipedia.org/wiki/Quebec
 
 < en: quebec
 en: Montreal
 xx: Montreal
+fr: Montréal
 web:en: https://montreal.ca/en/
 wikipedia:en: https://en.wikipedia.org/wiki/Montreal
+
+< en: quebec
+en: Quebec City
+xx: Quebec City
+fr: Ville de Québec
+wikipedia:en: https://en.wikipedia.org/wiki/Quebec_City
+
+< en: quebec
+en: Laval
+xx: Laval
+fr: Laval
+wikipedia:en: https://en.wikipedia.org/wiki/Laval,_Quebec
 
 < en: canada
 en: Saskatchewan
 xx: Saskatchewan
+fr: Saskatchewan
 iso:en: CA-SK
-wikipedia:en: wikipedia:en: https://en.wikipedia.org/wiki/Saskatchewan
+wikipedia:en: https://en.wikipedia.org/wiki/Saskatchewan
+
+< en: saskatchewan
+en: Saskatoon
+xx: Saskatoon
+fr: Saskatoon
+wikipedia:en: https://en.wikipedia.org/wiki/Saskatoon
+
+< en: saskatchewan
+en: Regina
+xx: Regina
+fr: Regina
+wikipedia:en: https://en.wikipedia.org/wiki/Regina,_Saskatchewan
 
 < en: canada
 en: Yukon
 xx: Yukon
+fr: Yukon
 iso:en: CA-YT
 wikipedia:en: https://en.wikipedia.org/wiki/Yukon
+
+< en: yukon
+en: Whitehorse
+xx: Whitehorse
+fr: Whitehorse
+wikipedia:en: https://en.wikipedia.org/wiki/Whitehorse,_Yukon
 
 # Germany regions
 


### PR DESCRIPTION
## What
Expands Canadian coverage in `taxonomies/origins.txt`:

- Adds 22 city-level origin sub-tags across all 10 provinces and 3 territories (2-3 per province, 1 for territories where a single major city dominates), following the existing Toronto/Montreal pattern:
  - AB: Calgary, Edmonton
  - BC: Vancouver, Surrey, Victoria
  - MB: Winnipeg, Brandon
  - NB: Saint John, Moncton
  - NL: St. John's
  - NT: Yellowknife
  - NS: Halifax, Sydney
  - NU: Iqaluit
  - ON: Ottawa, Mississauga
  - PE: Charlottetown
  - QC: Quebec City, Laval
  - SK: Saskatoon, Regina
  - YT: Whitehorse
- Adds `fr:` names to all Canadian province/territory and city entries, since Canada is officially bilingual (en + fr) — several provinces have distinct official French names (e.g. British Columbia → Colombie-Britannique, Nova Scotia → Nouvelle-Écosse).
- Fixes a pre-existing doubled-prefix typo on the Saskatchewan `wikipedia:en:` property (`wikipedia:en: wikipedia:en: ...`).

## Why
Product origin data for Canada was limited to provinces/territories plus only Toronto and Montreal at the city level, despite Canada being one of the taxonomy's bilingual-tracked countries. This gives more granular origin tagging for products labelled with a specific Canadian city.

## Testing
Ran `scripts/taxonomies/lint_taxonomy.pl --check taxonomies/origins.txt` — exits 0, no errors or warnings.

### Large Language Models usage disclosure
This PR was written agentically by Claude Code (Claude Sonnet 5), under human direction and review. The code/data was run and verified on the contributor's machine via `scripts/taxonomies/lint_taxonomy.pl --check` in the project's docker `backend` container (output included above).

### Related issue(s) and discussion
- Fixes: #14457
