### PR TITLE
taxonomy: fix vegetable oils (...) parsing

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -6067,8 +6067,10 @@ my %ingredients_categories_and_types = (
 			# note: multi-word types (e.g. "palm kernel", "palm stearin") must be listed
 			# before "palm", otherwise the regex matches only "palm" and leaves the
 			# trailing word (e.g. "stearin") as an unexpanded ingredient.
-			types =>
-				["avocado", "coconut", "colza", "cottonseed", "olive", "palm kernel", "palm stearin", "palm", "rapeseed", "safflower", "sunflower",],
+			types => [
+				"avocado", "coconut", "colza", "cottonseed", "olive", "palm kernel",
+				"palm stearin", "palm", "rapeseed", "safflower", "sunflower",
+			],
 		},
 	],
 

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -6064,8 +6064,11 @@ my %ingredients_categories_and_types = (
 			# categories
 			categories => ["oil", "vegetable oil", "vegetal oil",],
 			# types
+			# note: multi-word types (e.g. "palm kernel", "palm stearin") must be listed
+			# before "palm", otherwise the regex matches only "palm" and leaves the
+			# trailing word (e.g. "stearin") as an unexpanded ingredient.
 			types =>
-				["avocado", "coconut", "colza", "cottonseed", "olive", "palm", "rapeseed", "safflower", "sunflower",],
+				["avocado", "coconut", "colza", "cottonseed", "olive", "palm kernel", "palm stearin", "palm", "rapeseed", "safflower", "sunflower",],
 		},
 	],
 

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -132,7 +132,7 @@ stopwords:da: og, eller, samt, av, af, blandt andet, bl a, inklusive, heraf, ind
 stopwords:de: Allergene Zutaten, und, mit, von, aus, enthält, enthalten, mindestens, naturbelassen, in veränderlichen gewichtsanteilen, wenig, min, max
 stopwords:el: περιέχει
 # example: "artificial flavouring substances", "natural and nature identical flavouring substances"
-stopwords:en: and, or, added to enhance freshness, added to maintain flavor and freshness, assorted, based, contains, contains less than 2% of the following, contains one or more of the following, contain, edible, for freshness, from, including, inter alia, in varying proportions, less than 1% of:, may contain one or more of the following, minimum, possibly some, produced with, roasted in, substances, with, with added
+stopwords:en: and, or, added to enhance freshness, added to maintain flavor and freshness, assorted, based, contains, contains less than 2% of the following, contains one or more of the following, contain, edible, for freshness, from, including, inter alia, in varying portions, in varying proportions, less than 1% of:, may contain one or more of the following, minimum, possibly some, produced with, roasted in, substances, with, with added
 stopwords:es: contiene, de, del, la, el, las, los, con, y, e, en, minimo, maximo, puede, contener, por, categoria, calibre, minimo, min, vereidad, variedad, de cultivo, origen, nota, produccion, controlada, equivalente, equivale
 stopwords:fi: allergiatiedot, jossa, käymisen aikana muodostuva, koskenlaskija, muun muassa, noin, sisältää, snellmanin, valio
 stopwords:fr: aux, au, de, le, du, la, a, et, avec, ou, en, proportion, variable, contient, élaboré avec, papier traité, minimum, filets tournants et filets, pour souleves, dont, avec, autres, d'autres, d', avec ajout, sachet, marquants, demeter, minimum, base
@@ -12284,12 +12284,15 @@ ciqual_food_name:fr: Chipolata, crue
 fr: chipolatas aux herbes
 
 < en: pork
-en: pork skin, sausage skin
+en: pork skin
 bg: свинска кожа, свински кожички
 de: Schweinehaut
 fr: Peau de porc
 hr: svinjska koža
 it: pelle di maiale
+
+< en: pork skin
+en: pork drinde
 
 #< en: compound
 < en: pork meat
@@ -13438,6 +13441,9 @@ carbon_footprint_fr_foodges_value:fr: 5.1
 
 < en: meat
 fr: saucisse de strasbourg
+
+en: sausage skin
+comment:en: Not necessarily meat-based
 
 fr: plasma déshydraté
 

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -13444,6 +13444,9 @@ fr: saucisse de strasbourg
 
 en: sausage skin
 comment:en: Not necessarily meat-based
+vegan:en: maybe
+vegetarian:en: maybe
+wikidata:en: Q1372144
 
 fr: plasma déshydraté
 
@@ -15677,7 +15680,7 @@ hr: mješavina palminog ulja i palminog superoleina
 it: miscela di olio di palma e superoleina di palma
 
 < en: palm oil
-en: Palm stearin, palm stearin vegetable oil
+en: palm stearin, palm stearin vegetable oil
 da: palme stearin
 de: Palmstearin
 fi: palmusteariini

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -15671,7 +15671,7 @@ hr: mješavina palminog ulja i palminog superoleina
 it: miscela di olio di palma e superoleina di palma
 
 < en: palm oil
