### PR TITLE
taxonomy(food): add sv “no nuts” label synonym

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -21011,7 +21011,7 @@ fr: Sans fruits à coque, sans fruits secs, Sans noix
 it: Senza noci, senza frutta secca, senza frutta a guscio
 nl: Zonder noten
 pt: Sem nozes, livre de nozes
-sv: Utan nötter
+sv: Utan nötter, nötfri
 
 # French label
 fr: Saveurs de l'Année


### PR DESCRIPTION
Needed-for: https://se.openfoodfacts.org/product/7340083479434/n%C3%B6tfri-pesto-di-basilico-garant