### PR TITLE
taxonomy: add more ZH-language food category translations

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -1263,6 +1263,7 @@ pt: Produtos des abelhas, produtos de colmeia
 ro: Produse apicole, Produse de apicultură, Produse apicultură, Produse de apicultura, Produse apicultura
 ru: Продукция пчеловодства, Продукты пчеловодства
 tr: Arı ürünleri
+zh: 蜂产品
 wikidata_category:en: Q7189914
 
 < en: Bee products
@@ -1436,6 +1437,7 @@ it: Bevande e preparati per bevande
 nl: Dranken en drankbereidingen
 pl: Napoje i składniki do napojów
 pt: Bebidas e preparações para bebidas
+zh: 饮料及饮料备制品
 description:en: This mixes ready to drink beverages and not-ready to drink beverages
 incompatible_with:en: categories:en:meals
 
@@ -1669,6 +1671,7 @@ ro: Băuturi dulci, Băuturi cu zahăr, Bauturi dulci, Bauturi cu zahar
 ru: Напитки с добавлением сахара
 th: น้ำหวาน
 tr: Tatlı içecekler, Şekerli içecekler
+zh: 含糖饮料
 food_groups:en: en:sweetened-beverages
 pnns_group_2:en: Sweetened beverages
 
@@ -1691,6 +1694,7 @@ pl: Napoje sztucznie słodzone, Napoje ze sztucznymi słodzikami
 pt: Bebidas artificialmente doçeadas
 ro: Băuturi îndulcite artificial, Băuturi cu îndulcitori artificiali, Bauturi indulcite artificial, Bauturi cu indulcitori artificiali
 th: เครื่องดื่มผสมน้ำตาลเทียม
+zh: 人工甜味剂饮料
 food_groups:en: en:artificially-sweetened-beverages
 pnns_group_2:en: Artificially sweetened beverages
 
@@ -1713,6 +1717,7 @@ pt: Bebidas não adoçadas, Bebidas não açucaradas, bebidas sem açucar adicio
 ro: Băuturi fără zahăr, Băuturi fără zahăr adăugat, Bauturi fara zahar, Bauturi fara zahar adaugat
 ru: Напитки без добавления сахара
 th: เครื่องดื่มไม่เติมน้ำตาล
+zh: 无糖饮料
 food_groups:en: en:unsweetened-beverages
 pnns_group_2:en: Unsweetened beverages
 
@@ -2240,6 +2245,7 @@ description:en: Beers that are packed for example: 6x330ml
 en: Ales, Ale
 xx: Ales, Ale
 lt: Elis
+zh: 艾尔啤酒
 wikidata:en: Q208385
 
 < en: Ales
@@ -2267,6 +2273,7 @@ en: American-style IPA, American IPA
 xx: American-style IPA, American IPA
 lt: Amerikietiškas IPA
 pt: IPA estilo americano
+zh: 美式IPA啤酒
 
 < en: India Pale Ale (IPA)
 en: Cornish IPA
@@ -2402,6 +2409,7 @@ wikipedia:en: https://en.wikipedia.org/wiki/Saison
 < en: Pale ales
 en: American-style Pale Ale (APA), American Pale Ale (APA), American Pale Ale, APA
 xx: American-style Pale Ale (APA), American Pale Ale (APA), American Pale Ale, APA
+zh: 美式淡色艾尔啤酒（APA）
 wikidata:en: Q15940735
 
 < en: Ales
@@ -2428,6 +2436,7 @@ hr: Opatsko pivo
 hu: Apátsági sörök
 it: Birre d'abbazia
 nl: Abdijbieren
+zh: 修道院艾尔啤酒
 agribalyse_food_code:en: 5011
 ciqual_food_code:en: 5011
 ciqual_food_name:en: Beer, specialty, from abbey or regional (varying alcohol content)
@@ -2488,6 +2497,7 @@ xx: Belgian-style blonde ales, Belgian blonde, Belgian blonde ales
 < en: Blonde ales
 en: American-style blonde ales, American blonde, American blonde ales
 xx: American-style blonde ales, American blonde, American blonde ales
+zh: 美式金色艾尔啤酒
 
 < en: Ales
 en: Dark ales, Dark ale
@@ -2547,6 +2557,7 @@ wikidata:en: Q900660
 < en: Brown ales
 en: Altbier beers, Altbier
 xx: Altbier beers, Altbier
+zh: 阿尔特啤酒
 description:en: Altbier is a German-style brown ale that requires cold formentation and longer time in order to brew this beer.
 
 < en: Ales
@@ -3022,6 +3033,7 @@ it: Birre 5%, Birra 5%
 lt: 5% alaus, Alus su 5° alkoholiu, Alus su 4° alkoholiu
 nl: Bier met 5% alcohol, Bier met 4% alcohol
 pl: Piwo 5%, Piwo z 5° alkoholem, Piwo z 4° alkoholem
+zh: 5% 啤酒
 agribalyse_food_code:en: 5001
 ciqual_food_code:en: 5001
 ciqual_food_name:en: Beer, regular (4-5° alcohol)
@@ -3053,6 +3065,7 @@ it: Birre americane, Birre dagli USA, Birre dagli Stati Uniti d'America
 lt: Amerikietiškas alus, Alus iš JAV, Alus iš Amerikos
 nl: Bier uit de Verenigde Staten van Amerika, Amerikaanse bieren
 pl: Piwa amerykańskie, Piwo amerykańskie
+zh: 美国啤酒
 origins:en: en:united-states
 wikidata:en: Q15146313
 
@@ -3610,6 +3623,7 @@ fr: Cocktails sans alcool, Cocktail sans alcool à base de jus de fruits et de s
 hr: Kokteli bez alkohola
 hu: Alkoholmentes koktélok
 lt: Nealkoholiniai kokteiliai
