### PR TITLE
taxonomy(food): deduplication of name lists in categories.txt

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -2035,8 +2035,8 @@ wikidata:en: Q1142986
 
 < en: Rice wines
 xx: Sake
-bg: Саке
 en: Sake
+bg: Саке
 fr: Saké
 hu: Szaké
 it: Sake, Sakè
@@ -34981,8 +34981,8 @@ wikidata:en: Q940999
 
 < en: Breads
 en: Sourdough breads
-Fr: Pains au levain
 da: Surdejsbrød
+Fr: Pains au levain
 sv: Surdegsbröd
 agribalyse_food_code:en: 7002
 ciqual_food_code:en: 7002
@@ -36463,20 +36463,20 @@ gpc_category_name:en: Cakes - Sweet (Perishable)
 
 < en: Cakes
 xx: Bienenstich
-de: Bienenstich
 en: Bienenstich
+de: Bienenstich
 wikidata:en: Q338205
 
 < en: Cakes
 xx: Donauwelle
-de: Donauwelle
 en: Donauwelle
+de: Donauwelle
 wikidata:en: Q829243
 
 < en: Cakes
 xx: Streuselkuchen
-de: Streuselkuchen
 en: Streuselkuchen
+de: Streuselkuchen
 wikidata:en: Q451645
 
 < en: Streuselkuchen
@@ -36493,8 +36493,8 @@ de: Pflaumen Streuselkuchen
 
 < en: Cakes
 xx: Zupfkuchen
-de: Zupfkuchen
 en: Zupfkuchen
+de: Zupfkuchen
 
 < en: Cakes
 en: Banana breads
@@ -80909,8 +80909,8 @@ pl: Polskie produkty mięsne
 
 < en: Polish meat products
 pl: Kiełbasa krakowska sucha staropolska
-de: Krakauer
 en: Krakowska
+de: Krakauer
 fr: Karkauer
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-2145
@@ -81310,8 +81310,8 @@ pl: Słoweńskie produkty mięsne
 
 < en: Slovenian meat products
 sl: Kranjska klobasa
-de: Krainer Wurst
 en: Carniolan sausage
+de: Krainer Wurst
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0764
 protected_name_type:en: pgi
@@ -93068,9 +93068,9 @@ wikidata:en: Q1265899
 # don't confused the "French" style and the "German" style liver sausages. The French ones are cured and the German ones are precooked and usually spreadable
 < en: Prepared meats
 xx: Liverwurst
+en: Liverwurst
 bg: Колбаси от черен дроб
 de: Leberwürste, Leberwurst
-en: Liverwurst
 fi: Maksamakkarat
 hr: Jetrene kobasice
 hu: Májkolbászok
@@ -100479,8 +100479,8 @@ nl: Vruchtenbiscuits
 
 < en: Biscuits and cakes
 fr: Biscuits fourrés aux fruits
-de: Fruchtgefüllte Kekse
 en: Fruit-filled biscuits
+de: Fruchtgefüllte Kekse
 es: Galletas rellenas de fruta
 hr: Keksići punjeni voćem
 nl: Gevulde koekjes met fruit
@@ -101170,8 +101170,8 @@ ciqual_food_name:fr: Tarte aux fruits rouges
 
 < en: Sweet pies
 fr: Tarte aux groseilles
-de: Johannisbeerkuchen
 en: Red currant tart
+de: Johannisbeerkuchen
 es: Tarta de grosellas rojas
 hr: Tart od crvenog ribiza
 nl: Rode bessentaart
@@ -115691,8 +115691,8 @@ sv: Hela skalade datterini-tomater i tomatjuice
 
 < en: Tomatoes
 xx: Pomodoro San Marzano dell'Agro Sarnese-Nocerino
-da: San Marzano-tomater
 en: San Marzano tomatoes
+da: San Marzano-tomater
 it: Pomodoro San Marzano
 sv: San Marzano-tomater
 protected_name_file_number:en: PDO-IT-1524
@@ -118152,6 +118152,7 @@ pt: Manteigas de soja
 < en: Legumes and their products
 < en: Meat alternatives
 xx: Tofu
+en: Tofu, Tofus, bean curds
 ar: توفو
 ba: Тофу
 be: Тофу
@@ -118162,7 +118163,6 @@ cv: Тофу
 cy: toffw
 de: Tofu, Bohnenquark, Bohnenkäse
 el: Τόφου
-en: Tofu, Tofus, bean curds
 eo: Tofuo
 es: Tofu, Tofus
 fa: توفو
@@ -121685,8 +121685,8 @@ fr: Pains au chocolat au beurre
 
 < en: Chocolate croissant
 fr: Pains au chocolat à l'huile de tournesol
-de: Schokoladen-Croissants mit Sonnenblumenöl
 en: Chocolate croissants with sunflower oil
+de: Schokoladen-Croissants mit Sonnenblumenöl
 es: Croissants de chocolate con aceite de girasol
 hr: Čokoladni kroasani sa suncokretovim uljem
 it: Cornetti al cioccolato con olio di girasole

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -496,7 +496,7 @@ hu: Babakekszek, Baba kekszek, Kekszek csecsemőknek, Csecsemő kekszek
 it: Biscotti per neonati
 lt: Sausainiai kūdikiams
 nl: Babykoekjes, Koekjes voor babies
