### PR TITLE
fix: warn and skip edit on producer protected fields (#14492)

### DIFF
--- a/cgi/product_jqm_multilingual.pl
+++ b/cgi/product_jqm_multilingual.pl
@@ -58,7 +58,7 @@ use ProductOpener::EnvironmentalScore qw/:all/;
 use ProductOpener::Packaging qw/:all/;
 use ProductOpener::ForestFootprint qw/:all/;
 use ProductOpener::Text qw/remove_tags_and_quote/;
-use ProductOpener::API qw/get_initialized_response check_user_permission/;
+use ProductOpener::API qw/add_warning get_initialized_response check_user_permission/;
 use ProductOpener::APIProductWrite
 	qw/process_change_product_type_request_if_we_have_one process_change_product_code_request_if_we_have_one skip_protected_field update_product_field_api_v2_and_cgi/;
 
@@ -406,7 +406,7 @@ else {
 			$add_tags = 1;
 		}
 
-		update_product_field_api_v2_and_cgi($product_ref, $lc, $field, single_param($field), $source, $add_tags);
+		update_product_field_api_v2_and_cgi($product_ref, $lc, $field, single_param($field), $source, $add_tags, $response_ref);
 
 		if (defined $language_fields{$field}) {
 
@@ -416,6 +416,14 @@ else {
 
 					# Only moderators can update values for fields sent by the producer
 					if (skip_protected_field($product_ref, $field_lc, $User{moderator})) {
+						add_warning(
+							$response_ref,
+							{
+								message => {id => "field_protected_by_producer"},
+								field => {id => $field_lc},
+								impact => {id => "field_ignored"},
+							}
+						);
 						next;
 					}
 

--- a/lib/ProductOpener/APIProductWrite.pm
+++ b/lib/ProductOpener/APIProductWrite.pm
@@ -301,6 +301,19 @@ sub update_product_fields ($request_ref, $product_ref, $response_ref) {
 		# Call preprocess_product_field function for each field
 		$value = preprocess_product_field($field, $value);
 
+		# Check if field is protected (sent by producer)
+		if (skip_protected_field($product_ref, $field, $request_ref->{moderator} || $User{moderator})) {
+			add_warning(
+				$response_ref,
+				{
+					message => {id => "field_protected_by_producer"},
+					field => {id => $field},
+					impact => {id => "field_ignored"},
+				}
+			);
+			next;
+		}
+
 		# Packaging components
 		if ($field =~ /^(packagings)(_add)?$/) {
 			$request_ref->{updated_product_fields}{$1} = 1;
@@ -812,9 +825,13 @@ Source of the field value: "packaging" on the public platform, "manufacturer" on
 
 If set to 1, we will add the tags to existing values
 
+=head4 $response_ref (output)
+
+Reference to response structure to add warnings when protected fields are skipped.
+
 =cut
 
-sub update_product_field_api_v2_and_cgi($product_ref, $target_lc, $field, $value, $source, $add_tags = 0) {
+sub update_product_field_api_v2_and_cgi($product_ref, $target_lc, $field, $value, $source, $add_tags = 0, $response_ref = undef) {
 
 	$log->debug("update_product_field_api_v2_and_cgi", {field => $field, value => $value, source => $source})
 		if $log->is_debug();
@@ -834,6 +851,16 @@ sub update_product_field_api_v2_and_cgi($product_ref, $target_lc, $field, $value
 
 	# Only moderators can update values for fields sent by the producer
 	if (skip_protected_field($product_ref, $field, $User{moderator})) {
+		if (defined $response_ref) {
+			add_warning(
+				$response_ref,
+				{
+					message => {id => "field_protected_by_producer"},
+					field => {id => $field},
+					impact => {id => "field_ignored"},
+				}
+			);
+		}
 		return;
 	}
 	# Writable tags fields (e.g. categories_tags) are processed in a specific way, in order to update the tags_sources structure and generate the field_tags structure

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -3833,7 +3833,7 @@ Return 1 if the field value was provided by the owner (producer) and the field i
 sub is_owner_field ($product_ref, $field) {
 
 	my $base_field = $field;
-	if ($field =~ /^(.*)_(\w\w)$/) {
+	if ($field =~ /^(.*)_([a-z]{2,5}(?:-[a-z0-9]+)?)$/i) {
 		$base_field = $1;
 	}
 

--- a/lib/ProductOpener/Products.pm
+++ b/lib/ProductOpener/Products.pm
@@ -3832,10 +3832,16 @@ Return 1 if the field value was provided by the owner (producer) and the field i
 
 sub is_owner_field ($product_ref, $field) {
 
+	my $base_field = $field;
+	if ($field =~ /^(.*)_(\w\w)$/) {
+		$base_field = $1;
+	}
+
 	if (
 		(defined $product_ref->{owner_fields})
 		and (
 			(defined $product_ref->{owner_fields}{$field})
+			or (defined $product_ref->{owner_fields}{$base_field})
 			# If the producer sent a field value for salt or sodium, the other value was automatically computed
 			or (($field =~ /^salt/) and (defined $product_ref->{owner_fields}{"sodium" . $'}))
 			or (($field =~ /^sodium/) and (defined $product_ref->{owner_fields}{"salt" . $'}))
@@ -3844,6 +3850,7 @@ sub is_owner_field ($product_ref, $field) {
 		# and may have been updated by a contributor (e.g. to add a more precise category)
 		# So we don't consider them to be owner fields
 		and (not defined $tags_fields{$field})
+		and (not defined $tags_fields{$base_field})
 		)
 	{
 		return 1;

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -441,4 +441,23 @@ foreach my $test_ref (@uploaded_images_misc_tags_tests) {
 		[], 'uploaded image count tags are not exposed as product states');
 }
 
+# Test is_owner_field and skip_protected_field
+use ProductOpener::APIProductWrite qw/skip_protected_field/;
+
+my $owner_product_ref = {
+	code => '1234567890123',
+	owner_fields => {
+		'ingredients_text' => 1620000000,
+		'quantity' => 1620000000,
+	},
+};
+
+is(is_owner_field($owner_product_ref, 'ingredients_text'), 1, 'is_owner_field detects base owner field');
+is(is_owner_field($owner_product_ref, 'ingredients_text_fr'), 1, 'is_owner_field detects localized owner field via base name');
+is(is_owner_field($owner_product_ref, 'quantity'), 1, 'is_owner_field detects simple owner field');
+is(is_owner_field($owner_product_ref, 'product_name'), 0, 'is_owner_field returns 0 for non-owner field');
+
+is(skip_protected_field($owner_product_ref, 'ingredients_text_fr', 0), 1, 'skip_protected_field skips owner field for regular user');
+is(skip_protected_field($owner_product_ref, 'ingredients_text_fr', 1), 0, 'skip_protected_field allows owner field for moderator');
+
 done_testing();

--- a/tests/unit/products.t
+++ b/tests/unit/products.t
@@ -454,6 +454,7 @@ my $owner_product_ref = {
 
 is(is_owner_field($owner_product_ref, 'ingredients_text'), 1, 'is_owner_field detects base owner field');
 is(is_owner_field($owner_product_ref, 'ingredients_text_fr'), 1, 'is_owner_field detects localized owner field via base name');
+is(is_owner_field($owner_product_ref, 'ingredients_text_und'), 1, 'is_owner_field detects 3-letter localized owner field');
 is(is_owner_field($owner_product_ref, 'quantity'), 1, 'is_owner_field detects simple owner field');
 is(is_owner_field($owner_product_ref, 'product_name'), 0, 'is_owner_field returns 0 for non-owner field');
 


### PR DESCRIPTION
### What
When product data contains fields provided by the producer (recorded in `owner_fields` or under organization data protection), non-moderator user edits to those fields are skipped with explicit warning feedback returned in the API response.

Specifically:
- Updated `is_owner_field` in `lib/ProductOpener/Products.pm` to resolve localized field keys (e.g., `ingredients_text_fr`) to their base field names (`ingredients_text`) when checking `$product_ref->{owner_fields}`.
- Enforced `skip_protected_field` in `update_product_fields` (API v3) for non-moderators.
- Added structured API warning responses (`message => { id => "field_protected_by_producer" }`, `field => { id => $field }`, `impact => { id => "field_ignored" }`) to both API v3 and API v2/CGI write pathways.
- Added unit tests in `tests/unit/products.t` covering base and localized `is_owner_field` checks as well as moderator bypass rules.

### Large Language Models usage disclosure
- **LLM Used**: Claude 3.7 Sonnet (Agentic Pair Programmer)
- **Usage**: Used for root cause analysis of API field protection flow, Perl code updates, and unit test implementation.
- **Verification**: Verified code syntax and unit test coverage locally.

### Screenshot or video
N/A (Backend API response and product protection rule logic).

### Related issue(s) and discussion
- Fixes #14492