+zh: 无酒精鸡尾酒
 agribalyse_food_code:en: 2008
 ciqual_food_code:en: 2008
 ciqual_food_name:en: Cocktail, alcohol-free (juices and syrup-based cocktail)
@@ -4636,6 +4650,7 @@ lt: Amerikietiškas viskis
 nl: Amerikaanse whiskies
 pl: Amerykańskie whisky
 ro: Whisky american, whiskey american
+zh: 美国威士忌
 origins:en: en:united-states
 wikidata_category:en: Q8126582
 
@@ -5420,6 +5435,7 @@ hr: Poljoprivredni rumovi
 it: Rum agricoli
 nl: Agrarische rums
 pt: Rums agrícolas
+zh: 农业朗姆酒
 wikidata:en: Q3429796
 
 < en: Rums
@@ -5428,6 +5444,7 @@ de: Dunkler Rum
 fr: Rhums ambrés, rhum ambré
 hr: Jantarni rum
 nl: Donkere rums
+zh: 琥珀朗姆酒
 
 < en: Rums
 en: White rums, white rum
@@ -7529,6 +7546,7 @@ pl: Soki i nektary
 pt: Sucos e néctares
 ro: Sucuri și nectaruri, Sucuri si nectaruri
 ru: Соки и нектары
+zh: 果汁及果浆饮料
 
 < en: Juices and nectars
 en: Fruit and vegetable juices
@@ -9574,6 +9592,7 @@ pl: Herbaty ziołowe
 pt: Chás de ervas, infusões de ervas, infusões
 ru: Травяные чаи и настойки
 sv: Örtteer, Örtte
+zh: 花草茶
 agribalyse_proxy_food_code:en: 18020
 agribalyse_proxy_food_name:en: Tea, brewed, without sugar
 # 2026/01/22: (Stéphane) we had an old comment "should not be in pnns_group_2:en:Teas and herbal teas and coffees", and only the "herbal tea beverages" were under it, but it would make sense to have them here.
@@ -9619,6 +9638,7 @@ it: Artemisia absinthium
 la: Artemisia absinthium
 nl: Absint-alsem
 pl: Piołun, Bylica Piołun
+zh: 苦艾草
 wikidata:en: Q25686
 
 < en: Herbal teas
@@ -11019,6 +11039,7 @@ nl: Zuivelvervangers
 pl: Zastępniki nabiału, Substytuty nabiału
 pt: Alternativas aos produtos lácteos
 sv: Alternativ till mejeriprodukter
+zh: 乳制品替代品
 incompatible_with:en: categories:en:dairies
 wikidata:en: Q139604162
 
@@ -13201,6 +13222,7 @@ fr: Sirops à l'anis, Sirops d'anis
 hr: Sirupi od anisa
 hu: Ánizsszirup, Ánizsos szirup
 nl: Anijssiropen, Anijssiroop
+zh: 茴香糖浆
 
 < en: Flavoured syrups
 en: Kiwifruit syrups, Kiwi syrups
@@ -13443,6 +13465,7 @@ lt: Arbatos gėrimai, Nealkoholiniai gaivieji gėrimai su arbatos ekstraktu ir c
 nl: Dranken op basis van thee
 pt: Bebidas à base de chá
 sv: Tebaserade drycker
+zh: 茶饮料
 agribalyse_proxy_food_code:en: 18015
 agribalyse_proxy_food_name:en: Still soft drink with tea extract, with sugar and artificial sweetener(s)
 ciqual_food_code:en: 18062
@@ -14205,6 +14228,7 @@ wikidata:en: Q3576141
 < fr: Alsace Grand Cru
 fr: Alsace grand cru Rosacker, Rosacker
 en: Alsace Grand Cru preceded by Rosacker
+zh: Rosacker产区阿尔萨斯特级葡萄酒
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0341
 protected_name_type:en: pdo
@@ -32593,6 +32617,7 @@ pt: Produtos secos, produtos desidratados, Alimentos secos, Alimentos desidratad
 ru: Обезвоженные продукты
 th: อาหารแห้ง
 tr: Kurutulmuş ürünler
+zh: 干制品
 
 # Note: en:dried-products-to-be-rehydrated is a category that changes the computation of the Nutri-Score, the canonical name should not be changed without corresponding code changes
 < en: Dried products
@@ -32616,6 +32641,7 @@ fi: ateriakitit
 fr: Kits repas, Kits pour repas, Kits culinaires, Kit repas, Kit pour repas, Kit culinaire
 hr: Setovi obroka
 nl: Maaltijdpakketten
+zh: 快煮餐
 gpc_category_code:en: 10000292
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a vegetable based not ready to eat, prepared/processed product, such as Potato, Cabbage, Eggplant or any other vegetable with other ingredients, such as meat, poultry, fish, and/or seasoning. An optional seasoning/flavour packet may be present. These ingredients form a valuable part of the product, such as minced beef in a Shepherd's Pie or Duck with Vegetables. These products may have a main component which is considered a meal without any additional components. These products must not include any Dough Based, Grain Based, Dairy/Egg Based products. They may or may not contain a sauce. These products require cooking prior to consumption. These products have been specially treated or packaged to extend their consumable life. Includes not ready to eat self stable Ready-Made Meals where a Vegetable Based Product is the primary ingredient. Definition Excludes: Excludes Ready-Made Combination Meals. Specifically excludes all prepared and processed and unprepared and unprocessed vegetables to which no recipe has been applied.Excludes products such as Frozen and Perishable Not Ready to Eat and all Ready to Eat Vegetable-Based Prepared/Processed Products and all Prepared and Processed Vegetables.
 gpc_category_name:en: Vegetable Based Products / Meals - Not Ready to Eat (Shelf Stable)
@@ -33055,6 +33081,7 @@ it: Biscotti alle mandorle
 lt: Sausainiai su migdolais, Migdoliniai sausainiai
 nl: Amandelkoekjes, Amandelkoekje
 ro: Biscuiți cu migdale, Fursecuri cu migdale