-pt: Biscoitos para bebês, biscoitos para bebês, biscoitos para bebês
+pt: Biscoitos para bebês, biscoitos para bebês
 ro: Biscuiți pentru bebeluși, Biscuiți bebeluși
 agribalyse_food_code:en: 24689
 ciqual_food_code:en: 24689
@@ -678,7 +678,7 @@ it: Dessert per neonati a base di latticini, Dessert per neonati a base di prodo
 lt: Kūdikių pieniški desertai, Pieniški desertai kūdikiams
 nl: Babymelktoetjes, Babymelktoetje, Melktoetje voor babies
 nl_be: Babymelkdesserten, Melkdesserten voor babies, Melkdessert voor babies
-pt: Sobremesas lácteas para bebês, sobremesas lácteas para bebês, sobremesas lácteas para bebês
+pt: Sobremesas lácteas para bebês, sobremesas lácteas para bebês
 ro: Deserturi cu lactate pentru bebeluși, Deserturi cu lactate bebeluși
 
 < en: Dairy dessert for baby
@@ -776,7 +776,7 @@ gpc_category_name:en: Baby/Infant - Formula (Shelf Stable)
 
 < en: Infant formulas
 en: Ready to feed baby milks
-fr: Laits infantiles prêts à consommer, Laits infantiles prêts à consommer
+fr: Laits infantiles prêts à consommer
 pt: Pronto para alimentar o bebê com leite
 agribalyse_proxy_food_code:en: 19013
 
@@ -2035,8 +2035,8 @@ wikidata:en: Q1142986
 
 < en: Rice wines
 xx: Sake
-en: Sake
 bg: Саке
+en: Sake
 fr: Saké
 hu: Szaké
 it: Sake, Sakè
@@ -2535,7 +2535,7 @@ lt: Porteris
 wikidata:en: Q954166
 
 < en: Porters
-en: Baltic porter, Baltic porter, Baltic porter beers
+en: Baltic porter, Baltic porter beers
 lt: Baltijos porteris
 description:en: Baltic porter is a type of porter. Traditionally made in the countries of Baltic sea region with the majority being produced in Poland. This beer is stronger, 7-8,5% and has less burnt taste compared to Porter.
 
@@ -8096,7 +8096,7 @@ de: Fruchtsäfte aus Konzentrat
 es: Zumos procedentes de concentrado
 fi: Mehutiivisteet
 fr: Jus de fruits à base de concentré, jus de fruit à base de concentré, jus de fruits à base de concentrés
-he: מיצי פירות מרוכזים, מיצי פירות מרוכזים, תרכיזי פירות, תרכיזי פרות, תרכיזים מפירות, מיצים מרוכזים מפירות
+he: מיצי פירות מרוכזים, תרכיזי פירות, תרכיזי פרות, תרכיזים מפירות, מיצים מרוכזים מפירות
 hr: Voćni sokovi iz koncentrata
 hu: Gyümölcslevek sűrítményből, Gyümölcslé sűrítményből, Gyümölcslé koncentrátumból
 it: Succo di frutta da concentrato
@@ -11610,7 +11610,7 @@ cs: Instantní káva
 de: lösliche Kaffees, Pulverkaffees, Instantkaffees
 es: Cafés solubles
 fi: pikakahvit
-fr: Cafés solubles, cafés en poudre, café en poudre, cafés instantanés, café soluble, café instantané, café soluble, cafés instantanés en poudre, café instantané en poudre, Café en poudre soluble
+fr: Cafés solubles, cafés en poudre, café en poudre, cafés instantanés, café soluble, café instantané, cafés instantanés en poudre, café instantané en poudre, Café en poudre soluble
 hr: Instant kave
 hu: Instant kávék, Oldódó kávé, Kávéporok
 it: Caffè istantaneo
@@ -34981,8 +34981,8 @@ wikidata:en: Q940999
 
 < en: Breads
 en: Sourdough breads
-da: Surdejsbrød
 Fr: Pains au levain
+da: Surdejsbrød
 sv: Surdegsbröd
 agribalyse_food_code:en: 7002
 ciqual_food_code:en: 7002
@@ -35798,7 +35798,7 @@ nl: Speltbeschuiten, Speltbeschuit
 < en: Rusks
 en: Common wheat rusks
 de: Weizenzwieback
-fr: Biscottes de froment, Biscottes de froment, Biscottes au froment
+fr: Biscottes de froment, Biscottes au froment
 nl: Tarwebeschuiten, Tarwebeschuit
 
 < en: Rusks
@@ -36463,20 +36463,20 @@ gpc_category_name:en: Cakes - Sweet (Perishable)
 
 < en: Cakes
 xx: Bienenstich
-en: Bienenstich
 de: Bienenstich
+en: Bienenstich
 wikidata:en: Q338205
 
 < en: Cakes
 xx: Donauwelle
-en: Donauwelle
 de: Donauwelle
+en: Donauwelle
 wikidata:en: Q829243
 
 < en: Cakes
 xx: Streuselkuchen
-en: Streuselkuchen
 de: Streuselkuchen
+en: Streuselkuchen
 wikidata:en: Q451645
 
 < en: Streuselkuchen
