### PR TITLE
taxonomy: Split Japanese allergens

### DIFF
--- a/taxonomies/allergens.txt
+++ b/taxonomies/allergens.txt
@@ -64,7 +64,7 @@ hr: gluten, glutena, ječmeni, ječmeni slad, ječam, ječma, ječmeno, ječmeno
 hu: glutén, búza, búzaliszt, búzarost, búzadara, búzacsíra, búzafehérje, búzakorpa, búzamaláta, búzapehely, búzakeményítő, búzasikér, tönkölybúza, tönkölybúzaliszt, tönkölybúzapehely, durumbúza, durumbúzaliszt, rozs, rozsliszt, rozspehely, durumrozsliszt, árpa, árpaliszt, árpapehely, árpamaláta, árpadara, árpacsíra, zab, zabliszt, zabpehely, zabkorpa, durumliszt, durum liszt, Grahamliszt, Graham liszt, kenyérliszt, kenyér liszt, rétesliszt, rétes liszt, kamut, alakor, bulgur, glutént, glutént tartalmazó gabona, glutént tartalmazó gabonafélék
 is: glúten
 it: glutine, grano, segale, orzo, farro, kamut, frumento, farina di frumento, farina di frumento integrale
-ja: 小麦/そば, 小麦, 穀物, グルテン, コムギ, そば, ソバ
+ja: グルテン, 穀物
 lt: avižos, avižų, avižiniai, avižinės, glitimas, glitimo, glitimu, kamutas, kviečiai, kviečių, kvietiniai, kvietinės, miežiai, miežių, miežiniai, miežinės, rugiai, ruginiai, ruginės, rugių, spelta, manų
 lv: auzas, auzu, kvieši, kviešu, lipekli, manna, mieži, miežu, rudzi, speltas kvieši, triticum turgidum polonicum, satur lipekli saturošus graudaugus
 mt: glutina, qamħ, segala, barli, ħafur, ispelt, kamut
@@ -83,6 +83,12 @@ th: กลูเต็น, ข้าวสาลี, ข้าวไร, บา�
 zh: 麸质
 wikidata:en: Q188251
 
+<en:gluten
+ja: 小麦, コムギ
+
+<en:gluten
+ja: そば, ソバ
+
 en: crustaceans, crab, lobster, crayfish, prawn, shrimp
 ar: قشريات
 bg: ракообразни
@@ -99,7 +105,7 @@ ga: crústach, crústaigh
 hr: rakova, rakove
 hu: rákfélék, rák, homár, garnéla, garnélarák
 it: crostacei
-ja: えび/かに, えび, 甲殻類, カニ, エビ, かに
+ja: 甲殻類
 lt: vėžiagyviai, krabai, krabų, omarai, omarų, vėžiai, krevetės, krevečių
 lv: vēžveidīgie
 mt: krustaċej
@@ -113,6 +119,12 @@ sl: raki
 sv: kräftdjur, skaldjur, räkor, räkkrydda, krabba, krabbarom, krabbextrakt, räkarom, räkpulver
 th: ครัสเตเชียน, ปู, กั้ง, กุ้ง, กะปิ
 zh: 甲壳亚门
+
+<en:crustaceans
+ja: えび, エビ
+
+<en:crustaceans
+ja: かに, カニ
 
 en: eggs, egg, barn egg, egg whites, egg white, egg yolks, egg yolk, whole eggs, whole egg
 ar: بيض, بيضة
@@ -168,7 +180,7 @@ he: דג, דגים, טונה, סלמון, קוד, מקרל, ברבוניה, הל
 hr: riba, ribe, skuša
 hu: hal, halak, tőkehal, tőkehalfilé, makréla, hering, heringfilé, lazac, lazacfilé, pisztráng, tonhal, szardínia, lepényhal, rombuszhal, sprotni, alaszkai tőkehal
 it: pesce
-ja: さけ/さば, 魚, 魚類, さけ, 鮭, サケ, サーモン, しゃけ, シャケ, さば, 鯖, サバ
+ja: 魚類, 魚
 lt: žuvis, žuvys, žuvies, žuvų, menkė, menkės, menkių, skumbrė, skumbrės, skumbrių, plekšnė, plekšnės, plekšnių, lašiša, lašišos, lašišų, upėtakis, upėtakiai, upėtakių, tunas, tunu, tuno, sardinės, sardinė, sardinių
 lv: zivis
 mt: ħut