+zh: 杏仁饼干
 agribalyse_food_code:en: 24615
 ciqual_food_code:en: 24615
 ciqual_food_name:en: Biscuit (cookie), thin, w almonds
@@ -37835,6 +37862,7 @@ pt: Confeitaria
 ru: Кондитерские изделия
 sv: Konfekt
 th: ขนมหวาน
+zh: 糖果及甜食
 food_groups:en: en:sweets
 intake24_category_code:en: CONF
 pnns_group_2:en: Sweets
@@ -39301,7 +39329,7 @@ ja: ボンボン・ショコラ
 nl: Pralines, chocolades snoepjes
 pt: Bombons
 ru: Конфеты
-zh: 精致糖果, 夹心糖, 巧克力糖
+zh: 糖果, 精致糖果, 夹心糖, 巧克力糖
 wikidata:en: Q3272827
 
 < en: Bonbons
@@ -40461,6 +40489,7 @@ de: Alfajor
 es: Alfajores, Alfajor
 fr: Alfajores, Alfajor
 hr: Alfajores
+zh: 阿尔法霍雷夹心饼
 wikidata:en: Q938682
 
 < en: Alfajores
@@ -41707,7 +41736,7 @@ nl: Graankorrels
 pl: Ziarna zbóż
 pt: Grãos de cereais
 ru: Злаковое зерно
-zh: 麦片谷物
+zh: 谷物, 麦片谷物
 intake24_category_code:en: CARB
 
 < en: Cereal grains
@@ -45027,6 +45056,7 @@ ru: сыр из коровьего молока
 sr: крављи сир
 th: ชีสจากนมวัว
 tr: İnek peynirleri
+zh: 牛乳奶酪
 wikidata:en: Q3088299
 
 < en: Cow cheeses
@@ -46293,6 +46323,7 @@ nl: Franse kazen
 pl: Sery francuskie, sery z Francji
 pt: Queijos franceses, queijos da França
 ru: Французские сыры
+zh: 法国奶酪
 wikidata:en: Q2223649
 
 < en: French cheeses
@@ -47024,6 +47055,7 @@ lt: Kietieji sūriai, Kietasis sūris
 nl: Verhitte geperste kazen
 pt: Queijos cozidos e premidos
 ru: Варёный спрессованный сыр
+zh: 硬质奶酪
 ciqual_food_code:en: 12100
 ciqual_food_name:en: Hard cheese (average)
 ciqual_food_name:fr: Fromage à pâte pressée cuite (aliment moyen)
@@ -49850,6 +49882,7 @@ fr: Fromage frais aromatisé aux fruits, Petit suisse aromatisé aux fruits
 < en: Petits suisses
 en: 2-3% fat Petit-Suisse, 2-3% fat fresh cream cheese
 fr: Petit suisse à 2-3% de matières grasses, Fromage frais à 2-3% de matières grasses
+zh: 2-3%脂肪量 小瑞士奶酪
 
 < en: 2-3% fat Petit-Suisse
 < en: Petit-Suisse with fruits
@@ -51001,6 +51034,7 @@ gpc_category_name:en: Milk Substitutes (Shelf Stable)
 en: Milks (liquid and powder)
 fr: Laits (fluide et poudre)
 nl: Melk (vloeibaar en poeder)
+zh: 牛乳（液态奶和奶粉类）
 intake24_category_code:en: MILK
 
 < en: Milks (liquid and powder)
@@ -52136,6 +52170,7 @@ fr: Boissons à l'amarante, Laits d'amarante
 hr: Pića na bazi amaranta
 hu: Bársonyvirág tej
 nl: Amaranthmelken
+zh: 苋菜籽饮料
 
 < en: Cereal-based drinks
 en: Barley-based drinks, Barley milks, Barley drinks
@@ -52636,6 +52671,7 @@ pl: Mleka migdałowe, Napoje migdałowe
 pt: Bebidas de amêndoa
 ru: Миндальное молоко
 sv: Mandeldrycker, mandeldryck
+zh: 杏仁饮料
 agribalyse_proxy_food_code:en: 18107
 agribalyse_proxy_food_name:en: Almond drink not sweet, not fortified, prepacked
 agribalyse_proxy_food_name:fr: Boisson à l'amande
@@ -54524,6 +54560,7 @@ lt: Tyrės su obuoliais
 nl: Appelcompotes, Applemoezen, Appelmoes
 pt: Compotas de maçã
 sv: Äppelmos
+zh: 苹果果泥
 agribalyse_food_code:en: 13038
 ciqual_food_code:en: 13038
 ciqual_food_name:en: Apple compote
@@ -59436,6 +59473,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine), teneur réduit
 < en: Light unsalted margarines
 en: 60% unsalted vegetable fat with sunflowerseed, 60% fat unsalted margarine with sunflowerseed
 fr: Matière grasse végétale allégée à 60% doux au tournesol, margarine allégée à 60% doux au tournesol
+zh: 含葵花籽的60%无盐植物脂肪
 agribalyse_food_code:en: 16654
 ciqual_food_code:en: 16654
 ciqual_food_name:en: Vegetable fat (margarine type), 60% fat, unsalted, sunflowerseed
@@ -59444,6 +59482,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine) à 60% de MG, a
 < en: Light unsalted margarines
 en: 30-40% fat unsalted vegetable fat, 30-40% fat unsalted margarine
 fr: Matière grasse végétale légère à 30-40% doux, Margarine légère à 30-40% MG doux
+zh: 30-40%脂肪量 无盐植物脂肪
 agribalyse_food_code:en: 16733
 ciqual_food_code:en: 16733
 ciqual_food_name:en: Vegetable fat (margarine type), spreadable, 30-40% fat, light, unsalted