@@ -36493,13 +36493,13 @@ de: Pflaumen Streuselkuchen
 
 < en: Cakes
 xx: Zupfkuchen
-en: Zupfkuchen
 de: Zupfkuchen
+en: Zupfkuchen
 
 < en: Cakes
 en: Banana breads
 xx: Banana breads
-fr: Gâteaux aux bananes, gâteau aux bananes, gâteaux à la banane, gâteau à la banane, pains à la banane, pain à la banane, pains aux bananes, pain à la banane
+fr: Gâteaux aux bananes, gâteau aux bananes, gâteaux à la banane, gâteau à la banane, pains à la banane, pain à la banane, pains aux bananes
 nl: Bananenbroden, Banaanbroden
 wikidata:en: Q806097
 
@@ -39183,7 +39183,7 @@ nl: Chocorepen met noten en biscuit
 
 < en: Candy chocolate bars
 en: Candy chocolate bars filled with a dairy cream, Chocolate confectionery with dairy filling, Chocolate bar with dairy filling
-fr: Barres chocolatées au lait, Confiserie chocolatées au lait, Barres chocolatées au lait, Barre chocolatée au lait, Barres chocolatées au lait type Kinder Maxi, Kinder Maxi
+fr: Barres chocolatées au lait, Confiserie chocolatées au lait, Barre chocolatée au lait, Barres chocolatées au lait type Kinder Maxi, Kinder Maxi
 hr: Čokoladni slatkiši s mliječnim punjenjem
 ro: Batoane de ciocolată cu lapte
 agribalyse_food_code:en: 31012
@@ -41996,7 +41996,7 @@ wikidata:en: Q1186042
 en: Job's Tears
 de: Hiobsträne
 es: Lágrimas de Job
-fr: Coix lacryma-jobi, Coix lacryma-jobi
+fr: Coix lacryma-jobi
 hr: Poslovne suze
 la: Coix lacryma-jobi
 nl: Jobstranen
@@ -42829,7 +42829,7 @@ hr: Jasmin riža
 it: Riso Jasmine
 ja: ジャスミンライス, ジャスミン米
 lt: Jasmine ryžiai
-nl: Thaise rijsten, Thaise rijsten, Jasmijnrijsten, Pandan, Pandanrijsten
+nl: Thaise rijsten, Jasmijnrijsten, Pandan, Pandanrijsten
 agribalyse_food_code:en: 9119
 ciqual_food_code:en: 9119
 ciqual_food_name:en: Basmati rice, raw
@@ -43365,7 +43365,7 @@ agribalyse_proxy_food_name:fr: Maïs doux, appertisé, égoutté
 wikidata:en: Q67858763
 
 < en: Canned corn
-en: Canned sweet corn, Canned sweet corn
+en: Canned sweet corn
 bg: Консервирана сладка царевица
 de: Dosenzuckermais, Zuckermaiskonserve
 es: Maíz dulce en conserva
@@ -44130,7 +44130,7 @@ ru: Молочные продукты
 si: ගව කිරි ආශ්‍රිත නිෂ්පාදන
 sl: Mlečni izdelek
 sr: Млечни производи
-sv: Mejeriprodukt, Mejeriprodukter, Mejeriprodukt, Mjölkprodukter
+sv: Mejeriprodukt, Mejeriprodukter, Mjölkprodukter
 ta: பால் பொருள்
 th: ผลิตภัณฑ์จากนม, ผลิตภัณฑ์นม
 tr: Mandıra ürünü
@@ -44188,7 +44188,7 @@ ru: Кисломолочные продукты
 sv: Fermenterade mjölkprodukter
 th: กลุ่มผลิตภัณฑ์นมเปรี้ยว
 tr: Fermente süt ürünleri
-zh: 发酵乳制品, 发酵乳制食品, 发酵乳制品, 发酵乳制品
+zh: 发酵乳制品, 发酵乳制食品
 wikidata:en: Q3506176
 
 < en: Dairy drinks
@@ -45784,7 +45784,7 @@ en: Halloumi
 xx: Halloumi
 bg: Халуми
 de: Halloumi
-el: Χαλλούμι, Hellim, Halloumi, Hellim
+el: Χαλλούμι, Hellim, Halloumi
 es: Halloumi
 fr: Halloumi
 hr: Halloumi
@@ -48316,7 +48316,7 @@ ru: Итальянские сыры
 sv: Italienska ostar, ostar från Italien
 tr: İtalyan peynirleri, İtalya peynirleri
 uk: Італійські сири
-zh: 意大利奶酪, 意大利奶酪
+zh: 意大利奶酪
 origins:en: en:italy
 wikidata:en: Q1230305
 
@@ -50246,7 +50246,7 @@ en: Smetana with 15% fat
 de: Schmand mit 15% Fettanteil
 fr: Smetana avec 15% de matières grasses
 hr: Smetana sa 15% masti
-ru: Сметана 15%, Сметана 15%, Сметана 15% жирности, Сметана с массовой долей жира 15%
+ru: Сметана 15%, Сметана 15% жирности, Сметана с массовой долей жира 15%
 
 < en: Sour creams
 xx: Mileram
@@ -51946,7 +51946,7 @@ ru: Молоко питьевое с массовой долей жира 3.5% �
 ru: Молоко питьевое с массовой долей жира 3.6% пастеризованное, Молоко питьевое пастеризованное 3.6%
 
 < en: UHT Milks