-en: Palm stearin
+en: Palm stearin, palm stearin vegetable oil
 da: palme stearin
 de: Palmstearin
 fi: palmusteariini

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -15010,7 +15010,7 @@ description:en: argan oil is found in argan tree
 wikipedia:en: Q45418
 
 < en: vegetable oil
-en: avocado oil
+en: avocado oil, avocado vegetable oil
 bg: авокадово масло, авокадово олио
 da: avocadoolie
 de: Avocadoöl
@@ -15202,7 +15202,7 @@ it: grasso di semi di cotone
 from_palm_oil:en: no
 
 < en: vegetable oil
-en: cottonseed oil, cotton seed oil
+en: cottonseed oil, cotton seed oil, cottonseed vegetable oil
 ar: زيت بذرة القطن
 az: Pambıq yağı
 be: Баваўняны алей
@@ -16189,7 +16189,7 @@ usda_ndb_code:en: 4588
 usda_ndb_name:en: Oil, oat
 
 < en: vegetable oil
-en: olive oil
+en: olive oil, olive vegetable oil
 ar: زيت زيتون
 az: Zeytun yağı
 ba: Зәйтүн майы
@@ -16610,7 +16610,7 @@ sv: rypsoljeberedning
 # mainIngredient:en:canola oil
 
 < en: rapeseed oil
-en: colza oil
+en: colza oil, colza vegetable oil
 bg: рапично олио
 ca: Oli de colza
 de: Kolzaöl, Kohlsaatöl
@@ -17175,7 +17175,7 @@ nl: zonnebloemvet geheel gehard, geheel geharde zonnebloem
 
 < en: vegetable oil
 # <en:en:safflower
-en: safflower oil
+en: safflower oil, safflower vegetable oil
 bg: шафраново масло
 de: Distelöl, Färberdistelöl
 es: aceite ce cártamo

