### PR TITLE
taxonomy(food): add sötstark mustards category

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -79920,6 +79920,11 @@ nl: Zoete mosterds
 pl: Musztardy słodkie
 
 < en: Mustards
+en: Sweet and strong mustards, Sweet and spicy mustards, Sötstark mustards
+fi: Sinappi makea-väkevä
+sv: Sötstarka senap, Sötstark senap
+
+< en: Mustards
 en: Tomato mustards
 es: Mostazas con tomate
 fr: Moutardes à la tomate


### PR DESCRIPTION
It doesn’t seem like this type of mustard has an established English name/translation, but the ones used here seem to be some of the ones in use, according to some quick searching.

Needed-for: https://se.openfoodfacts.org/product/7310155600516/s%C3%B6tstark-senap-johnny-s
Needed-for: https://world-sv.openfoodfacts.org/cgi/search.pl?search_terms=S%C3%B6tstark
Needed-for: https://world.openfoodfacts.org/cgi/search.pl?search_terms=S%C3%B6tstark