@@ -59519,6 +59558,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine) à 30-40% MG, l
 < en: Salted margarines
 en: 80% salted vegetable fat, 80% fat salted margarine
 fr: Matière grasse végétale salée à 80%, Margarine salée à 80% MG
+zh: 80%含盐植物性脂肪
 agribalyse_food_code:en: 16614
 ciqual_food_code:en: 16614
 ciqual_food_name:en: Vegetable fat (like margarine), 80% fat, salted
@@ -59527,6 +59567,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine) à 80% MG, sal�
 < en: Unsalted margarines
 en: 80% unsalted vegetable fat, 80% fat unsalted margarine
 fr: Matière grasse végétale à 80% doux, Margarine douce à 80% MG
+zh: 80%无盐植物性脂肪
 agribalyse_food_code:en: 16615
 ciqual_food_code:en: 16615
 ciqual_food_name:en: Vegetable fat (margarine type), 80% fat, unsalted
@@ -59535,6 +59576,7 @@ ciqual_food_name:fr: Matière grasse végétale ou margarine, 80% MG, doux
 < en: Unsalted margarines
 en: 70% unsalted vegetable fat, 70% fat salted margarine
 fr: Matière grasse végétale à 70% doux, Margarine douce à 70% MG
+zh: 70% 无盐植物脂肪
 agribalyse_food_code:en: 16616
 ciqual_food_code:en: 16616
 ciqual_food_name:en: Vegetable fat (margarine type), 70% fat, unsalted
@@ -59561,6 +59603,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine) à 50-63% MG, a
 < en: Light unsalted margarines
 en: 50-63% unsalted vegetable fat, 50-63% unsalted margarine
 fr: Matière grasse végétale douce allégée à 50-63%, Margarine douce allégée à 50-63%
+zh: 50-63% 无盐植物脂肪
 agribalyse_food_code:en: 16741
 ciqual_food_code:en: 16741
 ciqual_food_name:en: Vegetable fat (margarine type), spreadable, 50-63% fat, light, unsalted
@@ -60313,6 +60356,7 @@ pl: Oliwa z oliwek extra virgin
 pt: Azeites virgem extra
 ru: Оливковое масло первого отжима
 sv: Extra jungfruolivoljor, Extra jungfruoljor
+zh: 特级初榨橄榄油
 agribalyse_food_code:en: 17270
 ciqual_food_code:en: 17270
 ciqual_food_name:en: Olive oil, extra virgin
@@ -65861,6 +65905,7 @@ nl: Gekoelde producten
 pt: Alimentos refrigerados, refrigerados
 ru: охлажденные продукты
 th: อาหารแช่เย็น
+zh: 冷藏食品
 storage_conditions:en: en:refrigerated
 
 < en: Plant-based foods
@@ -65877,6 +65922,7 @@ it: Alimenti essiccati al gelo
 lt: Šalčiu džiovinti maisto produktai, liofilizuoti maisto produktai
 nl: Gevriesdroogde producten
 ru: Лиофилизированные продукты
+zh: 冻干食品
 
 < en: Freeze-dried foods
 < en: Plant-based foods
@@ -68435,6 +68481,7 @@ fr: Pommes acides
 hr: Kisele jabuke
 lt: Rūgštūs obuoliai
 nl: Zure appels
+zh: 酸苹果
 
 < en: Apples
 < en: Sweet apples
@@ -71267,6 +71314,7 @@ en: Abate pears, Pears (Abate), Abate Fetel
 xx: Abate Fetel
 es: Limonea
 fr: Poires Abate, Poires Abbé Fétel, Abbé Fétel, Abate Fétel
+zh: 阿巴特梨
 wikidata:en: Q306912
 
 < en: Pears
@@ -74011,6 +74059,7 @@ lt: Prieskoniniai augalai, kulinariniai augalai
 nl: Plantaardige smaakmakers
 pt: Plantas para culinária
 sv: Kulinariska växter, Ätbara växter
+zh: 食用植物
 
 < en: Culinary plants
 en: Edible flowers
@@ -76109,6 +76158,7 @@ sv: Brittiska salter
 
 < en: British salts
 en: Anglesey Sea Salt, Halen Môn
+zh: 安格尔西海盐
 origins:en: en:united-kingdom
 protected_name_file_number:en: PDO-GB-1068
 protected_name_type:en: pdo
@@ -76524,6 +76574,7 @@ wikidata:en: Q28692
 < en: Spices
 en: Amchoor, amchur, aamchur, Mango powder, Dried mango powder
 fr: Amchur, amchoor, aamchur, Poudre de mangues, Poudre de mangue
+zh: 芒果粉
 description:en: powder of dried unripe mango used to acidify some dishes
 wikidata:en: Q2015681
 
@@ -79146,6 +79197,7 @@ de: Algerische Saucen
 fr: Sauces algériennes
 hr: Umaci na alžirski način
 lt: Alžyro padažai
+zh: 阿尔及利亚酱
 wikidata:en: Q108127132
 
 < en: Sauces
@@ -79397,6 +79449,7 @@ it: Salsa aioli
 ja: アイオリ
 nl: Knoflooksauzen, Aiolisauzen
 pl: Aioli, Sosy aioli
+zh: 蒜味蛋黄酱
 agribalyse_food_code:en: 11168
 ciqual_food_code:en: 11168
 ciqual_food_name:en: Aioli sauce (garlic and olive oil mayonnaise), prepacked
@@ -85244,6 +85297,7 @@ en: Ajoblanco, Ajo blanco
 es: Ajoblanco, Ajo blanco
 fr: Ajoblanco, Ajo blanco
 hr: Ajoblanco
+zh: 杏仁蒜蓉冷汤
 wikidata:en: Q413126
 
 < en: Cold soups
