### PR TITLE
taxonomy(food): Rhode Island dressing category

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -78937,16 +78937,34 @@ wikidata:en: Q1572278
 en: Salad creams
 description:en: Salad cream is a creamy, pale yellow condiment based on an emulsion of about 25–50 percent oil in water, emulsified by egg yolk and acidulated by spirit
 intake24_category_code:en: SDCM
+wikidata:en: Q6128321
 
 < en: Salad dressings
-en: Salad dressing with reduced fat, Low fat salad dressing, Light salad dressing
+en: Salad dressings with reduced fat, Salad dressing with reduced fat, Low fat salad dressing, Light salad dressing
+da: Lette salatdressinger
 fr: Sauces crudités allégées, Sauces crudités light, Sauce crudités allégée en matière grasse, Sauce salade allégée en matière grasse
 hr: Preljev za salatu sa smanjenom masnoćom
 lt: Salotų padažai su sumažintu riebalų kiekiu
+sv: Lätta salladsdressingar
 agribalyse_food_code:en: 11198
 ciqual_food_code:en: 11198
 ciqual_food_name:en: Salad dressing, reduced fat, prepacked
 ciqual_food_name:fr: Sauce crudités ou Sauce salade, allégée en matière grasse, préemballée
+
+< en: Salad dressings
+en: Rhode Island dressings
+da: Rhode Island-dressinger
+sv: Rhode Island-dressingar, Rhode Island-såser
+description:en: Swedish salad dressing similar to Thousand Island, with no known relation to Rhode Island.
+
+< en: Rhode Island dressings
+< en: Salad dressings with reduced fat
+en: Rhode Island dressings with reduced fat, Light Rhode Island dressings
+sv: Lätta Rhode Island-dressingar, Rhode Island lätt dressing
+agribalyse_proxy_food_code:en: 11198
+ciqual_proxy_food_code:en: 11198
+ciqual_proxy_food_name:en: Salad dressing, reduced fat, prepacked
+ciqual_proxy_food_name:fr: Sauce crudités ou Sauce salade, allégée en matière grasse, préemballée
 
 < en: Salad dressings
 en: Thousand Island dressings, Thousand Island dressing


### PR DESCRIPTION
- Adds Rhode Island dressing categories.
- Adds some sv/da translations.
- Normalises categories towards plural forms.
- Adds a `wikidata` property.

Needed-for: https://se.openfoodfacts.org/cgi/search.pl?search_terms=Rhode+Island