--- a/tests/unit/expected_test_results/ingredients/en-vegetable-oils-five-resolved-oils.json
+++ b/tests/unit/expected_test_results/ingredients/en-vegetable-oils-five-resolved-oils.json
@@ -1,0 +1,140 @@
+{
+   "estimate_ingredients_percent_service" : "product_opener",
+   "ingredients" : [
+      {
+         "from_palm_oil" : "maybe",
+         "id" : "en:vegetable-oil",
+         "ingredients" : [
+            {
+               "id" : "en:avocado vegetable oils",
+               "is_in_taxonomy" : 0,
+               "percent_estimate" : 60,
+               "percent_max" : 100,
+               "percent_min" : 20,
+               "text" : "avocado vegetable oils"
+            },
+            {
+               "id" : "en:olive vegetable oils",
+               "is_in_taxonomy" : 0,
+               "percent_estimate" : 20,
+               "percent_max" : 50,
+               "percent_min" : 0,
+               "text" : "olive vegetable oils"
+            },
+            {
+               "id" : "en:colza vegetable oils",
+               "is_in_taxonomy" : 0,
+               "percent_estimate" : 10,
+               "percent_max" : 33.3333333333333,
+               "percent_min" : 0,
+               "text" : "colza vegetable oils"
+            },
+            {
+               "id" : "en:cottonseed vegetable oils",
+               "is_in_taxonomy" : 0,
+               "percent_estimate" : 5,
+               "percent_max" : 25,
+               "percent_min" : 0,
+               "text" : "cottonseed vegetable oils"
+            },
+            {
+               "id" : "en:safflower vegetable oils",
+               "is_in_taxonomy" : 0,
+               "percent_estimate" : 5,
+               "percent_max" : 20,
+               "percent_min" : 0,
+               "text" : "safflower vegetable oils"
+            }
+         ],
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "vegetable oils",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:palm-oil-content-unknown" : [
+         "en:avocado vegetable oils",
+         "en:olive vegetable oils",
+         "en:colza vegetable oils",
+         "en:cottonseed vegetable oils",
+         "en:safflower vegetable oils"
+      ],
+      "en:vegan-status-unknown" : [
+         "en:avocado vegetable oils",
+         "en:olive vegetable oils",
+         "en:colza vegetable oils",
+         "en:cottonseed vegetable oils",
+         "en:safflower vegetable oils"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "en:avocado vegetable oils",
+         "en:olive vegetable oils",
+         "en:colza vegetable oils",
+         "en:cottonseed vegetable oils",
+         "en:safflower vegetable oils"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil-content-unknown",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_lc" : "en",
+   "ingredients_n" : 6,
+   "ingredients_n_tags" : [
+      "6",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:vegetable-oil",
+      "en:avocado vegetable oils",
+      "en:olive vegetable oils",
+      "en:colza vegetable oils",
+      "en:cottonseed vegetable oils",
+      "en:safflower vegetable oils"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:vegetable-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:avocado vegetable oils",
+      "en:olive vegetable oils",
+      "en:colza vegetable oils",
+      "en:cottonseed vegetable oils",
+      "en:safflower vegetable oils"
+   ],
+   "ingredients_text" : "vegetable oils (avocado, olive, colza, cottonseed, safflower)",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 5,
+   "ingredients_with_unspecified_percent_sum" : 100,
+   "ingredients_without_ciqual_codes" : [
+      "en:avocado vegetable oils",
+      "en:colza vegetable oils",
+      "en:cottonseed vegetable oils",
+      "en:olive vegetable oils",
+      "en:safflower vegetable oils",
+      "en:vegetable-oil"
+   ],
+   "ingredients_without_ciqual_codes_n" : 6,
+   "ingredients_without_ecobalyse_ids" : [
+      "en:avocado vegetable oils",
+      "en:colza vegetable oils",
+      "en:cottonseed vegetable oils",
+      "en:olive vegetable oils",
+      "en:safflower vegetable oils",
+      "en:vegetable-oil"
+   ],
+   "ingredients_without_ecobalyse_ids_n" : 6,
+   "known_ingredients_n" : 1,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:estimated-ingredients-with-product-opener"
+   ],
+   "unknown_ingredients_n" : 5
+}

--- a/tests/unit/expected_test_results/ingredients/en-vegetable-oils-five-resolved-oils.json
+++ b/tests/unit/expected_test_results/ingredients/en-vegetable-oils-five-resolved-oils.json
@@ -2,48 +2,71 @@
    "estimate_ingredients_percent_service" : "product_opener",
    "ingredients" : [
       {
+         "ciqual_food_code" : "17001",
          "from_palm_oil" : "maybe",
          "id" : "en:vegetable-oil",
          "ingredients" : [
             {
-               "id" : "en:avocado vegetable oils",
-               "is_in_taxonomy" : 0,
+               "ciqual_food_code" : "17100",
+               "from_palm_oil" : "no",
+               "id" : "en:avocado-oil",
+               "is_in_taxonomy" : 1,
                "percent_estimate" : 60,
                "percent_max" : 100,
                "percent_min" : 20,
-               "text" : "avocado vegetable oils"
+               "text" : "avocado vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
-               "id" : "en:olive vegetable oils",
-               "is_in_taxonomy" : 0,
+               "ciqual_food_code" : "17001",
+               "ecobalyse_code" : "f1b219e6-7a77-429b-b372-461e3ad0d3bd",
+               "from_palm_oil" : "no",
+               "id" : "en:olive-oil",
+               "is_in_taxonomy" : 1,
                "percent_estimate" : 20,
                "percent_max" : 50,
                "percent_min" : 0,
-               "text" : "olive vegetable oils"
+               "text" : "olive vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
-               "id" : "en:colza vegetable oils",
-               "is_in_taxonomy" : 0,
+               "ciqual_food_code" : "17130",
+               "ecobalyse_code" : "96b301d9-d21b-4cea-8903-bd7917e95a30",
+               "from_palm_oil" : "no",
+               "id" : "en:colza-oil",
+               "is_in_taxonomy" : 1,
                "percent_estimate" : 10,
                "percent_max" : 33.3333333333333,
                "percent_min" : 0,
-               "text" : "colza vegetable oils"
+               "text" : "colza vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
-               "id" : "en:cottonseed vegetable oils",
-               "is_in_taxonomy" : 0,
+               "ciqual_food_code" : "17170",
+               "from_palm_oil" : "no",
+               "id" : "en:cottonseed-oil",
+               "is_in_taxonomy" : 1,
                "percent_estimate" : 5,
                "percent_max" : 25,
                "percent_min" : 0,
-               "text" : "cottonseed vegetable oils"
+               "text" : "cottonseed vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
-               "id" : "en:safflower vegetable oils",
-               "is_in_taxonomy" : 0,
+               "ciqual_food_code" : "17126",
+               "from_palm_oil" : "no",
+               "id" : "en:safflower-oil",
+               "is_in_taxonomy" : 1,
                "percent_estimate" : 5,
                "percent_max" : 20,
                "percent_min" : 0,
-               "text" : "safflower vegetable oils"
+               "text" : "safflower vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             }
          ],
          "is_in_taxonomy" : 1,
@@ -55,33 +78,11 @@
          "vegetarian" : "yes"
       }
    ],
-   "ingredients_analysis" : {
-      "en:palm-oil-content-unknown" : [
-         "en:avocado vegetable oils",
-         "en:olive vegetable oils",
-         "en:colza vegetable oils",
-         "en:cottonseed vegetable oils",
-         "en:safflower vegetable oils"
-      ],
-      "en:vegan-status-unknown" : [
-         "en:avocado vegetable oils",
-         "en:olive vegetable oils",
-         "en:colza vegetable oils",
-         "en:cottonseed vegetable oils",
-         "en:safflower vegetable oils"
-      ],
-      "en:vegetarian-status-unknown" : [
-         "en:avocado vegetable oils",
-         "en:olive vegetable oils",
-         "en:colza vegetable oils",
-         "en:cottonseed vegetable oils",
-         "en:safflower vegetable oils"
-      ]
-   },
+   "ingredients_analysis" : {},
    "ingredients_analysis_tags" : [
-      "en:palm-oil-content-unknown",
-      "en:vegan-status-unknown",
-      "en:vegetarian-status-unknown"
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
    ],
    "ingredients_lc" : "en",
    "ingredients_n" : 6,
@@ -91,50 +92,42 @@
    ],
    "ingredients_original_tags" : [
       "en:vegetable-oil",
-      "en:avocado vegetable oils",
-      "en:olive vegetable oils",
-      "en:colza vegetable oils",
-      "en:cottonseed vegetable oils",
-      "en:safflower vegetable oils"
+      "en:avocado-oil",
+      "en:olive-oil",
+      "en:colza-oil",
+      "en:cottonseed-oil",
+      "en:safflower-oil"
    ],
    "ingredients_percent_analysis" : 1,
    "ingredients_tags" : [
       "en:vegetable-oil",
       "en:oil-and-fat",
       "en:vegetable-oil-and-fat",
-      "en:avocado vegetable oils",
-      "en:olive vegetable oils",
-      "en:colza vegetable oils",
-      "en:cottonseed vegetable oils",
-      "en:safflower vegetable oils"
+      "en:avocado-oil",
+      "en:olive-oil",
+      "en:colza-oil",
+      "en:rapeseed-oil",
+      "en:cottonseed-oil",
+      "en:safflower-oil"
    ],
    "ingredients_text" : "vegetable oils (avocado, olive, colza, cottonseed, safflower)",
    "ingredients_with_specified_percent_n" : 0,
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 5,
    "ingredients_with_unspecified_percent_sum" : 100,
-   "ingredients_without_ciqual_codes" : [
-      "en:avocado vegetable oils",
-      "en:colza vegetable oils",
-      "en:cottonseed vegetable oils",
-      "en:olive vegetable oils",
-      "en:safflower vegetable oils",
-      "en:vegetable-oil"
-   ],
-   "ingredients_without_ciqual_codes_n" : 6,
+   "ingredients_without_ciqual_codes" : [],
+   "ingredients_without_ciqual_codes_n" : 0,
    "ingredients_without_ecobalyse_ids" : [
-      "en:avocado vegetable oils",
-      "en:colza vegetable oils",
-      "en:cottonseed vegetable oils",
-      "en:olive vegetable oils",
-      "en:safflower vegetable oils",
+      "en:avocado-oil",
+      "en:cottonseed-oil",
+      "en:safflower-oil",
       "en:vegetable-oil"
    ],
-   "ingredients_without_ecobalyse_ids_n" : 6,
-   "known_ingredients_n" : 1,
+   "ingredients_without_ecobalyse_ids_n" : 4,
+   "known_ingredients_n" : 6,
    "lc" : "en",
    "misc_tags" : [
       "en:estimated-ingredients-with-product-opener"
    ],
-   "unknown_ingredients_n" : 5
+   "unknown_ingredients_n" : 0
 }