@@ -187,9 +199,15 @@ th: ปลา
 zh: 魚
 wikidata:en: Q600396
 
-# <en:fish
+<en:fish
+ja: さけ, 鮭, サケ, サーモン, しゃけ, シャケ
+
+<en:fish
 en: red caviar
 ja: いくら, イクラ, すじこ, スジコ
+
+<en:fish
+ja: さば, 鯖, サバ
 
 en: orange
 ja: オレンジ
@@ -351,7 +369,7 @@ hr: orašaste plodove, orašastih plodova, orašasto voće, orašasto voče, ora
 hu: diófélék, mandula, mogyoró, dió, kesudió, pekándió, brazil dió, pisztácia, makadámia, queenslandi dió, dióféléket, egyéb dióféléket
 is: hnetur
 it: frutta a guscio, mandorle, nocciole, noci, noci di acagiù, noci di pecan, noci del Brasile, pistacchi, noci macadamia, noci del Queensland
-ja: くるみ/アーモンド, くるみ, 種実類, 木の実, 木の実類, アーモンド, ヘーゼルナッツ, クルミ, カシューナッツ, ペカン, ブラジルナッツ, ピスタチオ, マカダミアナッツ
+ja: ナッツ, 種実類, 木の実, 木の実類, ヘーゼルナッツ, ペカン, ブラジルナッツ, ピスタチオ
 lt: riešutai, riešutų, riešutas, riešutais, migdolai, migdolų, migdolas, migdolais, lazdyno riešutai, lazdynų, lazdynas, lazdynais, lazdyno, graikiniai riešutai, graikinių riešutų, graikiniais riešutais, anakardžiai, anakardžių, anakardžiais, Anakardium occidentale, pekaninės karijos, pekaninių karijų, brazilinės bertoletijos, brazilinių bertoletijų, pistacijos, pistacijų, pistacija, makadamijos, makadamijų, makadamija, Kvinslendo riešutai, kitų riešutų
 lv: rieksti, mandeles, lazdu rieksti, valrieksti, Indijas rieksti, pekanrieksti, Brazīlijas rieksti, pistāciju rieksti, makadāmijas, Kvīnslendas rieksti
 mt: ġewż, lewż, ġellewż, ġewż, anakardji, ġewż Amerikan, ġewż tal-Brażil, pistaċċi, macadamia, Queensland nuts
@@ -368,6 +386,18 @@ sr: jezgrasto voće, orasi, badem, badema, bademi, indijski orah, indijski orasi
 sv: nötter, notter, mandel, mandlar, mandelprotein, hasselnöt, hasselnötter, hasselnötshalvor, hasselnötpasta, hasselnötssmör, valnöt, valnötter, cashewnöt, cashewnötter, pekannöt, pekannötter, paranöt, paranötter, pistachnöt, pistagenöt, pistagenötter, pistaschmandel, makadamianöt, makadamianötter, macadamianöt, macadamianötter, Queenslandsnöt, Queenslandsnötter, andra nötter, nötter (inga jordnötter)
 th: อัลมอนด์
 zh: 坚果, 扁桃仁, 坚果, 杏仁, 扁桃仁, 腰果, 榛子, 核桃, 松子, 榛仁, 核桃=核桃仁, 松子=松仁, 开心果=阿月浑子, 板栗, 白果, 银杏果, 开心果, 夏威夷果, 碧根果
+
+<en:nuts
+ja: くるみ, クルミ
+
+<en:nuts
+ja: アーモンド
+
+<en:nuts
+ja: マカダミアナッツ
+
+<en:nuts
+ja: カシューナッツ
 
 en: celery, celeriac
 ar: كرفس
@@ -565,7 +595,7 @@ ga: moilisc, breallach, breallaigh
 hr: mekušac, mekušaca
 hu: puhatestűek, kagyló, tintahal
 it: molluschi