@@ -86699,6 +86753,7 @@ it: Pizze e torte salate
 nl: Pizzas - hartige taarten en quiches
 pt: Pizas tortas e quiches
 ru: Пицца и солёные открытые пироги
+zh: 披萨、派和法式咸派
 food_groups:en: en:pizza-pies-and-quiches
 gpc_category_code:en: 10000248
 gpc_category_description:en: Definition: Includes any products that can be described/observed as a pastry, biscuit or crumble based product filled or topped with a mixture of shredded/sliced savoury ingredients, commonly including meat, vegetables, eggs or other additive. Products must be frozen to extend their consumable life. Definition Excludes: Excludes products such as Perishable and Shelf Stable Savoury Pies, Pastries, Pizzas and Quiches, Sweet Pies/Tarts, and Potato Topped Meat Pies.
@@ -87472,6 +87527,7 @@ lt: Paruoštos salotos
 nl: Opgemaakte salades
 pl: Gotowe sałatki
 ru: Готовые салаты
+zh: 预制沙拉
 
 < en: Prepared salads
 < en: Seaweeds and their products
@@ -89730,6 +89786,7 @@ fr: Brochettes, brochette
 hr: Ražnjići
 ja: ケバブ
 nl: Spiesjes
+zh: 烤串
 
 < en: Meat alternatives
 < en: Skewers
@@ -89895,6 +89952,7 @@ es: Carne de vacuno y sus productos
 fr: Viande de bœuf et dérivés, viande de boeuf et dérivés
 hr: Govedina i njeni proizvodi
 nl: Rundvlees en afgeleide producten
+zh: 牛肉及其制品
 
 < en: Beef and its products
 < en: Marinated meats
@@ -92887,6 +92945,7 @@ pl: Mięsa przetworzone
 pt: Carnes preparadas, carnes processadas
 ru: Предварительно обработанные блюда
 tr: İşlenmiş etler, Hazır etler
+zh: 预制肉类
 ciqual_food_code:en: 30900
 ciqual_food_name:en: Cured meat and sausages (average)
 ciqual_food_name:fr: Charcuterie (aliment moyen)
@@ -93274,6 +93333,7 @@ hu: Fehér sonka
 it: Prosciutti cotti, prosciutto cotto
 nl: Gekookte ham
 pt: Presuntos brancos
+zh: 白火腿
 agribalyse_food_code:en: 28925
 ciqual_food_code:en: 28925
 ciqual_food_name:en: Cooked ham, Parisian-style, rind less and fatless
@@ -98084,6 +98144,7 @@ hr: Tjestenine od žitarica
 it: Paste alimentari di cereali
 nl: Graanpastas
 sv: Spannmålspasta, Pasta av spannmål
+zh: 谷物意大利面
 
 < en: Pastas
 en: Conchiglie
@@ -99218,6 +99279,7 @@ pt: Massas secas
 ru: Макароны
 sv: Torr pasta, Torrpasta
 th: กลุ่ใผลิตภัณฑ์พาสต้าแห้ง
+zh: 干意面
 
 # In France, only products of durum wheat can be called pasta. The equivalent of "ciqual:en:Dried pasta, raw" is therefore "Dry durum wheat pasta" and not "Dry pastas"
 < en: Dry pastas
@@ -99865,6 +99927,7 @@ hr: Punjene tjestenine
 hu: Töltött tészták
 it: Pasta farcita, pasta ripiena
 nl: Gevulde pastas
+zh: 带馅义大利面
 ciqual_food_code:en: 25216
 ciqual_food_name:en: Pasta (e.g. ravioli), filled, cooked
 ciqual_food_name:fr: Pâtes fraîches farcies (ex : raviolis), cuites (aliment moyen)
@@ -100239,6 +100302,7 @@ pl: Dania z makaronem
 pt: Pratos de massa
 ru: Блюда из макарон
 sv: Pastarätter
+zh: 意大利面料理
 intake24_category_code:en: PTDH
 wikidata:en: Q18679685
 
@@ -100278,6 +100342,7 @@ pt: Pastéis
 ru: Мучные изделия
 sv: Bakverk
 tr: Hamur işi
+zh: 糕点
 ciqual_food_code:en: 23900
 ciqual_food_name:en: Pastry (average)
 ciqual_food_name:fr: Pâtisserie (aliment moyen)
@@ -101024,6 +101089,7 @@ fr: Tartes sucrées, tarte sucrée
 hr: Slatke pite
 it: Torte dolci
 nl: Zoeten taarten
+zh: 甜派
 food_groups:en: en:biscuits-and-cakes
 intake24_category_code:en: PIES
 pnns_group_2:en: Biscuits and cakes
@@ -102896,6 +102962,7 @@ fr: Poissons gras, poissons bleus, poisson gras, poisson bleu
 hr: Masne ribe
 nl: Vette vissen, Vette vis
 pl: Tłuste ryby
+zh: 高脂鱼类
 food_groups:en: en:fatty-fish
 
 < en: Fishes
@@ -103235,6 +103302,7 @@ fr: Noix de coquilles Saint-Jacques surgelées
 < en: Scallop
 en: American sea scallop without coral, Canadian sea scallop without coral
 fr: Pecten d'Amérique avec noix cru, Peigne du Canada avec noix
+zh: 不带珊瑚部分的美国海扇贝
 agribalyse_food_code:en: 10048
 ciqual_food_code:en: 10048
 ciqual_food_name:en: American or Canadian sea scallop, without coral, raw
@@ -104457,6 +104525,7 @@ nl: Visfilets
 pl: Filety rybne, filet rybny
 pt: Filetes de peixe
 ru: Рыбные филе
+zh: 鱼柳
 intake24_category_code:en: FFLT
 
 < en: Fish fillets
@@ -106742,6 +106811,7 @@ en: Abalone, Ormer, Sea ear
 fr: Ormeau
 hr: Puzlatka
 ja: アワビ, 鮑