--- a/tests/unit/expected_test_results/ingredients/en-vegetable-oils-palm-stearin-palm-kernel-with-other-oils.json
+++ b/tests/unit/expected_test_results/ingredients/en-vegetable-oils-palm-stearin-palm-kernel-with-other-oils.json
@@ -1,0 +1,128 @@
+{
+   "estimate_ingredients_percent_service" : "product_opener",
+   "ingredients" : [
+      {
+         "from_palm_oil" : "maybe",
+         "id" : "en:vegetable-oil",
+         "ingredients" : [
+            {
+               "ciqual_food_code" : "16040",
+               "from_palm_oil" : "no",
+               "id" : "en:coconut-oil",
+               "is_in_taxonomy" : 1,
+               "percent_estimate" : 62.5,
+               "percent_max" : 100,
+               "percent_min" : 25,
+               "text" : "coconut vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
+            },
+            {
+               "id" : "en:palm stearin vegetable oils",
+               "is_in_taxonomy" : 0,
+               "percent_estimate" : 18.75,
+               "percent_max" : 50,
+               "percent_min" : 0,
+               "text" : "palm stearin vegetable oils"
+            },
+            {
+               "ciqual_food_code" : "16129",
+               "ecobalyse_code" : "45658c32-66d9-4305-a34b-21d6a4cef89c",
+               "from_palm_oil" : "yes",
+               "id" : "en:palm-oil",
+               "is_in_taxonomy" : 1,
+               "percent_estimate" : 9.375,
+               "percent_max" : 33.3333333333333,
+               "percent_min" : 0,
+               "text" : "palm vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
+            },
+            {
+               "from_palm_oil" : "yes",
+               "id" : "en:palm-kernel-oil",
+               "is_in_taxonomy" : 1,
+               "percent_estimate" : 9.375,
+               "percent_max" : 25,
+               "percent_min" : 0,
+               "text" : "palm kernel vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
+            }
+         ],
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "vegetable oils",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:palm-oil" : [
+         "en:palm-oil",
+         "en:palm-kernel-oil"
+      ],
+      "en:vegan-status-unknown" : [
+         "en:palm stearin vegetable oils"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "en:palm stearin vegetable oils"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_lc" : "en",
+   "ingredients_n" : 5,
+   "ingredients_n_tags" : [
+      "5",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:vegetable-oil",
+      "en:coconut-oil",
+      "en:palm stearin vegetable oils",
+      "en:palm-oil",
+      "en:palm-kernel-oil"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:vegetable-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:coconut-oil",
+      "en:palm stearin vegetable oils",
+      "en:palm-oil",
+      "en:palm-oil-and-fat",
+      "en:palm-kernel-oil",
+      "en:palm-kernel-oil-and-fat"
+   ],
+   "ingredients_text" : "vegetable oils (coconut, palm stearin, palm, palm kernel)",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 4,
+   "ingredients_with_unspecified_percent_sum" : 100.0,
+   "ingredients_without_ciqual_codes" : [
+      "en:palm stearin vegetable oils",
+      "en:palm-kernel-oil",
+      "en:vegetable-oil"
+   ],
+   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ecobalyse_ids" : [
+      "en:coconut-oil",
+      "en:palm stearin vegetable oils",
+      "en:palm-kernel-oil",
+      "en:vegetable-oil"
+   ],
+   "ingredients_without_ecobalyse_ids_n" : 4,
+   "known_ingredients_n" : 4,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:estimated-ingredients-with-product-opener"
+   ],
+   "unknown_ingredients_n" : 1
+}