-ja: あわび/いか, あわび, いか, 軟体動物, イカ, タコ, カキ, アワビ
+ja: 軟体動物, タコ, カキ
 lt: moliuskai, moliuskas, moliuskų, moliuskais
 lv: gliemji
 mt: molluski
@@ -582,3 +612,8 @@ th: มอลลัสกา
 zh: 软体动物
 wikidata:en: Q1275863
 
+<en:molluscs
+ja: あわび, アワビ
+
+<en:molluscs
+ja: いか, イカ

--- a/taxonomies/allergens.txt
+++ b/taxonomies/allergens.txt
@@ -83,10 +83,10 @@ th: กลูเต็น, ข้าวสาลี, ข้าวไร, บา�
 zh: 麸质
 wikidata:en: Q188251
 
-<en:gluten
+< en: gluten
 ja: 小麦, コムギ
 
-<en:gluten
+< en: gluten
 ja: そば, ソバ
 
 en: crustaceans, crab, lobster, crayfish, prawn, shrimp
@@ -120,10 +120,10 @@ sv: kräftdjur, skaldjur, räkor, räkkrydda, krabba, krabbarom, krabbextrakt, r
 th: ครัสเตเชียน, ปู, กั้ง, กุ้ง, กะปิ
 zh: 甲壳亚门
 
-<en:crustaceans
+< en: crustaceans
 ja: えび, エビ
 
-<en:crustaceans
+< en: crustaceans
 ja: かに, カニ
 
 en: eggs, egg, barn egg, egg whites, egg white, egg yolks, egg yolk, whole eggs, whole egg
@@ -199,14 +199,14 @@ th: ปลา
 zh: 魚
 wikidata:en: Q600396
 
-<en:fish
+< en: fish
 ja: さけ, 鮭, サケ, サーモン, しゃけ, シャケ
 
-<en:fish
+< en: fish
 en: red caviar
 ja: いくら, イクラ, すじこ, スジコ
 
-<en:fish
+< en: fish
 ja: さば, 鯖, サバ
 
 en: orange
@@ -387,16 +387,16 @@ sv: nötter, notter, mandel, mandlar, mandelprotein, hasselnöt, hasselnötter, 
 th: อัลมอนด์
 zh: 坚果, 扁桃仁, 坚果, 杏仁, 扁桃仁, 腰果, 榛子, 核桃, 松子, 榛仁, 核桃=核桃仁, 松子=松仁, 开心果=阿月浑子, 板栗, 白果, 银杏果, 开心果, 夏威夷果, 碧根果
 
-<en:nuts
+< en: nuts
 ja: くるみ, クルミ
 
-<en:nuts
+< en: nuts
 ja: アーモンド
 
-<en:nuts
+< en: nuts
 ja: マカダミアナッツ
 
-<en:nuts
+< en: nuts
 ja: カシューナッツ
 
 en: celery, celeriac
@@ -612,8 +612,8 @@ th: มอลลัสกา
 zh: 软体动物
 wikidata:en: Q1275863
 
-<en:molluscs
+< en: molluscs
 ja: あわび, アワビ
 
-<en:molluscs
+< en: molluscs
 ja: いか, イカ

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -126439,3 +126439,4 @@ zh: 全杜兰小麦螺旋意面
 en: Semi whole durum wheat spirals
 fr: Spirales de blé dur semi-complet
 zh: 半杜兰小麦螺旋意面
+

--- a/taxonomies/ingredients_analysis.txt
+++ b/taxonomies/ingredients_analysis.txt
@@ -420,3 +420,4 @@ tr: Vejetaryen durumu bilinmiyor
 uk: Статус вегетаріанський невідомий
 vi: Tình trạng ăn chay không rõ
 zh: 素食状态未知
+

--- a/taxonomies/misc.txt
+++ b/taxonomies/misc.txt
@@ -1479,3 +1479,4 @@ fr: Nombre d'images téléversées - 51 à 100
 
 en: Number of uploaded images - More than 100
 fr: Nombre d'images téléversées - Plus de 100
+


### PR DESCRIPTION
### What
Some allergens are distinguished in Japan. This change puts them as children.

Reference: https://web.archive.org/web/20260903075351/https://www.caa.go.jp/policies/policy/food_labeling/food_sanitation/allergy/