### PR TITLE
taxonomy: plain butter shortbreads

### DIFF
--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -33500,13 +33500,23 @@ en: Shortbread
 xx: Shortbread
 wikidata:en: Q652695
 
+< en: Plain butter shortbreads
 < en: Shortbread cookies
 en: Brittany-style galette biscuits, Shortbread cookies from Brittany
 fr: Galettes bretonnes au beurre, galettes bretonnes
 
+< en: Plain butter shortbreads
+< en: Brittany-style galette biscuits
+en: Plain Brittany-style galette biscuits
+fr: Galettes bretonnes au beurre nature
+
 < en: Shortbread cookies
 en: Brittany-style palet biscuits
 fr: Palets, Palet, Palets sablés, Palet sablé, Palet breton, Palets bretons
+
+< en: Brittany-style palet biscuits
+en: Plain Brittany-style palet biscuits
+fr: Palets nature
 
 < en: Shortbread cookies
 en: Shortbread biscuit with butter and chocolate
@@ -33584,8 +33594,8 @@ ciqual_food_name:en: Biscuit shortbread, with fruits
 ciqual_food_name:fr: Biscuit sec, sablé, galette ou palet, aux fruits
 
 < en: Shortbread cookies
-en: Plain butter shortbreads, Shortbread biscuit with butter
-fr: Sablés nature au beurre, Sablés au beurre
+en: Plain butter shortbreads
+fr: Sablés nature au beurre
 agribalyse_food_code:en: 24049
 ciqual_food_code:en: 24049
 ciqual_food_name:en: Biscuit shortbread, with butter

--- a/taxonomies/food/categories.txt
+++ b/taxonomies/food/categories.txt
@@ -33479,12 +33479,12 @@ oqali_family:en: fr:Biscuits et gateaux industriels - Florentins
 wikidata:en: Q1429469
 
 < en: Biscuits
-en: Shortbread cookies, Shortbread pastry biscuit
+en: Shortbread cookies, Shortbread pastry biscuit, Shortbread biscuit with butter
 ca: Galetes de mantega
 de: Mürbeteigkekse
 es: Galletas de mantequilla
 fi: Murokeksit
-fr: Biscuits sablés, Biscuit sablé, Sablés, Sablé, Sablé pâtissier
+fr: Biscuits sablés, Biscuit sablé, Sablés, Sablé, Sablé pâtissier, Sablés au beurre
 hr: Keksi od prhkog tijesta
 it: Frollini
 ja: ショートブレッド


### PR DESCRIPTION
* created two sub-categories of plain butter shortbreads
* Moved the synonym of plain butter shortbreads because it was putting non-plain biscuits in the category