--- a/tests/unit/expected_test_results/ingredients/en-vegetable-oils-palm-stearin-palm-kernel-with-other-oils.json
+++ b/tests/unit/expected_test_results/ingredients/en-vegetable-oils-palm-stearin-palm-kernel-with-other-oils.json
@@ -2,6 +2,7 @@
    "estimate_ingredients_percent_service" : "product_opener",
    "ingredients" : [
       {
+         "ciqual_food_code" : "17001",
          "from_palm_oil" : "maybe",
          "id" : "en:vegetable-oil",
          "ingredients" : [
@@ -18,12 +19,17 @@
                "vegetarian" : "yes"
             },
             {
-               "id" : "en:palm stearin vegetable oils",
-               "is_in_taxonomy" : 0,
+               "ciqual_food_code" : "16129",
+               "ecobalyse_code" : "45658c32-66d9-4305-a34b-21d6a4cef89c",
+               "from_palm_oil" : "yes",
+               "id" : "en:palm-stearin",
+               "is_in_taxonomy" : 1,
                "percent_estimate" : 18.75,
                "percent_max" : 50,
                "percent_min" : 0,
-               "text" : "palm stearin vegetable oils"
+               "text" : "palm stearin vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "ciqual_food_code" : "16129",
@@ -61,20 +67,15 @@
    ],
    "ingredients_analysis" : {
       "en:palm-oil" : [
+         "en:palm-stearin",
          "en:palm-oil",
          "en:palm-kernel-oil"
-      ],
-      "en:vegan-status-unknown" : [
-         "en:palm stearin vegetable oils"
-      ],
-      "en:vegetarian-status-unknown" : [
-         "en:palm stearin vegetable oils"
       ]
    },
    "ingredients_analysis_tags" : [
       "en:palm-oil",
-      "en:vegan-status-unknown",
-      "en:vegetarian-status-unknown"
+      "en:vegan",
+      "en:vegetarian"
    ],
    "ingredients_lc" : "en",
    "ingredients_n" : 5,
@@ -85,7 +86,7 @@
    "ingredients_original_tags" : [
       "en:vegetable-oil",
       "en:coconut-oil",
-      "en:palm stearin vegetable oils",
+      "en:palm-stearin",
       "en:palm-oil",
       "en:palm-kernel-oil"
    ],
@@ -95,9 +96,9 @@
       "en:oil-and-fat",
       "en:vegetable-oil-and-fat",
       "en:coconut-oil",
-      "en:palm stearin vegetable oils",
-      "en:palm-oil",
+      "en:palm-stearin",
       "en:palm-oil-and-fat",
+      "en:palm-oil",
       "en:palm-kernel-oil",
       "en:palm-kernel-oil-and-fat"
    ],
@@ -105,24 +106,21 @@
    "ingredients_with_specified_percent_n" : 0,
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 4,
-   "ingredients_with_unspecified_percent_sum" : 100.0,
+   "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:palm stearin vegetable oils",
-      "en:palm-kernel-oil",
-      "en:vegetable-oil"
+      "en:palm-kernel-oil"
    ],