-ru: Молоко питьевое ультрапастеризованное, Молоко питьевое ультрапастеризованное, Молоко ультрапастеризованное питьевое, Молоко питьевое ультравысокотемпературно-обработанное
+ru: Молоко питьевое ультрапастеризованное, Молоко ультрапастеризованное питьевое, Молоко питьевое ультравысокотемпературно-обработанное
 wikidata:en: Q26867007
 
 < ru: Молоко питьевое ультрапастеризованное
@@ -61578,7 +61578,7 @@ protected_name_type:en: pdo
 
 < en: Greek oils and fats
 < en: Olive oils
-en: Olive oils from Greece, Greek olive oils, Olive oils from Greece, Greek olive oil
+en: Olive oils from Greece, Greek olive oils, Greek olive oil
 bg: Гръцко дървено масло, гръцки зехтин
 da: Olivenolier fra Grækenland, Græske olivenolier
 de: Olivenöle aus Griechenland
@@ -64015,7 +64015,7 @@ ciqual_food_name:en: Buckwheat flour
 ciqual_food_name:fr: Farine de sarrasin
 
 < en: Buckwheat flours
-fr: Farine de blé noir de Bretagne, Farine de blé noir de Bretagne
+fr: Farine de blé noir de Bretagne
 br: Gwinizh du Breizh
 lt: Grikių miltai iš Bretanės
 origins:en: en:france
@@ -64818,7 +64818,7 @@ en: Durum wheat semolinas, durum wheat semolina
 de: Hartweizengrieße, Hartweizengrieß
 es: Sémolas y semolinas de trigo duro, Sémolas de trigo duro, Sémola de trigo duro
 fi: Durumvehnäsuurimot
-fr: Semoules de blé dur, Semoules de blé dur
+fr: Semoules de blé dur
 hr: Griz od durum pšenice
 it: Semole di grano duro
 ja: デュラムセモリナ
@@ -65123,7 +65123,7 @@ de: Tahin, Sesammus
 es: Tahinis, Tahini, Tahina, Tahin, Mantecas de semilla de sésamo
 fi: Tahini
 fr: Purées de sésame, Tahini, Tahina, Tahin, Purée de sésame
-he: טחינה, ממרח שומשום, שומשום טחון, ממרח טחינה, ממרח שומשום
+he: טחינה, ממרח שומשום, שומשום טחון, ממרח טחינה
 hr: Tahini
 it: Tahina
 ja: 芝麻醤, チーマージャン, タヒーニ, タヒーナ
@@ -68750,7 +68750,7 @@ season_in_country_fr:en: 8,9
 # Morus nigra?
 < en: Berries
 en: Black mulberries, black mulberries
-fr: Mûres noires, Mûres noires
+fr: Mûres noires
 agribalyse_food_code:en: 13071
 ciqual_food_code:en: 13071
 ciqual_food_name:en: Black mulberry, raw
@@ -80909,8 +80909,8 @@ pl: Polskie produkty mięsne
 
 < en: Polish meat products
 pl: Kiełbasa krakowska sucha staropolska
-en: Krakowska
 de: Krakauer
+en: Krakowska
 fr: Karkauer
 origins:en: en:poland
 protected_name_file_number:en: TSG-PL-2145
@@ -81310,8 +81310,8 @@ pl: Słoweńskie produkty mięsne
 
 < en: Slovenian meat products
 sl: Kranjska klobasa
-en: Carniolan sausage
 de: Krainer Wurst
+en: Carniolan sausage
 origins:en: en:slovenia
 protected_name_file_number:en: PGI-SI-0764
 protected_name_type:en: pgi
@@ -82337,7 +82337,7 @@ he: מנות, ארוחות, אוכל מוכן
 hr: pripremljena jela
 hu: Ételek, Kész ételek, Elkészített ételek
 it: Pasti
-lt: Patiekalai, Paruošti patiekalai, Paruošti patiekalai
+lt: Patiekalai, Paruošti patiekalai
 nl: Kant-en-klaar maaltijden
 nl_be: Kant-en-klaar maaltijden
 no: Måltider, Tilberedte måltider, Tilberedte retter, Ferdigmat
@@ -85385,7 +85385,7 @@ nl: Courgettecrèmesoepen
 < en: Cream of vegetable soups
 fr: Veloutés de légumes du soleil
 
-en: broths, broths, stock, bouillon, Stocks
+en: broths, stock, bouillon, Stocks
 af: bouillon
 ar: زومات
 az: Bulyon
@@ -85862,7 +85862,7 @@ et: Hapukapsas
 eu: Aza minkor
 fa: کلم‌ترش
 fi: hapankaalit, hapankaali
-fr: choucroutes, choucroutes
+fr: choucroutes
 ga: Cabáiste géaraithe
 he: כרוב כבוש
 hr: Kiseli kupus
@@ -90011,7 +90011,7 @@ ciqual_food_name:fr: Bœuf, steak haché 5% MG, cuit
 
 < en: Ground beef steaks
 en: Minced beef steak with 10% fat, minced beef steak with 10% fat