+zh: 鲍鱼
 ciqual_food_code:en: 10041
 ciqual_food_name:en: Abalone or ormer or sea ear, raw
 ciqual_food_name:fr: Ormeau, cru
@@ -107217,6 +107287,7 @@ hr: Dipovi, Dip
 ja: ディップ
 nl: Dipsauzen
 ru: провалы
+zh: 蘸酱
 intake24_category_code:en: DIPS
 wikidata:en: Q2046560
 
@@ -107381,6 +107452,7 @@ nl: Plantaardige smeerbare producten
 pl: Roślinne smarowidła, Warzywne smarowidła, Produkty do smarowania na bazie roślin
 pt: Produtos para barrar à base de plantas, Produtos para barrar vegetais, patés vegetais
 tr: Ekmeğe sürülen bitkisel ürünler, Ekmeğe sürülen bitki kaynaklı ürünler, Bitkisel sürülebilir ürünler, Bitki kaynaklı sürülebilir ürünler, Sürülebilir bitkisel ürünler, Sürülebilir bitki kaynaklı ürünler
+zh: 植物性涂抹酱
 
 #Vegetarian alternative to "Fleischsalat"
 < en: Plant-based spreads
@@ -107475,6 +107547,7 @@ pt: Doces para barrar
 ru: Сладкие намазки
 sv: Söta pålägg
 tr: Ekmeğe sürülen tatlı ürünler, Tatlı sürülebilir ürünler, Sürülebilir tatlı ürünler
+zh: 甜味涂抹酱
 food_groups:en: en:sweets
 pnns_group_2:en: Sweets
 
@@ -107881,6 +107954,7 @@ wikidata:en: Q89999458
 
 < en: Blueberry jams
 en: American blueberry jams, Blueberry jams (American)
+zh: 美国蓝莓果酱
 wikidata:en: Q11961672
 
 < en: Berry jams
@@ -108939,6 +109013,7 @@ it: Creme spalmabili salate
 nl: Hartige smeerbare producten
 pl: Słone smarowidła, słone pasty do smarowania
 pt: Produtos salgados para barrar
+zh: 咸味涂抹酱
 food_groups:en: en:salty-and-fatty-products
 intake24_category_code:en: PATE
 pnns_group_2:en: Salty and fatty products
@@ -109038,6 +109113,7 @@ it: Puree di oli di semi
 nl: Puree van oliehoudende zaden
 nl_be: Puree van oliehoudende zaden
 pt: Purés de óleo de sementes
+zh: 油籽泥
 #agribalyse_proxy_food_code:en:15202
 #agribalyse_proxy_food_name:en:Peanut butter or peanut paste
 #agribalyse_proxy_food_name:fr:Beurre de cacahuète ou Pâte d'arachide
@@ -109936,6 +110012,7 @@ fr: Acésulfame potassium, Acésulfame K
 hr: Acesulfam kalij
 la: E-950
 pl: Acesulfam K, Acesulfam potasowy
+zh: 安赛蜜
 wikidata:en: Q132037
 
 < en: Artificial sugar substitutes
@@ -110262,6 +110339,7 @@ hr: Agavini sirupi
 it: Sciroppi d'agave
 ja: アガベシロップ
 nl: Agavesiropen
+zh: 龙舌兰糖浆
 agribalyse_food_code:en: 31089
 ciqual_food_code:en: 31089
 ciqual_food_name:en: Syrup, agave
@@ -110434,6 +110512,7 @@ en: Amber maple syrups, C maple syrups
 fr: Sirops d'érable ambrés, Sirops d'érable ambré, Sirop d'érable C
 hr: Jantarni javorov sirup
 nl: Amber esdoornstropen
+zh: 琥珀色枫糖浆
 
 < en: Maple syrups
 en: Dark maple syrups, D maple syrups
@@ -110698,6 +110777,7 @@ nl_be: Tomaten en tomatenproducten
 pl: Pomidory i produkty z pomidorów
 pt: Tomates e derivados
 ru: Помидоры и продукты из помидор
+zh: 番茄及其制品
 wikidata:en: Q23501
 
 < en: Canned plant-based foods
@@ -113351,6 +113431,7 @@ de: Neapolitanischer Lauch
 fr: Ail Blanc
 hr: Napolitanski luk
 nl: Witte knoflook
+zh: 那不勒斯野蒜
 sales_format:en: weight, package
 wikidata:en: Q1817792
 
@@ -114288,6 +114369,7 @@ la: Solanum tuberosum ‘Almond’
 nb: Mandelpoteter
 nn: Mandelpotetar, Mandelpoteter
 sv: Mandelpotatisar
+zh: 曼德尔土豆
 sales_format:en: weight, package
 wikidata:en: Q3183151
 
@@ -114306,6 +114388,7 @@ fr: Pommes de terre amandine
 nl: Amandine aardappelen, Aardappelen(Amandine)
 ru: Картофель Амандин
 sv: Amandinepotatisar, Potatisar (Amandine)
+zh: 阿曼丁马铃薯
 sales_format:en: weight, package
 wikidata:en: Q2841064
 
@@ -116629,6 +116712,7 @@ fr: Graines de alfalfa
 hr: Sjeme lucerne
 la: Medicago sativa
 nl: Alfalfazaden
+zh: 苜蓿种子
 agribalyse_food_code:en: 15032
 ciqual_food_code:en: 15032
 ciqual_food_name:en: Alphalfa seeds, raw
@@ -117773,6 +117857,7 @@ it: Legumi in scatola
 nl: Bonen in blik/pot
 pt: Legumes enlatados
 ru: Бобовые в консервах
+zh: 罐装豆类
 who_id:en: 16
 
 < en: Canned legumes
@@ -118678,6 +118763,7 @@ hr: Alkoholni ocat
 hu: Alkohol ecet, szeszesecet
 nl: Alcoholazijnen
 pl: Ocet spirytusowy
