### PR TITLE
taxonomy: Fix inaccurate origin note on canola oil in ingredients.txt

### DIFF
--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -16562,8 +16562,8 @@ ja: キャノーラ油, なたね油
 nl: canola olie, canolaolie
 # sv: rybsolja, rypsolja # duplicate, unclear which is correct
 tr: kanola yağı
-comment:en: Use only the word canola in this ingredient, as it is only for the american variety of rapeseed
-description:en: Canola oil, or canola for short, originally known as low erucic acid rapeseed, is a vegetable oil derived from a variety of rapeseed that is low in erucic acid, as opposed to colza oil.
+comment:en: Use only the word canola in this ingredient. "Canola" is a Canadian-bred and trademarked variety of low erucic acid rapeseed (the name is a portmanteau of "Canadian oil, low acid"), not a generic synonym for any rapeseed variety.
+description:en: Canola oil, or canola for short, originally known as low erucic acid rapeseed, is a vegetable oil derived from a variety of rapeseed bred in Canada (Saskatchewan and Manitoba, 1960s-1970s) to be low in erucic acid, as opposed to colza oil.
 description:es: El aceite de colza (aceite de nabina o de canola) es el extracto de la semilla de la colza, usado sobre todo en el norte de Europa como condimento y para el alumbrado.
 description:pt: Canola é um cultivo criado para ter baixo teor de ácido erúcico. O termo canola (Brassica napus L., Brassica rapa L., e Brassica juncea) se refere a variedades de plantas de três espécies da família das crucíferas, pertencentes ao gênero Brassica, que produzem um óleo comestível.
 usda_ndb_code:en: 4582


### PR DESCRIPTION
## What
Fixes the `comment:en:` and `description:en:` on `en:canola-oil` (child of `en:rapeseed-oil`) in `taxonomies/food/ingredients.txt`.

## Why
The existing comment said canola "is only for the american variety of rapeseed" — imprecise. "Canola" is specifically a **Canadian**-bred and trademarked variety of low erucic acid rapeseed, developed by plant breeders in Saskatchewan and Manitoba in the 1960s-70s. The name itself is a portmanteau of "**Can**adian **o**il, **l**ow **a**cid", trademarked by the Canadian Canola Council in 1978 to distinguish it from traditional rapeseed. It's not a general "American" term.

Also added the Canadian origin detail to the description, which previously didn't mention Canada at all despite canola being essentially a Canadian agricultural product/story.

## Testing
`scripts/taxonomies/lint_taxonomy.pl --check taxonomies/food/ingredients.txt` — exit 0, no errors/warnings.

### Large Language Models usage disclosure
This PR was written agentically by Claude Code (Claude Sonnet 5), under human direction and review. The code was run and verified on the contributor's machine via `scripts/taxonomies/lint_taxonomy.pl --check` in the project's docker `backend` container (output included above).

### Related issue(s) and discussion
- Fixes: #14460