-   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ciqual_codes_n" : 1,
    "ingredients_without_ecobalyse_ids" : [
       "en:coconut-oil",
-      "en:palm stearin vegetable oils",
       "en:palm-kernel-oil",
       "en:vegetable-oil"
    ],
-   "ingredients_without_ecobalyse_ids_n" : 4,
-   "known_ingredients_n" : 4,
+   "ingredients_without_ecobalyse_ids_n" : 3,
+   "known_ingredients_n" : 5,
    "lc" : "en",
    "misc_tags" : [
       "en:estimated-ingredients-with-product-opener"
    ],
-   "unknown_ingredients_n" : 1
+   "unknown_ingredients_n" : 0
 }

--- a/tests/unit/expected_test_results/ingredients/en-vegetable-oils-palm-stearin-palm-kernel.json
+++ b/tests/unit/expected_test_results/ingredients/en-vegetable-oils-palm-stearin-palm-kernel.json
@@ -2,16 +2,22 @@
    "estimate_ingredients_percent_service" : "product_opener",
    "ingredients" : [
       {
+         "ciqual_food_code" : "17001",
          "from_palm_oil" : "maybe",
          "id" : "en:vegetable-oil",
          "ingredients" : [
             {
-               "id" : "en:palm stearin vegetable oils",
-               "is_in_taxonomy" : 0,
+               "ciqual_food_code" : "16129",
+               "ecobalyse_code" : "45658c32-66d9-4305-a34b-21d6a4cef89c",
+               "from_palm_oil" : "yes",
+               "id" : "en:palm-stearin",
+               "is_in_taxonomy" : 1,
                "percent_estimate" : 66.6666666666667,
                "percent_max" : 100,
                "percent_min" : 33.3333333333333,
-               "text" : "palm stearin vegetable oils"
+               "text" : "palm stearin vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
             },
             {
                "ciqual_food_code" : "16129",
@@ -49,20 +55,15 @@
    ],
    "ingredients_analysis" : {
       "en:palm-oil" : [
+         "en:palm-stearin",
          "en:palm-oil",
          "en:palm-kernel-oil"
-      ],
-      "en:vegan-status-unknown" : [
-         "en:palm stearin vegetable oils"
-      ],
-      "en:vegetarian-status-unknown" : [
-         "en:palm stearin vegetable oils"
       ]
    },
    "ingredients_analysis_tags" : [
       "en:palm-oil",
-      "en:vegan-status-unknown",
-      "en:vegetarian-status-unknown"
+      "en:vegan",
+      "en:vegetarian"
    ],
    "ingredients_lc" : "en",
    "ingredients_n" : 4,
@@ -72,7 +73,7 @@
    ],
    "ingredients_original_tags" : [
       "en:vegetable-oil",
-      "en:palm stearin vegetable oils",
+      "en:palm-stearin",
       "en:palm-oil",
       "en:palm-kernel-oil"
    ],
@@ -81,9 +82,9 @@
       "en:vegetable-oil",
       "en:oil-and-fat",
       "en:vegetable-oil-and-fat",
-      "en:palm stearin vegetable oils",
-      "en:palm-oil",
+      "en:palm-stearin",
       "en:palm-oil-and-fat",
+      "en:palm-oil",
       "en:palm-kernel-oil",
       "en:palm-kernel-oil-and-fat"
    ],
@@ -91,23 +92,20 @@
    "ingredients_with_specified_percent_n" : 0,
    "ingredients_with_specified_percent_sum" : 0,
    "ingredients_with_unspecified_percent_n" : 3,
-   "ingredients_with_unspecified_percent_sum" : 100.0,
+   "ingredients_with_unspecified_percent_sum" : 100,
    "ingredients_without_ciqual_codes" : [
-      "en:palm stearin vegetable oils",
-      "en:palm-kernel-oil",
-      "en:vegetable-oil"
+      "en:palm-kernel-oil"
    ],
-   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ciqual_codes_n" : 1,
    "ingredients_without_ecobalyse_ids" : [
-      "en:palm stearin vegetable oils",
       "en:palm-kernel-oil",
       "en:vegetable-oil"
    ],
-   "ingredients_without_ecobalyse_ids_n" : 3,
-   "known_ingredients_n" : 3,
+   "ingredients_without_ecobalyse_ids_n" : 2,
+   "known_ingredients_n" : 4,
    "lc" : "en",
    "misc_tags" : [
       "en:estimated-ingredients-with-product-opener"
    ],
-   "unknown_ingredients_n" : 1
+   "unknown_ingredients_n" : 0
 }

