### PR TITLE
fix: off_ca nutrition table to match 2016 CFIA regulation (SOR/2016-305)

### DIFF
--- a/lib/ProductOpener/Food.pm
+++ b/lib/ProductOpener/Food.pm
@@ -206,7 +206,10 @@ It is a list of nutrients names with eventual prefixes and suffixes:
 
 =cut
 
-# http://healthycanadians.gc.ca/eating-nutrition/label-etiquetage/tips-conseils/nutrition-fact-valeur-nutritive-eng.php
+# Core nutrients mandatory in the Canadian Nutrition Facts table, per the Food and Drug
+# Regulations as amended by SOR/2016-305 (in force for all businesses since 2025-12-14):
+# https://gazette.gc.ca/rp-pr/p2/2016/2016-12-14/html/sor-dors305-eng.html
+# https://inspection.canada.ca/en/food-labels/labelling/industry/nutrition-labelling/nutrition-facts-table
 %nutrients_tables = (
 	off_europe => [
 		(
@@ -312,17 +315,17 @@ It is a list of nutrients names with eventual prefixes and suffixes:
 			'-serum-proteins-', '-nucleotides-',
 			'salt', '-added-salt-',
 			'sodium', 'alcohol',
-			'#vitamins', 'vitamin-a',
-			'beta-carotene-', 'vitamin-d-',
+			'#vitamins', 'vitamin-a-',
+			'beta-carotene-', 'vitamin-d',
 			'vitamin-d2-', 'vitamin-d3-',
 			'vitamin-e-', 'vitamin-k-',
-			'vitamin-c', 'vitamin-b1-',
+			'vitamin-c-', 'vitamin-b1-',
 			'vitamin-b2-', 'vitamin-pp-',
 			'vitamin-b6-', 'vitamin-b9-',
 			'folates-', 'vitamin-b12-',
 			'biotin-', 'pantothenic-acid-',
 			'#minerals', 'silica-',
-			'bicarbonate-', 'potassium-',
+			'bicarbonate-', 'potassium',
 			'chloride-', 'calcium',
 			'phosphorus-', 'iron',
 			'magnesium-', 'zinc-',

--- a/taxonomies/nutrients.txt
+++ b/taxonomies/nutrients.txt
@@ -3878,6 +3878,7 @@ dv_2016_value:en: 20
 dv_value:en: 20
 iu_value:en: 0.025
 unit:en: µg
+unit_ca:en: % DV
 wikidata:en: Q175621
 wikipedia:en: https://en.wikipedia.org/wiki/Vitamin_D
 
@@ -4964,6 +4965,7 @@ za: Gyaz
 zh: 钾
 dv_value:en: 4700
 unit:en: mg
+unit_ca:en: % DV
 wikidata:en: Q703
 wikipedia:en: https://en.wikipedia.org/wiki/Potassium
 


### PR DESCRIPTION
## What
The Canadian nutrition-facts table (`off_ca` in `lib/ProductOpener/Food.pm`) still reflects the pre-2016 mandatory-nutrient list:

| Nutrient | Before this PR | After this PR |
|---|---|---|
| Vitamin A | visible by default | hidden by default |
| Vitamin C | visible by default | hidden by default |
| Vitamin D | hidden by default | **visible by default** |
| Potassium | hidden by default | **visible by default** |

Also adds the missing `unit_ca:en: % DV` property to Vitamin D and Potassium in `taxonomies/nutrients.txt` (already present for Vitamin A, Vitamin C, Calcium, Iron — this was the last missing piece for full Canada %DV coverage).

## Why
The Food and Drug Regulations were amended by [SOR/2016-305](https://gazette.gc.ca/rp-pr/p2/2016/2016-12-14/html/sor-dors305-eng.html) (Canada Gazette, Part 2, Dec 14 2016). Per Item 13 and Item 16 of the amended table to section B.01.401, **Potassium and Vitamin D became mandatory core nutrients**, while Vitamin A and Vitamin C were moved out of the universal mandatory list into the conditional nutrient-claim section (B.01.402) — see also the current [CFIA nutrition labelling guidance](https://inspection.canada.ca/en/food-labels/labelling/industry/nutrition-labelling/nutrition-facts-table).

The small-business transition period for this rule ended December 14, 2025, so as of now the amended table applies to all prepackaged foods sold in Canada with no remaining exemption.

`off_us` was already updated for the equivalent US 2016 label reform (`vitamin-d` and `potassium` visible, `vitamin-a-`/`vitamin-c-` hidden) — `off_ca` had the same four fields in the opposite (pre-2016) state, which is what led me to this.

Also updated the source comment above `%nutrients_tables` — the old `healthycanadians.gc.ca` link is dead; replaced with the actual regulation and the current CFIA page.

## Testing
- `scripts/taxonomies/lint_taxonomy.pl --check taxonomies/nutrients.txt` — exit 0, no errors/warnings.
- `perl -c lib/ProductOpener/Food.pm` — syntax OK.
- No existing tests reference `off_ca` directly.

### Large Language Models usage disclosure
This PR was written agentically by Claude Code (Claude Sonnet 5), under human direction and review. The code was run and verified on the contributor's machine: `scripts/taxonomies/lint_taxonomy.pl --check` and `perl -c` on `Food.pm` in the project's docker `backend` container (output included above).

### Related issue(s) and discussion
- Fixes: #14458