-fr: Steak haché de bœuf à 10% de matières grasses, Steak haché de bœuf à 10% de matières grasses
+fr: Steak haché de bœuf à 10% de matières grasses
 hr: Mljeveni goveđi odrezak sa 10% masti
 lt: Maltos jautienos kepsniai su 10% riebalų
 agribalyse_food_code:en: 6252
@@ -90093,7 +90093,7 @@ nl: Gehakt rundvleesproducten
 
 < en: Beef preparations
 en: Roast veal, Roasted veal, Veal roast
-fr: Rôtis de veau, Rôti de veau, Rôti de veau
+fr: Rôtis de veau, Rôti de veau
 agribalyse_food_code:en: 6550
 ciqual_food_code:en: 6550
 ciqual_food_name:en: Veal, roast, raw
@@ -90764,7 +90764,7 @@ bg: Свински ребърца
 de: Schweinerippchen
 es: Costillas de cerdo
 fi: Porsaan kylkipalat, Porsaan ribsit
-fr: Côtes de porc, Côtes de porc
+fr: Côtes de porc
 hr: Svinjska rebarca
 it: Costine di maiale, Costolette di maiale, Coste di maiale
 lt: Kiaulienos šonkauliukai
@@ -90923,8 +90923,8 @@ ciqual_food_code:en: 28480
 ciqual_food_name:en: Prok, eye of shortloin, raw
 
 < en: Pork
-en: Pork filet mignon, Pork filet mignon
-fr: filet mignon de porc, filet mignon de porc
+en: Pork filet mignon
+fr: filet mignon de porc
 agribalyse_food_code:en: 28204
 ciqual_food_code:en: 28204
 ciqual_food_name:en: Pork filet mignon, raw
@@ -91387,7 +91387,7 @@ ciqual_food_name:fr: Coeur, poulet, cuit
 < en: Chickens
 en: Chicken heart, chicken heart
 bg: Пилешки сърца
-fr: Coeur de poulet, Coeur de poulet
+fr: Coeur de poulet
 hr: Pileće srce
 ja: 鶏ハツ
 agribalyse_food_code:en: 40054
@@ -91398,7 +91398,7 @@ ciqual_food_name:fr: Coeur, poulet, cru
 < en: Chickens
 en: Chicken liver, chicken liver
 bg: Пилешки черен дроб
-fr: Foie de poulet, Foie de poulet
+fr: Foie de poulet
 hr: Pileća jetra
 ja: 鶏レバー
 lt: Vištienos kepenėlės
@@ -91436,7 +91436,7 @@ ciqual_food_name:fr: Confit de foie de volaille
 < en: Poultries
 en: Poultry liver, poultry liver
 de: Geflügelleber
-fr: Foie de volaille, Foie de volaille
+fr: Foie de volaille
 hr: Jetra peradi
 agribalyse_food_code:en: 40108
 ciqual_food_code:en: 40108
@@ -93068,9 +93068,9 @@ wikidata:en: Q1265899
 # don't confused the "French" style and the "German" style liver sausages. The French ones are cured and the German ones are precooked and usually spreadable
 < en: Prepared meats
 xx: Liverwurst
-en: Liverwurst
 bg: Колбаси от черен дроб
 de: Leberwürste, Leberwurst
+en: Liverwurst
 fi: Maksamakkarat
 hr: Jetrene kobasice
 hu: Májkolbászok
@@ -93184,7 +93184,7 @@ ciqual_food_name:fr: Jambon sec, découenné, dégraissé
 
 < en: Fresh ground meat preparations
 < en: Pork
-fr: Steak hâché de porc, Steak hâché de porc
+fr: Steak hâché de porc
 
 < en: Hams
 en: Braised hams
@@ -94130,7 +94130,7 @@ gpc_category_description:en: Definition: Includes any products that can be descr
 gpc_category_name:en: Turkey Sausages - Prepared/Processed
 
 < en: Sausages
-fr: Merguez, Merguez
+fr: Merguez
 agribalyse_food_code:en: 30150
 ciqual_food_code:en: 30150
 ciqual_food_name:en: Merguez sausage, raw
@@ -94931,7 +94931,7 @@ ciqual_food_name:en: Ham in cube, grated or minced
 
 < en: Poultry hams
 en: Poultry ham in cube, Grated Poultry ham, Minced poultry ham
-fr: Allumettes de jambon de volaille, haché de jambon de volaille, dés de jambon de volaille, râpé de jambon de volaille, haché de jambon de volaille
+fr: Allumettes de jambon de volaille, haché de jambon de volaille, dés de jambon de volaille, râpé de jambon de volaille
 
 < en: Pâté
 en: Head cheese, Head-cheese pâté, Brawn pâté
@@ -97826,9 +97826,9 @@ hr: Smrznute gljive lisičarke
 nl: Diepvries cantharellen, Diepvries hanekammen
 
 < en: Frozen mushrooms
-en: Frozen champignon mushrooms, Frozen common mushrooms, Frozen white mushrooms, Frozen white button mushrooms, Frozen button mushrooms, Frozen Agaricus bisporus, Frozen button mushrooms, Frozen cultivated mushrooms
+en: Frozen champignon mushrooms, Frozen common mushrooms, Frozen white mushrooms, Frozen white button mushrooms, Frozen button mushrooms, Frozen Agaricus bisporus, Frozen cultivated mushrooms
 es: Champiñones congelados, Champiñones de París congelados, Champiñones comunes congelados, Champiñones blancos congelados, Agaricus bisporus congelados