+zh: 酒醋
 
 < en: Vinegars
 en: Tomato vinegars, Tomato vinegar
@@ -121092,6 +121178,7 @@ ro: Aperitive
 ru: Аппетайзеры, предястия
 sv: Aptitretare
 th: อาหารเรียกน้ำย่อย
+zh: 开胃菜
 food_groups:en: en:appetizers
 pnns_group_2:en: Appetizers
 
@@ -121493,6 +121580,7 @@ it: Pasta sfoglia
 ja: ヴィエノワズリー
 nl: Viennoiseries, Bladerdeegsnacks
 ru: Изделия из слоёного теста
+zh: 维也纳甜酥面包
 ciqual_food_code:en: 7600
 ciqual_food_name:en: Pastry, average food
 ciqual_food_name:fr: Viennoiserie (aliment moyen)
@@ -122195,6 +122283,7 @@ it: Pesce e carne e uova
 nl: Vis vlees en eieren
 pt: Peixes e carnes e ovos
 ru: Рыба - мясо и яйца
+zh: 鱼类、肉类和蛋类
 food_groups:en: en:fish-meat-eggs
 food_of_animal_origin:en: yes
 pnns_group_1:en: Fish Meat Eggs
@@ -122492,6 +122581,7 @@ ja: 代替肉
 nl: Vleeskopieën
 pl: Zastępniki mięsa
 ru: Мясозаменители
+zh: 肉类替代品
 google_product_taxonomy_id:en: 6843
 gpc_category_code:en: 10005824
 gpc_category_description:en: Definition: Includes all products which can be described/observed as a healthy food alternative to meat vegetable and egg proteins. These products are non animal based and an imitation of meat products, meant to simulate the taste and mouthfeel of real meat but are normally made from a combination of non animal based ingredients. Includes products such as soya, fungus, beans, lentils, peas and chickpeas based products. These products must be refrigerated to extend their consumable life. Definition Excludes: Excludes all meat-based products and any other protein rich products such as eggs and pulses that constitute the main recipe ingredients. Also excludes Meat Substitutes - Non Animal based frozen and shelf stable products and Meat Substitutes - Animal based frozen, perishable and shelf stable products.
@@ -123142,6 +123232,7 @@ ja: クラッカー
 nl: Crackers
 ru: Солёное печенье
 sv: Crackers
+zh: 饼干（开胃食品）
 agribalyse_proxy_food_code:en: 38402
 ciqual_food_code:en: 38399
 ciqual_food_name:en: Salty snacks
@@ -123777,6 +123868,7 @@ ja: ピュレ, ピューレ
 nl: Puree, Moes
 nl_be: Puree, Moes
 ru: Пюре
+zh: 泥状食品
 wikidata:en: Q636056
 
 < en: Potatoes and their products
@@ -125381,6 +125473,7 @@ en: Acras, Accras
 fr: Acras, Accras
 hr: Acras
 nl: Acra
+zh: 法式咸鳕鱼炸丸子
 
 < en: Acras
 < en: Fish preparations
@@ -125408,6 +125501,7 @@ fr: Aligots, Aligot, Purée de pomme de terre à la tomme fraîche
 hr: Aligoti
 it: Aligot
 nl: Aligot
+zh: 阿利戈土豆奶酪泥
 agribalyse_food_code:en: 4041
 ciqual_food_code:en: 4041
 ciqual_food_name:en: Mashed potatoes w fresh tome cheese

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -39329,7 +39329,7 @@ ja: ボンボン・ショコラ
 nl: Pralines, chocolades snoepjes
 pt: Bombons
 ru: Конфеты
-zh: 糖果, 精致糖果, 夹心糖, 巧克力糖
+zh: 精致糖果, 夹心糖, 巧克力糖
 wikidata:en: Q3272827
 
 < en: Bonbons
@@ -41736,7 +41736,7 @@ nl: Graankorrels
 pl: Ziarna zbóż
 pt: Grãos de cereais
 ru: Злаковое зерно
-zh: 谷物, 麦片谷物
+zh: 麦片谷物
 intake24_category_code:en: CARB
 
 < en: Cereal grains

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -2273,7 +2273,7 @@ en: American-style IPA, American IPA
 xx: American-style IPA, American IPA
 lt: Amerikietiškas IPA
 pt: IPA estilo americano
-zh: 美式IPA啤酒
+zh: 美式 IPA 啤酒
 
 < en: India Pale Ale (IPA)
 en: Cornish IPA
@@ -14228,7 +14228,7 @@ wikidata:en: Q3576141
 < fr: Alsace Grand Cru
 fr: Alsace grand cru Rosacker, Rosacker
 en: Alsace Grand Cru preceded by Rosacker
-zh: Rosacker产区阿尔萨斯特级葡萄酒
+zh: Rosacker 产区阿尔萨斯特级葡萄酒
 origins:en: en:france
 protected_name_file_number:en: PDO-FR-A0341
 protected_name_type:en: pdo
@@ -49882,7 +49882,7 @@ fr: Fromage frais aromatisé aux fruits, Petit suisse aromatisé aux fruits
 < en: Petits suisses
 en: 2-3% fat Petit-Suisse, 2-3% fat fresh cream cheese
 fr: Petit suisse à 2-3% de matières grasses, Fromage frais à 2-3% de matières grasses
-zh: 2-3%脂肪量 小瑞士奶酪
+zh: 2-3% 脂肪量 小瑞士奶酪
 
 < en: 2-3% fat Petit-Suisse
 < en: Petit-Suisse with fruits
@@ -59473,7 +59473,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine), teneur réduit
 < en: Light unsalted margarines
 en: 60% unsalted vegetable fat with sunflowerseed, 60% fat unsalted margarine with sunflowerseed
 fr: Matière grasse végétale allégée à 60% doux au tournesol, margarine allégée à 60% doux au tournesol
