### PR TITLE
taxonomy: Add Canadian Geographical Indication label scheme

### DIFF
--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -3975,6 +3975,60 @@ description:fr: Le contenu du produit est originaire du Canada à au moins 98%
 label_categories:en: en:Geographic label
 # https://bureau-concurrence.canada.ca/comment-nous-favorisons-concurrence/education-sensibilisation/publications/indications-produit-canada-fait-canada
 
+# Canadian Geographical Indication (GI): a name identifying a wine, spirit, agricultural
+# product, or food as originating in Canada, protected under the Trademarks Act. The regime
+# originally covered only wines and spirits; it was expanded to agricultural products and
+# food following the 2017 Canada-EU CETA agreement. Administered by the Canadian Intellectual
+# Property Office (CIPO). The 7 specific GI names below were each individually verified live
+# against CIPO's Canadian Trademarks Database (category: Geographical Indications) at
+# https://ised-isde.canada.ca/cipo/trademark-search/srch as of 2026-09-03, and all carry the
+# status "ENTERED ON THE LIST". This is not a claim that the list is exhaustive - the
+# register holds ~900 GI entries in total, the large majority of which are foreign
+# (EU/CETA-reciprocal) indications like Feta or Champagne, out of scope for this entry.
+en: Canadian Geographical Indication, Canadian GI
+xx: Canadian Geographical Indication
+fr: Indication géographique canadienne, IG canadienne
+country:en: en:Canada
+description:en: A name identifying a wine, spirit, agricultural product, or food as originating in Canada, where a quality, reputation, or other characteristic of the product is essentially attributable to that geographic origin, protected under Canada's Trademarks Act.
+description:fr: Un nom identifiant un vin, une boisson spiritueuse, un produit agricole ou un aliment comme étant originaire du Canada, dont une qualité, une réputation ou une autre caractéristique du produit est essentiellement attribuable à cette origine géographique, protégé en vertu de la Loi sur les marques de commerce du Canada.
+label_categories:en: en:Quality, en:Geographic label
+web:en: https://ised-isde.canada.ca/site/canadian-intellectual-property-office/en/ip-roadmap-geographical-indications-canada
+
+< en: Canadian Geographical Indication
+en: Canadian Whisky
+xx: Canadian Whisky
+fr: Whisky canadien
+
+< en: Canadian Geographical Indication
+en: Canadian Rye Whisky
+xx: Canadian Rye Whisky
+fr: Whisky de seigle canadien
+
+< en: Canadian Geographical Indication
+en: Okanagan Valley
+xx: Okanagan Valley
+fr: Vallée de l'Okanagan
+description:en: Wine geographical indication for British Columbia's Okanagan Valley region.
+
+< en: Canadian Geographical Indication
+en: Niagara Peninsula
+xx: Niagara Peninsula
+fr: Péninsule du Niagara
+description:en: Wine geographical indication for Ontario's Niagara Peninsula region.
+
+< en: Canadian Geographical Indication
+en: Ontario Icewine
+xx: Ontario Icewine
+
+< en: Canadian Geographical Indication
+en: Vin de glace du Québec, Quebec Icewine
+xx: Vin de glace du Québec
+
+< en: Canadian Geographical Indication
+en: Maïs sucré de Neuville, Neuville Sweet Corn
+xx: Maïs sucré de Neuville
+description:en: Agricultural product geographical indication for sweet corn grown in Neuville, Québec.
+
 # [CL] Chile
 
 en: Chilean front-of-package nutrition warnings

--- a/taxonomies/labels.txt
+++ b/taxonomies/labels.txt
@@ -4023,10 +4023,12 @@ xx: Ontario Icewine
 < en: Canadian Geographical Indication
 en: Vin de glace du Québec, Quebec Icewine
 xx: Vin de glace du Québec
+fr: Vin de glace du Québec
 
 < en: Canadian Geographical Indication
 en: Maïs sucré de Neuville, Neuville Sweet Corn
 xx: Maïs sucré de Neuville
+fr: Maïs sucré de Neuville
 description:en: Agricultural product geographical indication for sweet corn grown in Neuville, Québec.
 
 # [CL] Chile


### PR DESCRIPTION
### What
Adds a generic "Canadian Geographical Indication" label entry (mirroring the existing generic PDO/PGI EU scheme entries already in this file), plus 7 specific Canadian GI names as children: Canadian Whisky, Canadian Rye Whisky, Okanagan Valley, Niagara Peninsula, Ontario Icewine, Vin de glace du Québec, and Maïs sucré de Neuville.

Canada's GI regime is administered by CIPO under the Trademarks Act; it originally covered only wines and spirits and was expanded to agricultural products/food following the 2017 Canada-EU CETA agreement (per ised-isde.canada.ca's GI roadmap page).

**Verification**: each of the 7 specific GI names was individually looked up live against CIPO's Canadian Trademarks Database (filtered to the Geographical Indications category) at https://ised-isde.canada.ca/cipo/trademark-search/srch, and each returned status "ENTERED ON THE LIST". This isn't a claim of exhaustiveness — the register holds ~900 total GI entries, the large majority of which are foreign (EU/CETA-reciprocal) indications like Feta or Champagne, out of scope here. A maintainer with more time could pull the full domestic-origin list for completeness.

### Large Language Models usage disclosure
This PR was written agentically by Claude Code (Claude Sonnet 5), under human direction and review. All 7 specific GI claims were individually verified live against the official CIPO Canadian Trademarks Database (not just cited from memory or secondary sources) by driving the actual search form in a browser and reading the JSON API response for each. The code was run and verified on the contributor's machine via `scripts/taxonomies/lint_taxonomy.pl --check` in the project's docker `backend` container.

### Testing
`scripts/taxonomies/lint_taxonomy.pl --check taxonomies/labels.txt` — exit 0, no errors/warnings.

### Related issue(s) and discussion
- Fixes: #14463