-fr: Champignons de Paris surgelés, Agaricus bisporus surgelés, Champignons de Paris surgelés, Champignons de couche surgelés
+fr: Champignons de Paris surgelés, Agaricus bisporus surgelés, Champignons de couche surgelés
 hr: Smrznuti šampinjoni
 nl: Diepvries champignons
 ciqual_food_code:en: 20228
@@ -97975,8 +97975,8 @@ de: Pilzpulver, Pilzmehl
 el: Σκόνη μανιταριών, Αλεύρι μανιταριών
 eo: Gribo-pulvoroj, Gribo-farunoj
 es: Harinas de setas, Setas en polvo, Setas deshidratadas en polvo
-et: Seenejahu, Seenejahu
-eu: Harinak, Harinak
+et: Seenejahu
+eu: Harinak
 fi: Sienijauheet, Sienijauhot
 fr: Poudres de champignons
 hr: Prah gljiva
@@ -98552,7 +98552,7 @@ wikidata:en: Q20065
 
 < en: Dry pastas
 en: Dried wholemeal pasta
-fr: Pâtes sèches au blé complet, Pâtes sèches au blé complet, Pâtes sèches complètes
+fr: Pâtes sèches au blé complet, Pâtes sèches complètes
 agribalyse_proxy_food_code:en: 9870
 ciqual_food_code:en: 9870
 ciqual_food_name:en: Dried pasta, wholemeal, raw
@@ -98638,8 +98638,8 @@ sv: Glutenfri pasta
 
 < en: Dry pastas
 < en: Gluten-free pasta
-en: Gluten-free dry pasta, Dry gluten-free pasta, Dried gluten-free pasta, Dry gluten-free pasta, Dried gluten-free pasta
-fr: Pâtes sèches sans gluten, Pâtes sèches sans gluten
+en: Gluten-free dry pasta, Dry gluten-free pasta, Dried gluten-free pasta
+fr: Pâtes sèches sans gluten
 agribalyse_food_code:en: 9874
 ciqual_food_code:en: 9874
 ciqual_food_name:en: Dried pasta, gluten-free, raw
@@ -99201,13 +99201,13 @@ ciqual_food_name:en: Fresh egg pasta, cooked, unsalted
 ciqual_food_name:fr: Pâtes fraîches, aux œufs, cuites, non salées
 
 < en: Pastas
-en: Dry pastas, Dried pastas, Dry pastas, Dried pastas, Dry pasta
+en: Dry pastas, Dried pastas, Dry pasta
 bg: Суха паста
 ca: Pasta seca
 de: getrocknete Teigwaren
 es: Pasta seca
 fi: kuiva pasta
-fr: Pâtes sèches, Pâtes alimentaires sèches, Pâtes sèches
+fr: Pâtes sèches, Pâtes alimentaires sèches
 he: פסטה מיובשת
 hr: Suhe tjestenine
 hu: Száraztészták
@@ -100209,7 +100209,7 @@ hr: Sušeni vermicelli od soje
 it: Vermicelli di soia essiccati, Noodles di soia essiccati
 ja: 乾燥した大豆のビーフン、乾燥した大豆の麺
 nl: Gedroogde soja vermicelli, Gedroogde soja noedels
-pl: Suche makaronowe z soi, Suche makaronowe z soi
+pl: Suche makaronowe z soi
 pt: Vermicelli de soja seco, Noodles de soja seco
 ru: Сушеные соевые вермишель, Сушеные соевые лапша
 sv: Torkade sojaverimicelli, Torkade sojanudlar
@@ -100410,7 +100410,7 @@ hr: Biskvit s čokoladnim preljevom
 nl: Chocoladekoekje, Koekje met chocolade, Chocolade bedekt koekje
 pt: Bolacha com cobertura de chocolate, Biscoito com cobertura de chocolate, Bolacha coberta de chocolate
 ru: Печенье с шоколадной глазурью, Печенье с шоколадной оболочкой, Печенье с шоколадной крошкой
-tr: Çikolata kaplı bisküvi, Çikolata kaplı kurabiye, Çikolata kaplı bisküvi
+tr: Çikolata kaplı bisküvi, Çikolata kaplı kurabiye
 agribalyse_food_code:en: 24038
 ciqual_food_code:en: 24038
 ciqual_food_name:en: Biscuit (cookie), chocolate covering
@@ -100453,7 +100453,7 @@ es: Barquillo para helado
 fr: Cône pour glace, Cornet pour glace
 hr: Kornet oblatna za sladoled
 it: Cialda per gelato
-ja: アイスクリーム・コーン, アイスクリーム・コーン
+ja: アイスクリーム・コーン
 nl: Hoorntje voor ijs
 agribalyse_food_code:en: 24685
 ciqual_food_code:en: 24685
@@ -100479,8 +100479,8 @@ nl: Vruchtenbiscuits
 
 < en: Biscuits and cakes
 fr: Biscuits fourrés aux fruits
-en: Fruit-filled biscuits
 de: Fruchtgefüllte Kekse
+en: Fruit-filled biscuits
 es: Galletas rellenas de fruta
 hr: Keksići punjeni voćem
 nl: Gevulde koekjes met fruit
