### PR TITLE
taxonomy: standardise lowercasing of language codes

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -34982,7 +34982,7 @@ wikidata:en: Q940999
 < en: Breads
 en: Sourdough breads
 da: Surdejsbrød
-Fr: Pains au levain
+fr: Pains au levain
 sv: Surdegsbröd
 agribalyse_food_code:en: 7002
 ciqual_food_code:en: 7002
@@ -55226,7 +55226,7 @@ ciqual_food_name:fr: Gâteau au fromage blanc
 < en: Non-dairy desserts
 < en: Pastries
 en: Vegan tiramisu
-Fr: Tiramisu vegan
+fr: Tiramisu vegan
 
 < en: Pastries
 en: Tiramisu
@@ -72052,71 +72052,71 @@ ciqual_food_name:en: Lychee, pulp, raw
 ciqual_food_name:fr: Litchi, pulpe, cru
 
 < en: Tropical fruits
-En: Carambola, Star Fruit
-Ar: قلنباق
-As: কৰ্দ্দৈ
-Bg: Карамбола
-Bn: কামরাঙা
-Ca: Caramboler
-Ch: Bilembines
-Cs: Karambola, Čínská Hvězdice
-Da: Karambole, Stjernefrugt
-De: Karambole, Baumstachelbeere
-Dv: ކާމަރަނގަ
-El: Καραμπόλα
-Eo: Karambolfrukto
-Es: Carambolo, Fruta de Estrella
-Et: Karamboola
-Fa: میوه ستاره‌سان
-Fi: Karambola
-Fr: Carambole
-Ga: Toradh Réaltúil
-Gl: Carambola
-He: קרמבולה
-Hi: कमरख
-Ht: Karanbòl
-Hu: Csillaggyümölcs, Carambola
-Hy: Կարամբոլա
-Is: Stjörnuávöxtur
-It: Carambola
-Ja: スターフルーツ
-Jv: Belimbing, Carambola, Star Fruit
-Kn: ಕಮರಾಕ್ಷಿ
-Ko: 카람볼라
-Kv: Карамбола
-La: Averrhoa Carambola
-Ln: Pakapáka
-Lt: Karambola
-Lv: Karambola
-Ml: ആരംപുളി
-Mr: कमरक
-Ms: Belimbing Besi, ڤوکوق بليمبيڠ بسي‎‎
-My: စောင်းလျားပင်
-Nb: Stjernefrukt
-Ne: कन्तर
-Nl: Stervrucht, Carambola, Sterfruit
-Or: କରମଙ୍ଗା
-Pl: Karambola
-Pt: Caramboleiro, Carambola
-Ro: Carambola
-Ru: Карамбола
-Sd: ڪمرنگو
-Si: කාමරංගා
-Sk: Karambola, Čínska Hviezdica
-Sq: Starfruit
-Sr: Карамбола, Karambola
-Su: Balimbing
-Sv: Carambola
-Ta: விளிம்பிப்பழம்
-Te: నక్షత్ర ఫలం చెట్టు
-Th: มะเฟือง
-Tl: Balimbing
-To: Tapanima
-Tr: Yıldız Meyvesi
-Ty: Raparapa
-Uk: Карамбола
-Vi: Khế
-Zh: 楊桃
+en: Carambola, Star Fruit
+ar: قلنباق
+as: কৰ্দ্দৈ
+bg: Карамбола
+bn: কামরাঙা
+ca: Caramboler
+ch: Bilembines
+cs: Karambola, Čínská Hvězdice
+da: Karambole, Stjernefrugt
+de: Karambole, Baumstachelbeere
+dv: ކާމަރަނގަ
+el: Καραμπόλα
+eo: Karambolfrukto
+es: Carambolo, Fruta de Estrella
+et: Karamboola
+fa: میوه ستاره‌سان
+fi: Karambola
+fr: Carambole
+ga: Toradh Réaltúil
+gl: Carambola
+he: קרמבולה
+hi: कमरख
+ht: Karanbòl
+hu: Csillaggyümölcs, Carambola
+hy: Կարամբոլա
+is: Stjörnuávöxtur
+it: Carambola
+ja: スターフルーツ
+jv: Belimbing, Carambola, Star Fruit
+kn: ಕಮರಾಕ್ಷಿ
+ko: 카람볼라
+kv: Карамбола
+la: Averrhoa Carambola
+ln: Pakapáka
+lt: Karambola
+lv: Karambola
+ml: ആരംപുളി
+mr: कमरक
+ms: Belimbing Besi, ڤوکوق بليمبيڠ بسي‎‎
+my: စောင်းလျားပင်
+nb: Stjernefrukt
+ne: कन्तर
+nl: Stervrucht, Carambola, Sterfruit
+or: କରମଙ୍ଗା
+pl: Karambola
+pt: Caramboleiro, Carambola
+ro: Carambola
+ru: Карамбола
+sd: ڪمرنگو
+si: කාමරංගා
+sk: Karambola, Čínska Hviezdica
+sq: Starfruit
+sr: Карамбола, Karambola
+su: Balimbing
+sv: Carambola
+ta: விளிம்பிப்பழம்
+te: నక్షత్ర ఫలం చెట్టు
+th: มะเฟือง
+tl: Balimbing
+to: Tapanima
+tr: Yıldız Meyvesi
+ty: Raparapa
+uk: Карамбола
+vi: Khế
+zh: 楊桃
 #Bcl:Biriran
 #Koi:Карамбола
 #Lbe:Карамбола
@@ -83664,11 +83664,11 @@ ciqual_food_name:fr: Boeuf bourguignon
 
 < en: Bœufs bourguignons
 en: Bœufs bourguignons without side dishes
-Fr: Bœufs bourguignons sans accompagnements
+fr: Bœufs bourguignons sans accompagnements
 
 < en: Bœufs bourguignons
 en: Bœufs bourguignons with side dishes
-Fr: Bœufs bourguignons avec accompagnements
+fr: Bœufs bourguignons avec accompagnements
 
 < en: Beef
 en: Beef stew meat

--- a/taxonomies/food/ingredients.txt
+++ b/taxonomies/food/ingredients.txt
@@ -38580,7 +38580,7 @@ id: sukun
 it: frutto del pane
 ja: パンの実
 ko: 빵열매
-La: Artocarpus Altilis
+la: Artocarpus Altilis
 ms: sukun, ‏سوكون‎‎, kulur, كولور‎
 nl: broodvrucht
 pt: fruta-pão


### PR DESCRIPTION
### What
I think it is at least an inconsistency, or perhaps a bug, that some of the taxonomy files have entries where the language codes contain uppercase letters.

Only a small number of entries are affected, in `ingredients.txt` and `categories.txt`, and it always seems to be the first of the two characters in the two-letter language codes that are unexpectedly uppercase.

The following `vim` search-and-replace can fix this within a file: `:%s/^\([A-Z][a-z]:\) /\L\1 /g`

(`%s/` = 'global search and replace', `\(...\)` captures and saves a temporary result for each match, `[A-Z][a-z]` matches precisely one uppercase latin character followed by precisely one lowercase, `/` divides the search (on the left) with the replacement (on the right), `\L` in the replacement transforms a saved item from uppercase to lowercase, and `\1` indicates that the saved result to insert is the match from the search)

### Large Language Models usage disclosure
I haven't used any LLMs to prepare this changeset or to open the pull request.

### Screenshot or video
N/A

### Related issue(s) and discussion
Observed during follow-up work from #14336.