-zh: 含葵花籽的60%无盐植物脂肪
+zh: 含葵花籽的 60% 无盐植物脂肪
 agribalyse_food_code:en: 16654
 ciqual_food_code:en: 16654
 ciqual_food_name:en: Vegetable fat (margarine type), 60% fat, unsalted, sunflowerseed
@@ -59482,7 +59482,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine) à 60% de MG, a
 < en: Light unsalted margarines
 en: 30-40% fat unsalted vegetable fat, 30-40% fat unsalted margarine
 fr: Matière grasse végétale légère à 30-40% doux, Margarine légère à 30-40% MG doux
-zh: 30-40%脂肪量 无盐植物脂肪
+zh: 30-40% 脂肪量 无盐植物脂肪
 agribalyse_food_code:en: 16733
 ciqual_food_code:en: 16733
 ciqual_food_name:en: Vegetable fat (margarine type), spreadable, 30-40% fat, light, unsalted
@@ -59558,7 +59558,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine) à 30-40% MG, l
 < en: Salted margarines
 en: 80% salted vegetable fat, 80% fat salted margarine
 fr: Matière grasse végétale salée à 80%, Margarine salée à 80% MG
-zh: 80%含盐植物性脂肪
+zh: 80% 含盐植物性脂肪
 agribalyse_food_code:en: 16614
 ciqual_food_code:en: 16614
 ciqual_food_name:en: Vegetable fat (like margarine), 80% fat, salted
@@ -59567,7 +59567,7 @@ ciqual_food_name:fr: Matière grasse végétale (type margarine) à 80% MG, sal�
 < en: Unsalted margarines
 en: 80% unsalted vegetable fat, 80% fat unsalted margarine
 fr: Matière grasse végétale à 80% doux, Margarine douce à 80% MG
-zh: 80%无盐植物性脂肪
+zh: 80% 无盐植物性脂肪
 agribalyse_food_code:en: 16615
 ciqual_food_code:en: 16615
 ciqual_food_name:en: Vegetable fat (margarine type), 80% fat, unsalted

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -122563,7 +122563,7 @@ fr: Alternatives à la viande
 hr: Mesne alternative
 nl: Vleesvervangers
 pl: Alternatywy mięsa
-zh: 肉类替代品
+zh: 肉類替代物
 
 # Meat alternatives that are created to look replace meat and often look like it. E.g. vegetarian sausages, nuggets...
 < en: Meat alternatives
@@ -122580,6 +122580,7 @@ ja: 代替肉
 nl: Vleeskopieën
 pl: Zastępniki mięsa
 ru: Мясозаменители
+zh: 植物肉
 google_product_taxonomy_id:en: 6843
 gpc_category_code:en: 10005824
 gpc_category_description:en: Definition: Includes all products which can be described/observed as a healthy food alternative to meat vegetable and egg proteins. These products are non animal based and an imitation of meat products, meant to simulate the taste and mouthfeel of real meat but are normally made from a combination of non animal based ingredients. Includes products such as soya, fungus, beans, lentils, peas and chickpeas based products. These products must be refrigerated to extend their consumable life. Definition Excludes: Excludes all meat-based products and any other protein rich products such as eggs and pulses that constitute the main recipe ingredients. Also excludes Meat Substitutes - Non Animal based frozen and shelf stable products and Meat Substitutes - Animal based frozen, perishable and shelf stable products.

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -122581,7 +122581,6 @@ ja: 代替肉
 nl: Vleeskopieën
 pl: Zastępniki mięsa
 ru: Мясозаменители
-zh: 肉类替代品
 google_product_taxonomy_id:en: 6843
 gpc_category_code:en: 10005824
 gpc_category_description:en: Definition: Includes all products which can be described/observed as a healthy food alternative to meat vegetable and egg proteins. These products are non animal based and an imitation of meat products, meant to simulate the taste and mouthfeel of real meat but are normally made from a combination of non animal based ingredients. Includes products such as soya, fungus, beans, lentils, peas and chickpeas based products. These products must be refrigerated to extend their consumable life. Definition Excludes: Excludes all meat-based products and any other protein rich products such as eggs and pulses that constitute the main recipe ingredients. Also excludes Meat Substitutes - Non Animal based frozen and shelf stable products and Meat Substitutes - Animal based frozen, perishable and shelf stable products.

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -109117,7 +109117,6 @@ zh: 油籽泥
 #agribalyse_proxy_food_code:en:15202
 #agribalyse_proxy_food_name:en:Peanut butter or peanut paste
 #agribalyse_proxy_food_name:fr:Beurre de cacahuète ou Pâte d'arachide
-zh: 油籽泥
 
 < en: Oilseed purees
 < en: Pumpkin seeds and their products


### PR DESCRIPTION
### What
This is a follow-up to an import provided in pull request #14336; a [bug in the import script](https://codeberg.org/openculinary/openfoodfacts-data-utils/issues/2) used to create that PR meant that some translations were omitted (specifically: cases where the target product had a list of synonyms in the identifier/primary language).

This is done to improve the translation coverage of categories in Chinese, and to complete the work started in #14336.

The [latest version](https://codeberg.org/openculinary/openfoodfacts-data-utils/src/commit/82ebfaa405cf28ac083af3a72de662712638a239/category-taxonomy-translation) of the import script, used to merge the translations, includes improvements on the language-code and property sorting behaviour compared to #14336.

### Large Language Models usage disclosure
I did not use any LLMs, neither to develop the import script, nor to identify/fix the cause of the bug in the script, nor to create this pull request.

@meowdolee used machine translation as an initial batch/draft process on the food categories presented here, and then followed that by manually reviewing each entry (due to a ~%50 accuracy in those automated machine translations).

### Related issue(s) and discussion
Follow-up to #14336