@@ -101170,8 +101170,8 @@ ciqual_food_name:fr: Tarte aux fruits rouges
 
 < en: Sweet pies
 fr: Tarte aux groseilles
-en: Red currant tart
 de: Johannisbeerkuchen
+en: Red currant tart
 es: Tarta de grosellas rojas
 hr: Tart od crvenog ribiza
 nl: Rode bessentaart
@@ -101592,7 +101592,7 @@ it: Panini polari, panino polare, panini fatti con pane polare
 nl: Poolse broodjes, poolse sandwich, broodjes op poolbrood
 
 < en: Sandwiches
-en: Baguette sandwiches, French bread sandwiches, Sandwiches on French bread, Sandwiches made with French bread, Baguette sandwiches, Sandwich made with French bread, Baguette sandwich
+en: Baguette sandwiches, French bread sandwiches, Sandwiches on French bread, Sandwiches made with French bread, Sandwich made with French bread, Baguette sandwich
 da: Baguette-sandwicher
 de: Baguette-Sandwiches, Sandwiches auf Baguette, Sandwiches mit Baguette
 es: Bocadillos de pan francés, Bocadillos en pan francés, Bocadillos hechos con pan francés
@@ -101887,16 +101887,16 @@ intake24_category_code:en: BRGO
 < en: Hamburgers
 en: Fish hamburgers, Fish burgers
 bg: Рибени хамбургери, Рибени бургери, Бургери от риба, Бургери от треска
-ca: Hamburgueses de peix, Hamburgueses de peix, Hamburgueses del mar, Hamburgueses de bacallà
+ca: Hamburgueses de peix, Hamburgueses del mar, Hamburgueses de bacallà
 de: Fischburger, Fisch-Burger, Meeresburger, Kabeljau-Burger
-el: Ψαρομπέργκερ, Ψαρομπέργκερ, Ψαρομπέργκερ της θάλασσας, Ψαρομπέργκερ μπακαλιάρου
-es: Hamburguesas de pescado, Hamburguesas de pescado, Hamburguesas del mar, Hamburguesas de bacalao
-fi: Kala-hampurilaiset, Kala-hampurilaiset, Meren hampurilaiset, Turskahampurilaiset
+el: Ψαρομπέργκερ, Ψαρομπέργκερ της θάλασσας, Ψαρομπέργκερ μπακαλιάρου
+es: Hamburguesas de pescado, Hamburguesas del mar, Hamburguesas de bacalao
+fi: Kala-hampurilaiset, Meren hampurilaiset, Turskahampurilaiset
 fr: Hamburgers au poisson, Burgers au poisson, Burgers de la mer, Burgers de cabillaud
 hr: Riblji hamburgeri
-it: Hamburger di pesce, Hamburger di pesce, Hamburger di mare, Hamburger di merluzzo
-ja: 魚のハンバーガー, 魚のハンバーガー, 海のハンバーガー, タラのハンバーガー
-nl: Visburgers, Visburgers, Zeeburgers, Kabeljauwburgers
+it: Hamburger di pesce, Hamburger di mare, Hamburger di merluzzo
+ja: 魚のハンバーガー, 海のハンバーガー, タラのハンバーガー
+nl: Visburgers, Zeeburgers, Kabeljauwburgers
 ru: Рыбные гамбургеры, Рыбные бургеры, Бургеры из рыбы, Бургеры из трески
 agribalyse_food_code:en: 25416
 ciqual_food_code:en: 25416
@@ -108766,7 +108766,7 @@ en: Chestnut spreads, Chestnut purees, Creme de marrons, Cremes de marrons, Ches
 bg: Подсладено пюре от кестени
 cs: Kaštanovým krémem
 da: Kastanjecreme
-de: Maronenkrem, Maronenkrem
+de: Maronenkrem
 el: κρέμα κάστανου
 es: Cremas de castañas, Mermeladas de castañas, Confituras de castañas, Cremas de marron glacé, Purés de castaña, Crema de castañas
 et: Magustatud kastanipüree
@@ -110726,7 +110726,7 @@ who_id:en: 16
 
 < en: Artichokes
 < en: Canned vegetables
-en: Canned artichokes, Canned artichokes
+en: Canned artichokes
 de: Artischocken in Dosen, Dosen-Artischocken
 es: Alcachofas en conserva
 fi: purkitetut artisokat
@@ -110825,7 +110825,7 @@ nl: Snijbiet in blik/pot
 < en: Diced vegetables
 < en: Mixed vegetables
 en: Canned diced mixed vegetables
-fr: Macédoines de légumes en conserve, macédoines de légume en conserve, macédoine de légumes en conserve, macédoine de légume en conserve, Macédoines de légumes appertisées, Macédoines de légumes appertisées
+fr: Macédoines de légumes en conserve, macédoines de légume en conserve, macédoine de légumes en conserve, macédoine de légume en conserve, Macédoines de légumes appertisées
 agribalyse_food_code:en: 20051
 ciqual_food_code:en: 20051
 ciqual_food_name:en: Diced mixed vegetables, canned, drained
@@ -112328,7 +112328,7 @@ fr: Choux pointus, Chou pointu
 < en: Cabbages
 en: White cabbage, white cabbage
 bg: Бяло зеле