--- a/tests/unit/expected_test_results/ingredients/en-vegetable-oils-palm-stearin-palm-kernel.json
+++ b/tests/unit/expected_test_results/ingredients/en-vegetable-oils-palm-stearin-palm-kernel.json
@@ -1,0 +1,113 @@
+{
+   "estimate_ingredients_percent_service" : "product_opener",
+   "ingredients" : [
+      {
+         "from_palm_oil" : "maybe",
+         "id" : "en:vegetable-oil",
+         "ingredients" : [
+            {
+               "id" : "en:palm stearin vegetable oils",
+               "is_in_taxonomy" : 0,
+               "percent_estimate" : 66.6666666666667,
+               "percent_max" : 100,
+               "percent_min" : 33.3333333333333,
+               "text" : "palm stearin vegetable oils"
+            },
+            {
+               "ciqual_food_code" : "16129",
+               "ecobalyse_code" : "45658c32-66d9-4305-a34b-21d6a4cef89c",
+               "from_palm_oil" : "yes",
+               "id" : "en:palm-oil",
+               "is_in_taxonomy" : 1,
+               "percent_estimate" : 16.6666666666667,
+               "percent_max" : 50,
+               "percent_min" : 0,
+               "text" : "palm vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
+            },
+            {
+               "from_palm_oil" : "yes",
+               "id" : "en:palm-kernel-oil",
+               "is_in_taxonomy" : 1,
+               "percent_estimate" : 16.6666666666667,
+               "percent_max" : 33.3333333333333,
+               "percent_min" : 0,
+               "text" : "palm kernel vegetable oils",
+               "vegan" : "yes",
+               "vegetarian" : "yes"
+            }
+         ],
+         "is_in_taxonomy" : 1,
+         "percent_estimate" : 100,
+         "percent_max" : 100,
+         "percent_min" : 100,
+         "text" : "vegetable oils",
+         "vegan" : "yes",
+         "vegetarian" : "yes"
+      }
+   ],
+   "ingredients_analysis" : {
+      "en:palm-oil" : [
+         "en:palm-oil",
+         "en:palm-kernel-oil"
+      ],
+      "en:vegan-status-unknown" : [
+         "en:palm stearin vegetable oils"
+      ],
+      "en:vegetarian-status-unknown" : [
+         "en:palm stearin vegetable oils"
+      ]
+   },
+   "ingredients_analysis_tags" : [
+      "en:palm-oil",
+      "en:vegan-status-unknown",
+      "en:vegetarian-status-unknown"
+   ],
+   "ingredients_lc" : "en",
+   "ingredients_n" : 4,
+   "ingredients_n_tags" : [
+      "4",
+      "1-10"
+   ],
+   "ingredients_original_tags" : [
+      "en:vegetable-oil",
+      "en:palm stearin vegetable oils",
+      "en:palm-oil",
+      "en:palm-kernel-oil"
+   ],
+   "ingredients_percent_analysis" : 1,
+   "ingredients_tags" : [
+      "en:vegetable-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:palm stearin vegetable oils",
+      "en:palm-oil",
+      "en:palm-oil-and-fat",
+      "en:palm-kernel-oil",
+      "en:palm-kernel-oil-and-fat"
+   ],
+   "ingredients_text" : "vegetable oils (palm stearin, palm, palm kernel)",
+   "ingredients_with_specified_percent_n" : 0,
+   "ingredients_with_specified_percent_sum" : 0,
+   "ingredients_with_unspecified_percent_n" : 3,
+   "ingredients_with_unspecified_percent_sum" : 100.0,
+   "ingredients_without_ciqual_codes" : [
+      "en:palm stearin vegetable oils",
+      "en:palm-kernel-oil",
+      "en:vegetable-oil"
+   ],
+   "ingredients_without_ciqual_codes_n" : 3,
+   "ingredients_without_ecobalyse_ids" : [
+      "en:palm stearin vegetable oils",
+      "en:palm-kernel-oil",
+      "en:vegetable-oil"
+   ],
+   "ingredients_without_ecobalyse_ids_n" : 3,
+   "known_ingredients_n" : 3,
+   "lc" : "en",
+   "misc_tags" : [
+      "en:estimated-ingredients-with-product-opener"
+   ],
+   "unknown_ingredients_n" : 1
+}

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -898,6 +898,16 @@ puffed orange and caramelized unknown_fruit4.",
 		}
 	],
 
