### PR TITLE
taxonomy: Update Canadian FOP nutrition symbol description to reflect mandatory status

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -23775,8 +23775,8 @@ web:fr: https://prixjuste.be/
 en: Canadian Front-of-package nutrition symbol
 fr: Symbole nutritionnel sur le devant de l'emballage
 country:en: en:Canada
-description:en: In Canada, a front-of-package nutrition symbol is required on foods that are high in one or more of these nutrients: sodium, sugars, saturated fat. The food industry has been given until January 1, 2026 to make this change. However, you may start seeing the front-of-package nutrition symbol earlier.
-description:fr: Au Canada, un symbole nutritionnel sur le devant de l'emballage doit être apposé sur les aliments riches en un ou plusieurs de ces nutriments : sodium, sucres, gras saturés. L'industrie alimentaire a jusqu'au 1er janvier 2026 pour procéder à ce changement. Toutefois, il est possible que vous commenciez à voir le symbole nutritionnel sur la face avant des emballages plus tôt.
+description:en: In Canada, a front-of-package nutrition symbol is required on most prepackaged foods that are high in one or more of these nutrients: sodium, sugars, saturated fat. This requirement has been mandatory since January 1, 2026.
+description:fr: Au Canada, un symbole nutritionnel sur le devant de l'emballage doit être apposé sur la plupart des aliments préemballés riches en un ou plusieurs de ces nutriments : sodium, sucres, gras saturés. Cette exigence est obligatoire depuis le 1er janvier 2026.
 label_categories:en: nutritional-values
 web:en: https://www.canada.ca/en/health-canada/services/food-nutrition/nutrition-labelling/front-package.html
 web:fr: https://www.canada.ca/fr/sante-canada/services/aliments-nutrition/etiquetage-nutritionnel/devant-emballage.html


### PR DESCRIPTION
## What
Updates the `en`/`fr` `description:` properties on the "Canadian front-of-package nutrition symbol" label entry in `taxonomies/labels.txt`.

## Why
The description still said the food industry had "until January 1, 2026" to comply, with a note that the symbol "may" appear earlier. That deadline has now passed — per Health Canada / CFIA implementation guidance, the requirement is mandatory for most prepackaged foods with no enforcement grace period. Updated the wording from pre-deadline framing to reflect the now-in-force status.

## Testing
`scripts/taxonomies/lint_taxonomy.pl --check taxonomies/labels.txt` — exit 0, no errors/warnings.

### Large Language Models usage disclosure
This PR was written agentically by Claude Code (Claude Sonnet 5), under human direction and review. The code was run and verified on the contributor's machine via `scripts/taxonomies/lint_taxonomy.pl --check` in the project's docker `backend` container (output included above).

### Related issue(s) and discussion
- Fixes: #14459