-fr: Chou blanc, Chou blanc
+fr: Chou blanc
 hr: Bijeli kupus
 pl: Kapusta biała, Kapusty białe
 agribalyse_food_code:en: 20116
@@ -113699,7 +113699,7 @@ season_in_country_fr:en: 5,6,7,8,9
 
 < en: Lettuces
 en: Romaine lettuce, cos, romaine lettuce
-fr: Laitue romaine, Laitue romaine
+fr: Laitue romaine
 hr: Romaine salata
 ja: ロメインレタス, コスレタス
 nl: Romainesla
@@ -115691,8 +115691,8 @@ sv: Hela skalade datterini-tomater i tomatjuice
 
 < en: Tomatoes
 xx: Pomodoro San Marzano dell'Agro Sarnese-Nocerino
-en: San Marzano tomatoes
 da: San Marzano-tomater
+en: San Marzano tomatoes
 it: Pomodoro San Marzano
 sv: San Marzano-tomater
 protected_name_file_number:en: PDO-IT-1524
@@ -117816,7 +117816,7 @@ agribalyse_proxy_food_name:en: French bean, canned, drained
 agribalyse_proxy_food_name:fr: Haricot vert, appertisé, égoutté
 
 < en: Canned common beans
-en: Canned flageolet beans, Canned flageolet beans
+en: Canned flageolet beans
 es: Flageolets en conserva
 fr: Flageolets en conserve, Flageolets appertisés égouttés, Flageolets en conserve égouttés, Haricots flageolets appertisés, Haricots flageolets en conserve égouttés
 hr: Konzervirani flageolet grah
@@ -118152,7 +118152,6 @@ pt: Manteigas de soja
 < en: Legumes and their products
 < en: Meat alternatives
 xx: Tofu
-en: Tofu, Tofus, bean curds
 ar: توفو
 ba: Тофу
 be: Тофу
@@ -118163,6 +118162,7 @@ cv: Тофу
 cy: toffw
 de: Tofu, Bohnenquark, Bohnenkäse
 el: Τόφου
+en: Tofu, Tofus, bean curds
 eo: Tofuo
 es: Tofu, Tofus
 fa: توفو
@@ -120617,7 +120617,7 @@ nl: Diepvries groene knoflook
 < en: Frozen legumes
 < en: Frozen vegetables
 en: Frozen broad beans, Frozen fresh broad beans, Frozen fresh fava beans, Frozen immature broad beans
-es: Habas congeladas, Habas frescas congeladas, Habitas frescas congeladas, Habas inmaduras congeladas, Habitas inmaduras congeladas, Habas congeladas
+es: Habas congeladas, Habas frescas congeladas, Habitas frescas congeladas, Habas inmaduras congeladas, Habitas inmaduras congeladas
 fr: Fèves surgelées, Fèves fraîches surgelées, Féverolles frais surgelés
 hr: Smrznuti bob
 nl: Diepvries tuinbonen
@@ -121685,8 +121685,8 @@ fr: Pains au chocolat au beurre
 
 < en: Chocolate croissant
 fr: Pains au chocolat à l'huile de tournesol
-en: Chocolate croissants with sunflower oil
 de: Schokoladen-Croissants mit Sonnenblumenöl
+en: Chocolate croissants with sunflower oil
 es: Croissants de chocolate con aceite de girasol
 hr: Čokoladni kroasani sa suncokretovim uljem
 it: Cornetti al cioccolato con olio di girasole
@@ -122346,7 +122346,7 @@ wikidata:en: Q34807
 
 < en: Geese
 en: Goose liver, goose liver
-fr: Foie d'oie, Foie d'oie
+fr: Foie d'oie
 agribalyse_food_code:en: 40120
 ciqual_food_code:en: 40120
 ciqual_food_name:en: Liver, goose, raw
@@ -125346,7 +125346,7 @@ nl: Gyozas met kip
 
 < en: Gyoza
 en: Shrimp gyoza
-fr: Gyozas aux crevettes, Gyosas aux crevettes, Gyosas aux crevettes, Gyoza à la crevette
+fr: Gyozas aux crevettes, Gyosas aux crevettes, Gyoza à la crevette
 nl: Gyozas met garnalen
 
 < en: Tortellini


### PR DESCRIPTION
### What
I'm developing a process to batch-import translations from a CSV file provided by a translator into OpenFoodFacts taxonomies, beginning with the food `categories` taxonomy.

To tolerate changes that occur while translation is taking place, I've added logic to run an order-preserving deduplication on product names, and also to sort the resulting translations on a per-product basis.

During this process, the script has uncovered that a small number of duplicated product names exist, and that a similar small number of translations were not sorted by language code.

This pull request applies those changes _without_ merging in any new translations.  In other words: this should not produce any user-visible effect, but does tidy up the `categories.txt` taxonomy file.

:warning: **NB**: It seems that I do not yet understand the sorting rules for names in the taxonomy files -- so I have reverted the changes in this branch related to that aspect.

### Large Language Models usage disclosure
I have not used any LLMs, neither to develop the import script that produces these cleanups, nor to open this pull request.

### Related issue(s) and discussion
Follow-up to #14336 

Edit: add note that only deduplication is applied in the latest revision of the changeset.