### PR TITLE
taxonomy(food): soy ice cream categories

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -67101,14 +67101,21 @@ nl: Plantaardige ijswafels
 
 < en: Plant-based ice creams
 < en: Soy desserts
-en: Soy-based ice creams
+en: Soy-based ice creams, Soy ice creams
 sv: Sojaglasser
 wikidata:en: Q133892366
 
-< en: Chocolate soy desserts
 < en: Soy-based ice creams
 en: Chocolate soy ice creams
 sv: Kakaosojaglasser
+
+< en: Soy-based ice creams
+en: Strawberry soy ice creams
+sv: Jordgubbssojaglasser
+
+< en: Soy-based ice creams
+en: Vanilla soy ice creams
+sv: Vaniljsojaglasser
 
 < en: Ice creams and sorbets
 en: Ice pops, Popsicle, Freeze pop, Ice lolly, Ice block, Icy pole, Freezer pop

--- a/tests/integration/expected_test_results/api_cgi_suggest/categories-string-strawberry.json
+++ b/tests/integration/expected_test_results/api_cgi_suggest/categories-string-strawberry.json
@@ -15,13 +15,13 @@
    "Strawberry off-season raw",
    "Strawberry pies",
    "Strawberry sorbets",
+   "Strawberry soy desserts",
+   "Strawberry soy ice creams",
    "Strawberry soy yogurts",
    "Strawberry syrups",
    "Strawberry tartlets",
    "Strawberry yogurt drinks",
    "Strawberry yogurts",
    "Strawberry-Vanilla ice cream cones",
-   "strawberry juice",
-   "Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D",
-   "Rhubarb-strawberry jams"
+   "strawberry juice"
 ]

--- a/tests/integration/expected_test_results/api_cgi_suggest/categories-string-strawberry.json
+++ b/tests/integration/expected_test_results/api_cgi_suggest/categories-string-strawberry.json
@@ -15,7 +15,6 @@
    "Strawberry off-season raw",
    "Strawberry pies",
    "Strawberry sorbets",
-   "Strawberry soy desserts",
    "Strawberry soy ice creams",
    "Strawberry soy yogurts",
    "Strawberry syrups",
@@ -23,5 +22,6 @@
    "Strawberry yogurt drinks",
    "Strawberry yogurts",
    "Strawberry-Vanilla ice cream cones",
-   "strawberry juice"
+   "strawberry juice",
+   "Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D"
 ]

--- a/tests/integration/expected_test_results/api_cgi_suggest/categories-term-strawberry.json
+++ b/tests/integration/expected_test_results/api_cgi_suggest/categories-term-strawberry.json
@@ -15,13 +15,13 @@
    "Strawberry off-season raw",
    "Strawberry pies",
    "Strawberry sorbets",
+   "Strawberry soy desserts",
+   "Strawberry soy ice creams",
    "Strawberry soy yogurts",
    "Strawberry syrups",
    "Strawberry tartlets",
    "Strawberry yogurt drinks",
    "Strawberry yogurts",
    "Strawberry-Vanilla ice cream cones",
-   "strawberry juice",
-   "Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D",
-   "Rhubarb-strawberry jams"
+   "strawberry juice"
 ]

--- a/tests/integration/expected_test_results/api_cgi_suggest/categories-term-strawberry.json
+++ b/tests/integration/expected_test_results/api_cgi_suggest/categories-term-strawberry.json
@@ -15,7 +15,6 @@
    "Strawberry off-season raw",
    "Strawberry pies",
    "Strawberry sorbets",
-   "Strawberry soy desserts",
    "Strawberry soy ice creams",
    "Strawberry soy yogurts",
    "Strawberry syrups",
@@ -23,5 +22,6 @@
    "Strawberry yogurt drinks",
    "Strawberry yogurts",
    "Strawberry-Vanilla ice cream cones",
-   "strawberry juice"
+   "strawberry juice",
+   "Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D"
 ]

--- a/tests/integration/expected_test_results/api_v3_taxonomy_suggestions/categories-string-strawberry.json
+++ b/tests/integration/expected_test_results/api_v3_taxonomy_suggestions/categories-string-strawberry.json
@@ -18,15 +18,15 @@
       "Strawberry off-season raw",
       "Strawberry pies",
       "Strawberry sorbets",
+      "Strawberry soy desserts",
+      "Strawberry soy ice creams",
       "Strawberry soy yogurts",
       "Strawberry syrups",
       "Strawberry tartlets",
       "Strawberry yogurt drinks",
       "Strawberry yogurts",
       "Strawberry-Vanilla ice cream cones",
-      "strawberry juice",
-      "Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D",
-      "Rhubarb-strawberry jams"
+      "strawberry juice"
    ],
    "warnings" : []
 }

--- a/tests/integration/expected_test_results/api_v3_taxonomy_suggestions/categories-string-strawberry.json
+++ b/tests/integration/expected_test_results/api_v3_taxonomy_suggestions/categories-string-strawberry.json
@@ -18,7 +18,6 @@
       "Strawberry off-season raw",
       "Strawberry pies",
       "Strawberry sorbets",
-      "Strawberry soy desserts",
       "Strawberry soy ice creams",
       "Strawberry soy yogurts",
       "Strawberry syrups",
@@ -26,7 +25,8 @@
       "Strawberry yogurt drinks",
       "Strawberry yogurts",
       "Strawberry-Vanilla ice cream cones",
-      "strawberry juice"
+      "strawberry juice",
+      "Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D"
    ],
    "warnings" : []
 }

--- a/tests/integration/expected_test_results/api_v3_taxonomy_suggestions/categories-term-strawberry.json
+++ b/tests/integration/expected_test_results/api_v3_taxonomy_suggestions/categories-term-strawberry.json
@@ -18,15 +18,15 @@
       "Strawberry off-season raw",
       "Strawberry pies",
       "Strawberry sorbets",
+      "Strawberry soy desserts",
+      "Strawberry soy ice creams",
       "Strawberry soy yogurts",
       "Strawberry syrups",
       "Strawberry tartlets",
       "Strawberry yogurt drinks",
       "Strawberry yogurts",
       "Strawberry-Vanilla ice cream cones",
-      "strawberry juice",
-      "Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D",
-      "Rhubarb-strawberry jams"
+      "strawberry juice"
    ],
    "warnings" : []
 }

--- a/tests/integration/expected_test_results/api_v3_taxonomy_suggestions/categories-term-strawberry.json
+++ b/tests/integration/expected_test_results/api_v3_taxonomy_suggestions/categories-term-strawberry.json
@@ -18,7 +18,6 @@
       "Strawberry off-season raw",
       "Strawberry pies",
       "Strawberry sorbets",
-      "Strawberry soy desserts",
       "Strawberry soy ice creams",
       "Strawberry soy yogurts",
       "Strawberry syrups",
@@ -26,7 +25,8 @@
       "Strawberry yogurt drinks",
       "Strawberry yogurts",
       "Strawberry-Vanilla ice cream cones",
-      "strawberry juice"
+      "strawberry juice",
+      "Partially skimmed strawberry flavoured milk with sugar fortified with vitamins D"
    ],
    "warnings" : []
 }


### PR DESCRIPTION
- Adds vanilla and strawberry soy ice cream categories.
- Removes “Chocolate soy desserts” parent from chocolate soy ice cream.

Needed-for: https://se.openfoodfacts.org/product/8714100083352/vanilla-flavoured-soya-ice-cream-choice
Needed-for: https://se.openfoodfacts.org/product/8714100079249/refreshing-strawberry-choice