+	# Oils that resolve to their taxonomy id via an "X vegetable oil(s)" synonym
+	# (ingredients.txt). Guards the synonym entries added for these oils.
+	[
+		"en-vegetable-oils-five-resolved-oils",
+		{
+			lc => "en",
+			ingredients_text => "vegetable oils (avocado, olive, colza, cottonseed, safflower)",
+		}
+	],
+
 	# émulsifiant : lécithines (tournesol)
 	[
 		"fr-emulsifiant-lecithines-tournesol",

--- a/tests/unit/ingredients.t
+++ b/tests/unit/ingredients.t
@@ -879,6 +879,25 @@ puffed orange and caramelized unknown_fruit4.",
 		}
 	],
 
+	# Multi-word oils inside a generic name: "palm kernel" and "palm stearin"
+	# must be expanded as a single ingredient each, not left as a dangling word
+	# after "palm" was matched (e.g. "palm, palm, stearin, palm kernel").
+	[
+		"en-vegetable-oils-palm-stearin-palm-kernel",
+		{
+			lc => "en",
+			ingredients_text => "vegetable oils (palm stearin, palm, palm kernel)",
+		}
+	],
+
+	[
+		"en-vegetable-oils-palm-stearin-palm-kernel-with-other-oils",
+		{
+			lc => "en",
+			ingredients_text => "vegetable oils (coconut, palm stearin, palm, palm kernel)",
+		}
+	],
+
 	# émulsifiant : lécithines (tournesol)
 	[
 		"fr-emulsifiant-lecithines-tournesol",


### PR DESCRIPTION
<!-- 
⚠️ Acceptance Requirements
**This Pull Request will only be accepted if:**
- ✅ It is linked to an issue (using linking keywords like `Fixes`, `Closes`, or `Resolves`)
- ✅ There's an agreement by a maintainer or core contributor in the linked issue to assign it to the author of this PR
-->

<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `style`, for Code style changes (formatting, whitespace, etc.)
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
  - `test`, for Adding or updating tests
  - `build`, for Build system or dependency changes
  - `revert`, for Reverting previous changes
  - `l10n`, for Localization and translation updates
  - `taxonomy`, for Changes to product categories and tags taxonomy
-->
<!-- IMPORTANT CHECKLIST: Make sure you've done all the following (You can delete the checklist before submitting)-->
<!-- - [ ] Code is well documented-->
<!-- - [ ] Include unit tests for new functionality-->
<!-- - [ ] Code passes GitHub workflow checks in your branch-->
<!-- - [ ] If you have multiple commits please combine them into one commit by squashing them.-->
<!-- - [ ] Read and understood the [contribution guidelines](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/CONTRIBUTING.md)-->

### What
<!-- Describe the changes made -->
<!-- Describe why they were made instead of how they were made. -->
If the ingredients have `vegetable oils (...)` and the first entry is anything in this list https://github.com/openfoodfacts/openfoodfacts-server/blob/9b18084512e56da2e51664a407650f906103b620/lib/ProductOpener/Ingredients.pm#L6068 all the entries will have "vegetable oils" suffixed to then look them up in the taxonomy. So everything in that list needs a `x vegetable oil` synonym. E.g.
- "olive vegetable oils" in https://world.openfoodfacts.org/product/8719200237902/bertolli#panel_ingredients_analysis_details

Any with other `palm x` in the oils list would get mangled by the regexp. `palm stearin` would be parsed as palm oil, and then `stearin` left as a standalone ingredient.
- https://world.openfoodfacts.org/facets/ingredients/stearin
- `vegetable oils (coconut, palm stearin, palm, palm kernel)` becomes `vegetable oils (coconut vegetable oils, palm vegetable oils), stearin, palm, palm kernel` 
  https://world.openfoodfacts.org/product/4056489270423/strawberries-and-cream-lidl#panel_ingredients_analysis_details

Going through the ingredients tsv there are a bunch of other oil variants that appear inside the brackets that perhaps need adding too. Any time the parser sees an unknown "oil", it ends the bracket parsing and add the rest of the brackets contents as following ingredients.
E.g.
- `vegetable oils (sunflower, palm, corn) in varying proportions` becomes `vegetable oils (sunflower vegetable oils, palm vegetable oils), corn) in varying proportions`
  https://world.openfoodfacts.org/product/5053990161966/pringles-texas-bbq-sauce#panel_ingredients_analysis_details

Also sausage skin isn't necessarily pork, or even meat based, these days.

### Large Language Models usage disclosure
<!-- ⚠️ If you used an LLM, please disclose which LLM you used (and its version) and how (agentic, autocomplete). Please confirm you have run successfully the code on your device. Also provide a screenshot or video as proof -->
vscode copilot using ornith 1.5 35B FP8 running locally.