### PR TITLE
fix: cleanup translations

### DIFF
--- a/po/common/aa.po
+++ b/po/common/aa.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/ach.po
+++ b/po/common/ach.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/af.po
+++ b/po/common/af.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/ak.po
+++ b/po/common/ak.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/am.po
+++ b/po/common/am.po
@@ -42,7 +42,7 @@ msgstr "ከመላው ዓለም የተውጣጡ የመዋቢያ ምርቶች እ�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ክፍት የውበት እውነታዎች ከመላው ዓለም የተውጣጡ የመዋቢያ ምርቶች መረጃዎችን እና መረጃዎችን ይሰበስባሉ።"
+msgstr "Open Beauty Facts ከመላው ዓለም የተውጣጡ የመዋቢያ ምርቶች መረጃዎችን እና መረጃዎችን ይሰበስባሉ።"
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "እና የ <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ክፍት የውበት እውነታዎች የምርት ፍለጋ"
+msgstr "Open Beauty Facts የምርት ፍለጋ"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "አረንጓዴ-ውጤት ከ A+ እስከ F ያለው የአካባቢ ውጤት ሲሆን የምግብ ምርቶች በአካባቢ ላይ ያላቸውን ተጽእኖ ለማነፃፀር ቀላል ያደርገዋል።"
+msgstr "Green-Score ከ A+ እስከ F ያለው የአካባቢ ውጤት ሲሆን የምግብ ምርቶች በአካባቢ ላይ ያላቸውን ተጽእኖ ለማነፃፀር ቀላል ያደርገዋል።"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "አረንጓዴ-ውጤት ከ A+ እስከ F ያለው የአካባቢ ውጤት ሲሆን የምግብ ምርቶች በአካባቢ ላይ ያላቸውን ተጽእኖ ለማነፃፀር ቀላል ያደርገዋል።"
+msgstr "Green-Score ከ A+ እስከ F ያለው የአካባቢ ውጤት ሲሆን የምግብ ምርቶች በአካባቢ ላይ ያላቸውን ተጽእኖ ለማነፃፀር ቀላል ያደርገዋል።"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "አረንጓዴው ውጤት መጀመሪያ ላይ ለፈረንሳይ የተዘጋጀ ሲሆን ወደ ሌሎች የአውሮፓ አገሮችም እየተስፋፋ ነው። አረንጓዴው ውጤት ቀመር በየጊዜው እየተሻሻለ እና ለእያንዳንዱ አገር የበለጠ ትክክለኛ እንዲሆን ስለሚደረግ ሊለወጥ ይችላል።"
+msgstr "Green-Score መጀመሪያ ላይ ለፈረንሳይ የተዘጋጀ ሲሆን ወደ ሌሎች የአውሮፓ አገሮችም እየተስፋፋ ነው። Green-Score ቀመር በየጊዜው እየተሻሻለ እና ለእያንዳንዱ አገር የበለጠ ትክክለኛ እንዲሆን ስለሚደረግ ሊለወጥ ይችላል።"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ለዚህ ምርት ያለን ምድብ አረንጓዴ-ውጤት ለማስላት በቂ አይደለም. ይበልጥ ትክክለኛ የሆነ የምርት ምድብ ማከል ይችላሉ?"
+msgstr "ለዚህ ምርት ያለን ምድብ Green-Score ለማስላት በቂ አይደለም. ይበልጥ ትክክለኛ የሆነ የምርት ምድብ ማከል ይችላሉ?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7686,7 +7681,7 @@ msgstr "ሊሎ የፍለጋ ሞተር"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "በሮቦቶች በደረሰብን ከባድ ጥቃት ምክንያት ይህን ገጽ ማንነታቸው ላልታወቁ ተጠቃሚዎች ማገልገል አልቻልንም። ሁሉንም ክፍት የምግብ እውነታዎች ለማግኘት እባክህ ነጻ የምግብ እውነታዎች መለያ ፍጠር።"
+msgstr "በሮቦቶች በደረሰብን ከባድ ጥቃት ምክንያት ይህን ገጽ ማንነታቸው ላልታወቁ ተጠቃሚዎች ማገልገል አልቻልንም። ሁሉንም Open Food Facts ለማግኘት እባክህ ነጻ Open Food Facts መለያ ፍጠር።"
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "የማይፈለጉ ንጥረ ነገሮች"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "ይህ ምርጫ በክፍት ምግብ እውነታዎች ስለ ንጥረ ነገሩ ዝርዝር ግንዛቤ ላይ የተመሰረተ ነው እና ትክክል ላይሆን ይችላል፣ ሁልጊዜ ምርቱን እራስዎ ያረጋግጡ።"
+msgstr "ይህ ምርጫ በOpen Food Facts ስለ ንጥረ ነገሩ ዝርዝር ግንዛቤ ላይ የተመሰረተ ነው እና ትክክል ላይሆን ይችላል፣ ሁልጊዜ ምርቱን እራስዎ ያረጋግጡ።"
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "እኛ አላገኘንም: {unwanted_ingredients}. አንዳንድ ን�
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "እነዚያ ምርጫዎች የተመሰረቱት በክፍት ምግብ እውነታዎች የንጥረ ነገር ዝርዝር ግንዛቤ ላይ ነው እና ሁልጊዜም ትክክል ወይም ሙሉ ላይሆን የሚችልበት እድል አለ፣ ሁልጊዜ ምርቱን እራስዎ ያረጋግጡ።"
+msgstr "እነዚያ ምርጫዎች የተመሰረቱት በOpen Food Facts የንጥረ ነገር ዝርዝር ግንዛቤ ላይ ነው እና ሁልጊዜም ትክክል ወይም ሙሉ ላይሆን የሚችልበት እድል አለ፣ ሁልጊዜ ምርቱን እራስዎ ያረጋግጡ።"
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/ar.po
+++ b/po/common/ar.po
@@ -42,7 +42,7 @@ msgstr "قاعدة بيانات شاملة و مجانية و متاحه عن م
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "الحقائق الجمالية المفتوحة تجمع معلومات وبيانات منتجات مواد التجميل من جميع أنحاء العالم."
+msgstr "Open Beauty Facts تجمع معلومات وبيانات منتجات مواد التجميل من جميع أنحاء العالم."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "و مجموعة فيسبوك للمساهمين:<a href=\"https://www.fa
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "البحث عن منتج"
+msgstr "Open Beauty Facts - Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -166,7 +166,7 @@ msgstr "المكونات والمواد المثيرة للحساسية والم
 
 msgctxt "search_description_opensearch_opff"
 msgid "Open Pet Food Facts product search"
-msgstr "البحث المفتوح عن منتج حقائق طعام الحيوانات الأليفة"
+msgstr "البحث المفتوح عن منتج Open Pet Food Facts"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -447,7 +447,7 @@ msgstr "رقم الرمز الشريطي:"
 
 msgctxt "you_can_also_help_us"
 msgid "You can also help to fund the Open Food Facts project"
-msgstr "يمكنك أيضًا المساعدة في تمويل مشروع حقائق الغذاء المفتوح"
+msgstr "يمكنك أيضًا المساعدة في تمويل مشروع Open Food Facts"
 
 msgctxt "producers_administration_manual"
 msgid "Producers Admin manual"
@@ -1071,7 +1071,7 @@ msgstr "https://world-ar.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "حقائق غذائية مفتوحة للمنتجين"
+msgstr "Open Food Facts للمنتجين"
 
 msgctxt "for"
 msgid "for"
@@ -1763,11 +1763,6 @@ msgstr "درجات التغذية"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "درجة التغذية"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -2902,7 +2897,7 @@ msgstr "المترجمين لدينا"
 
 msgctxt "translators_lead"
 msgid "We would like to say THANK YOU to the awesome translators that make it possible to present Open Food Facts, Open Beauty Facts, and Open Pet Food Facts to you in all these different languages! <a href=\"https://translate.openfoodfacts.org/\">You can join us in this global effort: it doesn't require any technical knowledge.</a>"
-msgstr "نود أن نقول شكراً للمترجمين الرائعين الذين تمكنوا من تقديم حقائق الغذاء المفتوح ، وحقائق الجمال المفتوحة ، وحقائق أغذية الحيوانات الأليفة المفتوحة لكم بجميع هذه اللغات المختلفة! <a href=\"https://translate.openfoodfacts.org/\"> يمكنك الانضمام إلينا في هذا الجهد العالمي: لا يتطلب أي معرفة تقنية. </a>"
+msgstr "نود أن نقول شكراً للمترجمين الرائعين الذين تمكنوا من تقديم Open Food Facts ، وOpen Beauty Facts ، وOpen Pet Food Facts لكم بجميع هذه اللغات المختلفة! <a href=\"https://translate.openfoodfacts.org/\"> يمكنك الانضمام إلينا في هذا الجهد العالمي: لا يتطلب أي معرفة تقنية. </a>"
 
 msgctxt "translators_renewal_notice"
 msgid "Please note that this table is refreshed nightly and might be out of date."
@@ -2983,7 +2978,7 @@ msgstr "مجموعة NOVA"
 # Title for the link to the explanation of what a NOVA Group is
 msgctxt "nova_groups_info"
 msgid "NOVA groups for food processing"
-msgstr "مجموعات نوفا للصناعات الغذائية"
+msgstr "مجموعات NOVA للصناعات الغذائية"
 
 msgctxt "footer_partners"
 msgid "Partners"
@@ -3995,7 +3990,7 @@ msgstr "عدد المنتجات المتوافقة مع فرص التحسين"
 
 msgctxt "improvements_facet_description_1"
 msgid "This table lists possible opportunities to improve the nutritional quality, the Nutri-Score and the composition of food products."
-msgstr "يسرد هذا الجدول الفرص الممكنة لتحسين الجودة الغذائية، كما يعرض الرمز الغذائي درجة الجودة الغذائية، وتكوين المنتجات الغذائية."
+msgstr "يسرد هذا الجدول الفرص الممكنة لتحسين الجودة الغذائية، كما يعرض Nutri-Score Nutri-Score، وتكوين المنتجات الغذائية."
 
 msgctxt "improvements_facet_description_2"
 msgid "In order to get relevant results, please make sure the product data is complete (nutrition facts with values for fiber and fruits and vegetables to compute the Nutri-Score, and a precise category to compare each product to similar products)."
@@ -4158,7 +4153,7 @@ msgstr "Nutri-Score"
 # This is not the Nutri-Score grade with letters, but the Nutri-Score number score used to compute the grade. Translate score but not Nutri-Score.
 msgctxt "nutriscore_score_producer"
 msgid "Nutri-Score score"
-msgstr "نتيجة درجة الجودة الغذائية"
+msgstr "نتيجة Nutri-Score"
 
 # Do not translate
 msgctxt "nutriscore_grade_producer"
@@ -4168,7 +4163,7 @@ msgstr "Nutri-Score"
 # free as in not costing something
 msgctxt "donate_free_and_independent"
 msgid "Open Food Facts is 100% free and independent."
-msgstr "تعد حقائق الأغذية المفتوحة مجانية ومستقلة بنسبة 100%."
+msgstr "تعد Open Food Facts مجانية ومستقلة بنسبة 100%."
 
 # leave empty link
 msgctxt "donate_help_and_donations"
@@ -4195,7 +4190,7 @@ msgstr "متوسط قيمة الفئة %s"
 # Keep the %s
 msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
-msgstr "تتغير درجة الجودة الغذائية من %s إلى %s بتغيير قيمة %s من %s إلى %s ( بفرق %s في المئة)."
+msgstr "تتغير Nutri-Score من %s إلى %s بتغيير قيمة %s من %s إلى %s ( بفرق %s في المئة)."
 
 msgctxt "export_products_to_public_database_email"
 msgid "The platform for producers is still under development and we make manual checks before importing products to the public database. Please e-mail us at <a href=\"mailto:producers@openfoodfacts.org\">producers@openfoodfacts.org</a> to update the public database."
@@ -4334,19 +4329,19 @@ msgstr "استيراد التصنيفات"
 
 msgctxt "nutri_score_score_from_producer"
 msgid "Nutri-Score score from producer"
-msgstr "درجة الجودة الغذائية هي نتيجة من المنتج"
+msgstr "Nutri-Score هي نتيجة من المنتج"
 
 msgctxt "nutri_score_score_calculated"
 msgid "Calculated Nutri-Score score"
-msgstr "حساب نتيجة درجة الجودة الغذائية"
+msgstr "حساب نتيجة Nutri-Score"
 
 msgctxt "nutri_score_grade_from_producer"
 msgid "Nutri-Score grade from producer"
-msgstr "مستوى درجة الجودة الغذائية من المنتج"
+msgstr "مستوى Nutri-Score من المنتج"
 
 msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
-msgstr "حساب مستوى درجة الجودة الغذائية"
+msgstr "حساب مستوى Nutri-Score"
 
 msgctxt "scanned_code"
 msgid "Scanned code"
@@ -4571,7 +4566,7 @@ msgstr " يستخدم المنتج كود داخلي لتحديد إصدار ا�
 
 msgctxt "categories_import_note"
 msgid "Providing a category is very important to make the product easy to search for, and to compute the Nutri-Score"
-msgstr "يعد توفير فئة مهم للغاية اتسهيل البحث عن المنتج ولحساب درجة الجودة الغذائية"
+msgstr "يعد توفير فئة مهم للغاية اتسهيل البحث عن المنتج ولحساب Nutri-Score"
 
 msgctxt "labels_import_note"
 msgid "Some labels such as the organic label are used to filter and/or rank search results, so it is strongly recommended to specify them."
@@ -4587,19 +4582,19 @@ msgstr "نص أو جمل تشير إلى أصل المنتج و/أو مكونا�
 
 msgctxt "nutriscore_grade_producer_note"
 msgid "Nutri-Score grade from A to E displayed on the product label"
-msgstr "يتم عرض تصنيف درجة الجودة الغذائية من A إلى E على ملصق المنتج"
+msgstr "يتم عرض تصنيف Nutri-Score من A إلى E على ملصق المنتج"
 
 msgctxt "nutriscore_grade_producer_import_note"
 msgid "Open Food Facts computes the Nutri-Score grade based on the information provided (nutrition facts and category). If the grade we compute is different from the grade you provide, you will get a private notification on the producers platform so that the difference can be resolved."
-msgstr "تحسب Open Food Facts درجة الجودة الغذائية بناءً على المعلومات المُقدمة (الحقائق الغذائية والفئة). إذا كانت الدرجة التي نحسبها مختلفة عن الدرجة التي تُقدمها، فستتلقى إشعارًا خاصًا على منصة المُنتجين لحلّ الاختلاف."
+msgstr "تحسب Open Food Facts Nutri-Score بناءً على المعلومات المُقدمة (الحقائق الغذائية والفئة). إذا كانت الدرجة التي نحسبها مختلفة عن الدرجة التي تُقدمها، فستتلقى إشعارًا خاصًا على منصة المُنتجين لحلّ الاختلاف."
 
 msgctxt "nutriscore_score_producer_note"
 msgid "Nutri-Score score (numeric value from which the A to E grade is derived)"
-msgstr "درجة الجودة الغذائية (القيمة العددية التي يتم من خلالها استخلاص الدرجة من A إلى E)"
+msgstr "Nutri-Score (القيمة العددية التي يتم من خلالها استخلاص الدرجة من A إلى E)"
 
 msgctxt "nutriscore_score_producer_import_note"
 msgid "Open Food Facts computes the Nutri-Score score based on the information provided (nutrition facts and category). If the score we compute is different from the score you provide, you will get a private notification on the producers platform so that the difference can be resolved."
-msgstr "تحسب Open Food Facts درجة الجودة الغذائية بناءً على المعلومات المُقدمة (الحقائق الغذائية والفئة). إذا كانت الدرجة التي نحسبها مختلفة عن الدرجة التي تُقدمها، فستتلقى إشعارًا خاصًا على منصة المُنتجين لحلّ الاختلاف."
+msgstr "تحسب Open Food Facts Nutri-Score بناءً على المعلومات المُقدمة (الحقائق الغذائية والفئة). إذا كانت الدرجة التي نحسبها مختلفة عن الدرجة التي تُقدمها، فستتلقى إشعارًا خاصًا على منصة المُنتجين لحلّ الاختلاف."
 
 msgctxt "mandatory_field"
 msgid "Mandatory field"
@@ -4701,24 +4696,24 @@ msgstr "Nutri-Score"
 
 msgctxt "attribute_nutriscore_setting_name"
 msgid "Good nutritional quality (Nutri-Score)"
-msgstr "جودة غذائية جيدة (درجة الجودة الغذائية)"
+msgstr "جودة غذائية جيدة (Nutri-Score)"
 
 msgctxt "attribute_nutriscore_setting_note"
 msgid "The Nutri-Score is computed and can be taken into account for all products, even if is not displayed on the packaging."
-msgstr "يتم حساب درجة الجودة الغذائية ويمكن أخذه في الاعتبار لجميع المنتجات، حتى لو لم يتم عرضه على العبوة."
+msgstr "يتم حساب Nutri-Score ويمكن أخذه في الاعتبار لجميع المنتجات، حتى لو لم يتم عرضه على العبوة."
 
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "درجة الجودة الغذائية%s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
-msgstr "درجة الجودة الغذائية غير معروف"
+msgstr "Nutri-Score غير معروف"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
 msgid "Missing data to compute the Nutri-Score"
-msgstr "بيانات مفقودة لحساب درجة الجودة الغذائية"
+msgstr "بيانات مفقودة لحساب Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
@@ -4835,19 +4830,19 @@ msgstr "مستخدم غير معروف."
 
 msgctxt "attribute_low_salt_setting_note"
 msgid "The salt level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low salt diet."
-msgstr "مستوى الملح يؤخذ في الاعتبار بواسطة درجة الجودة الغذائية. استخدم هذا الخيار فقط إذا كنت على وجه التحديد على نظام غذائي منخفض الملح."
+msgstr "مستوى الملح يؤخذ في الاعتبار بواسطة Nutri-Score. استخدم هذا الخيار فقط إذا كنت على وجه التحديد على نظام غذائي منخفض الملح."
 
 msgctxt "attribute_low_sugars_setting_note"
 msgid "The sugars level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low sugars diet."
-msgstr "مستوى السكريات يؤخذ في الاعتبار بواسطة درجة الجودة الغذائية. استخدم هذا الخيار فقط إذا كنت على وجه التحديد على نظام غذائي منخفض السكر."
+msgstr "مستوى السكريات يؤخذ في الاعتبار بواسطة Nutri-Score. استخدم هذا الخيار فقط إذا كنت على وجه التحديد على نظام غذائي منخفض السكر."
 
 msgctxt "attribute_low_fat_setting_note"
 msgid "The fat level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low fat diet."
-msgstr "مستوى الدهون يؤخذ في الاعتبار بواسطة درجة الجودة الغذائية. استخدم هذا الخيار فقط إذا كنت على وجه التحديد على نظام غذائي منخفض الدهون."
+msgstr "مستوى الدهون يؤخذ في الاعتبار بواسطة Nutri-Score. استخدم هذا الخيار فقط إذا كنت على وجه التحديد على نظام غذائي منخفض الدهون."
 
 msgctxt "attribute_low_saturated_fat_setting_note"
 msgid "The saturated fat level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low saturated fat diet."
-msgstr "مستوى الدهون المشبعة يؤخذ في الاعتبار بواسطة درجة الجودة الغذائية. استخدم هذا الخيار فقط إذا كنت على وجه التحديد على نظام غذائي منخفض الدهون المشبعة."
+msgstr "مستوى الدهون المشبعة يؤخذ في الاعتبار بواسطة Nutri-Score. استخدم هذا الخيار فقط إذا كنت على وجه التحديد على نظام غذائي منخفض الدهون المشبعة."
 
 msgctxt "attribute_group_allergens_name"
 msgid "Allergens"
@@ -4948,11 +4943,11 @@ msgstr "البيئة"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "النتيجة البيئية"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "تأثير بيئي منخفض (الدرجة الخضراء)"
+msgstr "تأثير بيئي منخفض (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
@@ -4961,11 +4956,11 @@ msgstr "يُعدّ مؤشر Green-Score مؤشراً بيئياً يتراوح �
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "النتيجة البيئية"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "تأثير بيئي منخفض (الدرجة الخضراء)"
+msgstr "تأثير بيئي منخفض (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
@@ -4974,7 +4969,7 @@ msgstr "يُعدّ مؤشر Green-Score مؤشراً بيئياً يتراوح �
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "النتيجة البيئية %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5160,22 +5155,22 @@ msgstr "التأثير البيئي"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "النتيجة البيئية"
+msgstr "Green-Score"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "درجة النتيجة البيئية"
+msgstr "درجة Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "تفاصيل حساب النتيجة البيئية"
+msgstr "تفاصيل حساب Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "معلومات عن النتيجة البيئية"
+msgstr "معلومات عن Green-Score"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5212,19 +5207,19 @@ msgstr "معلومات غذائية مفقودة للمنتج المُحضر"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "النتيجة البيئية"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "النتيجة البيئية"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "النتيجة البيئية"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "النتيجة البيئية"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5395,7 +5390,7 @@ msgstr "وتوفر المنصة أيضًا تحليلًا متعمقًا للم�
 # It = the platform
 msgctxt "product_edits_by_producers_indicators"
 msgid "It computes indicators such as the Nutri-Score, NOVA, and the Green-Score, and automatically identifies suggestions to improve them (for instance all products that would get a better Nutri-Score grade with a slight composition change)."
-msgstr "يقوم بحساب المؤشرات مثل درجة الجودة الغذائية و NOVA و الدرجة البيئية، ويحدد تلقائيًا الاقتراحات لتحسينها (على سبيل المثال، جميع المنتجات التي ستحصل على درجة الجودة الغذائية أفضل مع تغيير طفيف في التركيب)."
+msgstr "يقوم بحساب المؤشرات مثل Nutri-Score و NOVA و Green-Score، ويحدد تلقائيًا الاقتراحات لتحسينها (على سبيل المثال، جميع المنتجات التي ستحصل على Nutri-Score أفضل مع تغيير طفيف في التركيب)."
 
 msgctxt "attribute_forest_footprint_name"
 msgid "Forest footprint"
@@ -5472,11 +5467,11 @@ msgstr "المنتجات الأكثر فحصا"
 
 msgctxt "sort_by_nutriscore_score"
 msgid "Products with the best Nutri-Score"
-msgstr "المنتجات ذات أفضل تقييم غذائي"
+msgstr "المنتجات ذات أفضل Nutri-Score"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "المنتجات ذات أفضل تقييم بيئي"
+msgstr "المنتجات ذات أفضل Green-Score"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5530,7 +5525,7 @@ msgstr "جاري حذف المستخدم. قد يستغرق هذا بضع دقا
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "النتيجة البيئية غير قابلة للتطبيق"
+msgstr "Green-Score غير قابلة للتطبيق"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5543,11 +5538,11 @@ msgstr "غير قابل للتطبيق بعد على الفئة: {category}"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "لا يزال الدرجة البيئية غير قابل للتطبيق لهذه الفئة، ولكننا نعمل على إضافة الدعم لها."
+msgstr "لا يزال Green-Score غير قابل للتطبيق لهذه الفئة، ولكننا نعمل على إضافة الدعم لها."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "لم يتم حساب الدرجة البيئية"
+msgstr "لم يتم حساب Green-Score"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5559,7 +5554,7 @@ msgstr "فقدان فئة دقيقة"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "لم نتمكن من حساب الدرجة البيئية لهذا المنتج لأنه يفتقد بعض البيانات، هل يمكنك مساعدتنا في استكمالها؟"
+msgstr "لم نتمكن من حساب Green-Score لهذا المنتج لأنه يفتقد بعض البيانات، هل يمكنك مساعدتنا في استكمالها؟"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5667,7 +5662,7 @@ msgstr "بعض البيانات الخاصة بمنتجات %s تأتي من %s.
 
 msgctxt "data_source_database_note_about_the_producers_platform"
 msgid "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_url>\">free plaform for producers</a> to access and complete this data, and to obtain reports, analysis and product improvements opportunities (e.g. better Nutri-Score)."
-msgstr "يمكن للمصنعين استخدام منصة Open Food Facts المجانية <a href=\"<producers_platform_url>\">للمنتجين</a> للوصول إلى هذه البيانات واستكمالها، والحصول على التقارير والتحليلات وفرص تحسين المنتج (على سبيل المثال درجة الجودة الغذائية أفضل)."
+msgstr "يمكن للمصنعين استخدام منصة Open Food Facts المجانية <a href=\"<producers_platform_url>\">للمنتجين</a> للوصول إلى هذه البيانات واستكمالها، والحصول على التقارير والتحليلات وفرص تحسين المنتج (على سبيل المثال Nutri-Score أفضل)."
 
 # variable names between { } must not be translated
 msgctxt "f_data_source_database_provider"
@@ -5689,7 +5684,7 @@ msgstr "يتم حساب الأثر على الغابات من خلال الأخ�
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "لا يمكن حساب الدرجة البيئية إلا إذا كان المنتج يحتوي على فئة دقيقة بدرجة كافية."
+msgstr "لا يمكن حساب Green-Score إلا إذا كان المنتج يحتوي على فئة دقيقة بدرجة كافية."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5701,7 +5696,7 @@ msgstr "إذا كنت الشركة المصنعة لهذا المنتج، فيم
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "تحذير: بعض المعلومات اللازمة لحساب النتيجة البيئية بدقة غير متوفرة (انظر تفاصيل الحساب أدناه)."
+msgstr "تحذير: بعض المعلومات اللازمة لحساب Green-Score بدقة غير متوفرة (انظر تفاصيل الحساب أدناه)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5856,12 +5851,12 @@ msgstr "المعلومات المتعلقة بتغليف هذا المنتج ل�
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "للحصول على حساب أكثر دقة للدرجة البيئية، يمكنك تعديل صفحة المنتج وإضافتها."
+msgstr "للحصول على حساب أكثر دقة Green-Score، يمكنك تعديل صفحة المنتج وإضافتها."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "للحصول على حساب أكثر دقة للدرجة البيئية، يمكنك تعديل صفحة المنتج وإضافتها."
+msgstr "للحصول على حساب أكثر دقة Green-Score، يمكنك تعديل صفحة المنتج وإضافتها."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5883,12 +5878,12 @@ msgstr "إذا كنت الشركة المصنعة لهذا المنتج، فيم
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "<a href=\"/green-score\">النتيجة البيئية</a> هي نتيجة تجريبية تلخص التأثيرات البيئية للمنتجات الغذائية."
+msgstr "<a href=\"/green-score\">Green-Score</a> هي نتيجة تجريبية تلخص التأثيرات البيئية للمنتجات الغذائية."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
 msgid "The Green-Score formula is subject to change as it is regularly improved to make it more precise."
-msgstr "إن صيغة النتيجة البيئية قابلة للتغيير حيث يتم تحسينها بانتظام لجعلها أكثر دقة."
+msgstr "إن صيغة Green-Score قابلة للتغيير حيث يتم تحسينها بانتظام لجعلها أكثر دقة."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
@@ -5905,7 +5900,7 @@ msgstr "إن التأثير الكامل للنقل إلى بلدك غير مع�
 
 msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Green-Score and more!"
-msgstr "قم بمسح الباركود للحصول على درجة الجودة الغذائية و النتيجة البيئية والمزيد!"
+msgstr "قم بمسح الباركود للحصول على Nutri-Score و Green-Score والمزيد!"
 
 msgctxt "org_gs1_product_name_is_abbreviated"
 msgid "GS1 product names for this manufacturer are abbreviated."
@@ -6052,7 +6047,7 @@ msgstr "لا نزال بحاجة إلى 120,000 يورو لإنهاء عام 202
 
 msgctxt "donation_title_2026"
 msgid "Become an Open Food Facts patron"
-msgstr "انضم إلى رعاة برنامج حقائق الطعام المفتوحة"
+msgstr "انضم إلى رعاة برنامج Open Food Facts"
 
 msgctxt "donation_list_2026_main"
 msgid "Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:"
@@ -6060,7 +6055,7 @@ msgstr "نستقبل شهرياً 8 ملايين زائر، وأضعاف هذا 
 
 msgctxt "donation_list_2026_first"
 msgid "keep Open Food Facts open & available to all,"
-msgstr "أبقوا قسم حقائق الطعام مفتوحاً ومتاحاً للجميع"
+msgstr "أبقوا قسم Open Food Facts ومتاحاً للجميع"
 
 msgctxt "donation_list_2026_first_sub"
 msgid "support infrastructure, the website, mobile app and API with a small permanent team"
@@ -6216,7 +6211,7 @@ msgstr "المكافآت والعقوبات"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "النتيجة البيئية لهذا المنتج"
+msgstr "Green-Score لهذا المنتج"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6244,15 +6239,15 @@ msgstr "يقتصر تقييم المنتجات التي تحتوي على موا
 
 msgctxt "nutriscore_not_applicable"
 msgid "Nutri-Score not applicable for this product category."
-msgstr "لا ينطبق درجة الجودة الغذائية على فئة المنتج هذه."
+msgstr "لا ينطبق Nutri-Score على فئة المنتج هذه."
 
 msgctxt "nutriscore_missing_category"
 msgid "The category of the product must be specified in order to compute the Nutri-Score."
-msgstr "يجب تحديد فئة المنتج حتى تتمكن من حساب درجة الجودة الغذائية."
+msgstr "يجب تحديد فئة المنتج حتى تتمكن من حساب Nutri-Score."
 
 msgctxt "nutriscore_missing_nutrition_data"
 msgid "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
-msgstr "يجب تحديد المعلومات الغذائية للمنتج حتى تتمكن من حساب درجة الجودة الغذائية."
+msgstr "يجب تحديد المعلومات الغذائية للمنتج حتى تتمكن من حساب Nutri-Score."
 
 msgctxt "nutriscore_missing_nutrition_data_details"
 msgid "Missing nutrition facts:"
@@ -6264,7 +6259,7 @@ msgstr "معلومات غذائية مفقودة للمنتج المُحضر:"
 
 msgctxt "nutriscore_missing_category_and_nutrition_data"
 msgid "The category and the nutrition facts of the product must be specified in order to compute the Nutri-Score."
-msgstr "يجب تحديد فئة المنتج والحقائق الغذائية الخاصة به حتى تتمكن من حساب درجة الجودة الغذائية."
+msgstr "يجب تحديد فئة المنتج والحقائق الغذائية الخاصة به حتى تتمكن من حساب Nutri-Score."
 
 msgctxt "health"
 msgid "Health"
@@ -6495,7 +6490,7 @@ msgstr "معرفة المزيد عن Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "تعرف على المزيد حول الدرجة البيئية"
+msgstr "تعرف على المزيد حول Green-Score"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6533,7 +6528,7 @@ msgstr "استخدام التفضيلات الافتراضية"
 
 msgctxt "reset_preferences_details"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "درجة الجودة الغذائية و الدرجة البيئية ومستوى معالجة الأغذية (NOVA)"
+msgstr "Nutri-Score و Green-Score ومستوى معالجة الأغذية (NOVA)"
 
 msgctxt "actions_add_ingredients"
 msgid "Could you add the ingredients list?"
@@ -6541,15 +6536,15 @@ msgstr "هل بإمكانك إضافة قائمة المكونات؟"
 
 msgctxt "actions_to_compute_nutriscore"
 msgid "Could you add the information needed to compute the Nutri-Score?"
-msgstr "هل بإمكانك إضافة المعلومات اللازمة لحساب درجة الجودة الغذائية؟"
+msgstr "هل بإمكانك إضافة المعلومات اللازمة لحساب Nutri-Score؟"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "هل بإمكانك إضافة فئة منتج محددة حتى نتمكن من حساب النتيجة البيئية؟"
+msgstr "هل بإمكانك إضافة فئة منتج محددة حتى نتمكن من حساب Green-Score؟"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "تصنيف هذا المنتج ليس دقيقًا بما يكفي لحساب درجة الجودة الخضراء. هل يمكنك إضافة تصنيف أكثر دقة؟"
+msgstr "تصنيف هذا المنتج ليس دقيقًا بما يكفي لحساب Green-Score. هل يمكنك إضافة تصنيف أكثر دقة؟"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7138,7 +7133,7 @@ msgstr "يُعتبر هذا المنتج ماءً لحساب مؤشر القيم
 
 msgctxt "nutriscore_is_fat_oil_nuts_seeds"
 msgid "This product is considered to be fat, oil, nuts or seeds for the calculation of the Nutri-Score."
-msgstr "يُعتبر هذا المنتج دهونًا أو زيوتًا أو مكسرات أو بذورًا لحساب مؤشر القيمة الغذائية."
+msgstr "يُعتبر هذا المنتج دهونًا أو زيوتًا أو مكسرات أو بذورًا لحساب Nutri-Score."
 
 msgctxt "nutriscore_is_cheese"
 msgid "This product is considered to be cheese for the calculation of the Nutri-Score."
@@ -7178,7 +7173,7 @@ msgstr "اكتشف نظام Nutri-Score الجديد!"
 
 msgctxt "nutriscore_new_computation_description"
 msgid "<p>The computation of the Nutri-Score is evolving to provide better recommendations based on the latest scientific evidence.</p><p>Main improvements:</p><ul><li>Better score for some fatty fish and oils rich in good fats</li><li>Better score for whole products rich in fiber</li><li>Worse score for products containing a lot of salt or sugar</li><li>Worse score for red meat (compared to poultry)</li></ul>"
-msgstr "<p>يتم تطوير حساب مؤشر التغذية لتقديم توصيات أفضل بناءً على أحدث الأدلة العلمية.</p><p>التحسينات الرئيسية:</p><ul><li>تحسين النتيجة لبعض الأسماك الدهنية والزيوت الغنية بالدهون الصحية</li><li>تحسين النتيجة للمنتجات الكاملة الغنية بالألياف</li><li>انخفاض النتيجة للمنتجات التي تحتوي على الكثير من الملح أو السكر</li><li>انخفاض النتيجة للحوم الحمراء (مقارنة بالدواجن)</li></ul>"
+msgstr "<p>يتم تطوير حساب Nutri-Score لتقديم توصيات أفضل بناءً على أحدث الأدلة العلمية.</p><p>التحسينات الرئيسية:</p><ul><li>تحسين النتيجة لبعض الأسماك الدهنية والزيوت الغنية بالدهون الصحية</li><li>تحسين النتيجة للمنتجات الكاملة الغنية بالألياف</li><li>انخفاض النتيجة للمنتجات التي تحتوي على الكثير من الملح أو السكر</li><li>انخفاض النتيجة للحوم الحمراء (مقارنة بالدواجن)</li></ul>"
 
 msgctxt "nutriscore_new_computation_link_text"
 msgid "Discover all the improvements of the new Nutri-Score"
@@ -7416,7 +7411,7 @@ msgstr "تاريخ الإنشاء"
 
 msgctxt "knowledge_panels_ingredients_rare_crops_divinfood"
 msgid "Open Food Facts participates in the European project <a href=\"https://divinfood.eu/\">DIVINFOOD</a> (funded from European Union’s Horizon 2020 research and innovation programme). DIVINFOOD aims to develop food chains that value under-utilised agrobiodiversity in order to act against the decline of biodiversity and to meet the growing expectations of consumers for healthy, local products that contribute to sustainable food systems."
-msgstr "تشارك حقائق الغذاء المفتوحة في المشروع الأوروبي <a href=\"https://divinfood.eu/\">DIVINFOOD</a> (الممول من برنامج أفق 2020 للبحث والإبداع). ويهدف برنامج DIVINFOOD إلى تطوير سلاسل غذائية قيِّمة التنوع البيولوجي الزراعي غير المستغل بالقدر الكافي من أجل التصدي لتدهور التنوع البيولوجي وتلبية توقعات المستهلكين المتزايدة في مجال الصحة والصحة. المنتجات المحلية التي تسهم في النظم الغذائية المستدامة."
+msgstr "تشارك Open Food Factsة في المشروع الأوروبي <a href=\"https://divinfood.eu/\">DIVINFOOD</a> (الممول من برنامج أفق 2020 للبحث والإبداع). ويهدف برنامج DIVINFOOD إلى تطوير سلاسل غذائية قيِّمة التنوع البيولوجي الزراعي غير المستغل بالقدر الكافي من أجل التصدي لتدهور التنوع البيولوجي وتلبية توقعات المستهلكين المتزايدة في مجال الصحة والصحة. المنتجات المحلية التي تسهم في النظم الغذائية المستدامة."
 
 msgctxt "deny"
 msgid "Deny"
@@ -7448,7 +7443,7 @@ msgstr "عدد المنتجات التي لا تحتوي على مؤشر Nutri-S
 
 msgctxt "percent_of_products_with_nutriscore"
 msgid "% of products where Nutri-Score is computed"
-msgstr "% من المنتجات التي يتم فيها حساب نقاط التغذية"
+msgstr "% من المنتجات التي يتم فيها حساب Nutri-Score"
 
 msgctxt "products_to_be_exported"
 msgid "Products to be exported"
@@ -7460,7 +7455,7 @@ msgstr "المنتجات المصدرة"
 
 msgctxt "opportunities_to_improve_nutriscore"
 msgid "Opp. for Nutri-Score improvements"
-msgstr "فرص لتحسين مؤشر التغذية"
+msgstr "فرص لتحسين Nutri-Score"
 
 msgctxt "date_of_last_update"
 msgid "Date of last update"
@@ -7672,7 +7667,7 @@ msgstr "الزراعة العضوية والتجارة العادلة"
 
 msgctxt "reset_preferences_details_food"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "درجة الجودة الغذائية و الدرجة البيئية ومستوى معالجة الأغذية (NOVA)"
+msgstr "Nutri-Score و Green-Score ومستوى معالجة الأغذية (NOVA)"
 
 msgctxt "reset_preferences_details_product"
 msgid "Good repairability"
@@ -7688,7 +7683,7 @@ msgstr "أبلغ المشرفين لدينا عن هذه الصورة"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "نحن نفتقد قيمة حجم الحصة و/أو الوحدة لحساب النتيجة الغذائية"
+msgstr "نحن نفتقد قيمة حجم الحصة و/أو الوحدة لحساب Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/as.po
+++ b/po/common/as.po
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "এই প্ৰডাক্ট পেজটো সম্পূৰ্ণ হোৱা নাই। আপুনি ইয়াক সম্পাদনা কৰি আৰু আমাৰ হাতত থকা ফটোসমূহৰ পৰা অধিক তথ্য যোগ কৰি, বা <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">এণ্ড্ৰইড</a> বা <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">আইফোন/আইপেড</a>ৰ বাবে ইউনিভাৰ্চেল মুক্ত খাদ্য তথ্য এপ ব্যৱহাৰ কৰি অধিক ফটো তুলি ইয়াক সম্পূৰ্ণ কৰাত সহায় কৰিব পাৰে। ধন্যবাদ!"
+msgstr "এই প্ৰডাক্ট পেজটো সম্পূৰ্ণ হোৱা নাই। আপুনি ইয়াক সম্পাদনা কৰি আৰু আমাৰ হাতত থকা ফটোসমূহৰ পৰা অধিক তথ্য যোগ কৰি, বা <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">এণ্ড্ৰইড</a> বা <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">আইফোন/আইপেড</a>ৰ বাবে ইউনিভাৰ্চেল Open Food Facts এপ ব্যৱহাৰ কৰি অধিক ফটো তুলি ইয়াক সম্পূৰ্ণ কৰাত সহায় কৰিব পাৰে। ধন্যবাদ!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "এই প্ৰডাক্ট পেজটো সম্পূৰ্ণ হোৱা নাই। আপুনি ইয়াক সম্পাদনা কৰি আৰু আমাৰ হাতত থকা ফটোসমূহৰ পৰা অধিক তথ্য যোগ কৰি, বা <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">এণ্ড্ৰইড</a> বা <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">আইফোন/আইপেড</a>ৰ বাবে ইউনিভাৰ্চেল মুক্ত খাদ্য তথ্য এপ ব্যৱহাৰ কৰি অধিক ফটো তুলি ইয়াক সম্পূৰ্ণ কৰাত সহায় কৰিব পাৰে। ধন্যবাদ!"
+msgstr "এই প্ৰডাক্ট পেজটো সম্পূৰ্ণ হোৱা নাই। আপুনি ইয়াক সম্পাদনা কৰি আৰু আমাৰ হাতত থকা ফটোসমূহৰ পৰা অধিক তথ্য যোগ কৰি, বা <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">এণ্ড্ৰইড</a> বা <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">আইফোন/আইপেড</a>ৰ বাবে ইউনিভাৰ্চেল Open Food Facts এপ ব্যৱহাৰ কৰি অধিক ফটো তুলি ইয়াক সম্পূৰ্ণ কৰাত সহায় কৰিব পাৰে। ধন্যবাদ!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "নিউট্ৰি-স্ক’ৰ প্ৰযোজ্য নহয়"
+msgstr "Nutri-Score প্ৰযোজ্য নহয়"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "গ্ৰীণ-স্ক’ৰ হৈছে এ+ৰ পৰা এফলৈকে পৰিৱেশগত স্ক’ৰ যিয়ে খাদ্য সামগ্ৰীৰ পৰিৱেশৰ ওপৰত প্ৰভাৱৰ তুলনা কৰাটো সহজ কৰি তোলে।"
+msgstr "Green-Score হৈছে এ+ৰ পৰা এফলৈকে পৰিৱেশগত স্ক’ৰ যিয়ে খাদ্য সামগ্ৰীৰ পৰিৱেশৰ ওপৰত প্ৰভাৱৰ তুলনা কৰাটো সহজ কৰি তোলে।"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "গ্ৰীণ-স্ক’ৰ হৈছে এ+ৰ পৰা এফলৈকে পৰিৱেশগত স্ক’ৰ যিয়ে খাদ্য সামগ্ৰীৰ পৰিৱেশৰ ওপৰত প্ৰভাৱৰ তুলনা কৰাটো সহজ কৰি তোলে।"
+msgstr "Green-Score হৈছে এ+ৰ পৰা এফলৈকে পৰিৱেশগত স্ক’ৰ যিয়ে খাদ্য সামগ্ৰীৰ পৰিৱেশৰ ওপৰত প্ৰভাৱৰ তুলনা কৰাটো সহজ কৰি তোলে।"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "প্ৰথমতে ফ্ৰান্সৰ বাবে গ্ৰীণ-স্ক’ৰ প্ৰস্তুত কৰা হৈছিল আৰু ইয়াক ইউৰোপৰ অন্যান্য দেশলৈও সম্প্ৰসাৰিত কৰা হৈছে। গ্ৰীণ-স্ক’ৰ সূত্ৰ সলনি হ’ব পাৰে কাৰণ ইয়াক নিয়মিতভাৱে উন্নত কৰা হয় যাতে ইয়াক অধিক নিখুঁত আৰু প্ৰতিখন দেশৰ বাবে অধিক উপযুক্ত কৰি তোলা হয়।"
+msgstr "প্ৰথমতে ফ্ৰান্সৰ বাবে Green-Score প্ৰস্তুত কৰা হৈছিল আৰু ইয়াক ইউৰোপৰ অন্যান্য দেশলৈও সম্প্ৰসাৰিত কৰা হৈছে। Green-Score সূত্ৰ সলনি হ’ব পাৰে কাৰণ ইয়াক নিয়মিতভাৱে উন্নত কৰা হয় যাতে ইয়াক অধিক নিখুঁত আৰু প্ৰতিখন দেশৰ বাবে অধিক উপযুক্ত কৰি তোলা হয়।"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "এই প্ৰডাক্টৰ বাবে আমাৰ হাতত থকা শ্ৰেণীটো গ্ৰীণ-স্ক’ৰ গণনা কৰিবলৈ যথেষ্ট নিখুঁত নহয়। আপুনি অধিক নিখুঁত পণ্যৰ শ্ৰেণী যোগ কৰিব পাৰিবনে?"
+msgstr "এই প্ৰডাক্টৰ বাবে আমাৰ হাতত থকা শ্ৰেণীটো Green-Score গণনা কৰিবলৈ যথেষ্ট নিখুঁত নহয়। আপুনি অধিক নিখুঁত পণ্যৰ শ্ৰেণী যোগ কৰিব পাৰিবনে?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,7 +7665,7 @@ msgstr "এই ছবিখন আমাৰ মডাৰেটৰসকলক �
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "আমি নিউট্ৰি-স্ক'ৰ গণনা কৰিবলৈ পৰিবেশনৰ আকাৰৰ মান আৰু/বা ইউনিট হেৰুৱাইছো"
+msgstr "আমি Nutri-Score গণনা কৰিবলৈ পৰিবেশনৰ আকাৰৰ মান আৰু/বা ইউনিট হেৰুৱাইছো"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
@@ -7686,7 +7681,7 @@ msgstr "লিলো চাৰ্চ ইঞ্জিন"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "ৰবটৰ পৰা হোৱা প্ৰচণ্ড অপব্যৱহাৰৰ বাবে আমি এই পৃষ্ঠাটো অচিনাক্ত ব্যৱহাৰকাৰীক সেৱা আগবঢ়াব পৰা নাই। মুক্ত খাদ্যৰ সকলো তথ্য প্ৰৱেশ কৰিবলৈ অনুগ্ৰহ কৰি এটা বিনামূলীয়া মুক্ত খাদ্য তথ্য একাউণ্ট সৃষ্টি কৰক।"
+msgstr "ৰবটৰ পৰা হোৱা প্ৰচণ্ড অপব্যৱহাৰৰ বাবে আমি এই পৃষ্ঠাটো অচিনাক্ত ব্যৱহাৰকাৰীক সেৱা আগবঢ়াব পৰা নাই। Open Food Facts সকলো তথ্য প্ৰৱেশ কৰিবলৈ অনুগ্ৰহ কৰি এটা বিনামূলীয়া Open Food Facts একাউণ্ট সৃষ্টি কৰক।"
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"

--- a/po/common/ast.po
+++ b/po/common/ast.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/az.po
+++ b/po/common/az.po
@@ -448,7 +448,7 @@ msgstr "Barkod nömrəsi:"
 
 msgctxt "you_can_also_help_us"
 msgid "You can also help to fund the Open Food Facts project"
-msgstr "Həmçinin Açıq Qida Faktları layihəsinin maliyyələşdirilməsinə kömək edə bilərsiniz"
+msgstr "Həmçinin Open Food Facts layihəsinin maliyyələşdirilməsinə kömək edə bilərsiniz"
 
 msgctxt "producers_administration_manual"
 msgid "Producers Admin manual"
@@ -1073,7 +1073,7 @@ msgstr "https://world-az.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "İstehsalçılar üçün açıq qida faktları"
+msgstr "İstehsalçılar üçün Open Food Facts"
 
 msgctxt "for"
 msgid "for"
@@ -1756,7 +1756,7 @@ msgstr "Cədvəldə tez-tez göstərilən qida maddələri standart olaraq sadal
 
 msgctxt "nutrition_data_table_asterisk"
 msgid "Essential nutrients to calculate the Nutri-Score."
-msgstr "Nutri-Skorunu hesablamaq üçün vacib qida maddələri."
+msgstr "Nutri-Score hesablamaq üçün vacib qida maddələri."
 
 msgctxt "nutrition_grades_p"
 msgid "Nutrition grades"
@@ -1765,11 +1765,6 @@ msgstr ""
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -2904,7 +2899,7 @@ msgstr "Tərcüməçilərimiz"
 
 msgctxt "translators_lead"
 msgid "We would like to say THANK YOU to the awesome translators that make it possible to present Open Food Facts, Open Beauty Facts, and Open Pet Food Facts to you in all these different languages! <a href=\"https://translate.openfoodfacts.org/\">You can join us in this global effort: it doesn't require any technical knowledge.</a>"
-msgstr "Bütün bu müxtəlif dillərdə sizə Açıq Qida Faktları, Açıq Gözəllik Faktları və Açıq Ev Heyvanları Yeməyi Faktlarını təqdim etməyi mümkün edən möhtəşəm tərcüməçilərə TƏŞƏKKÜR EDİRİK! <a href=\"https://translate.openfoodfacts.org/\">Bu qlobal səydə bizə qoşula bilərsiniz: bu, heç bir texniki bilik tələb etmir.</a>"
+msgstr "Bütün bu müxtəlif dillərdə sizə Open Food Facts, Open Beauty Facts və Open Pet Food Facts təqdim etməyi mümkün edən möhtəşəm tərcüməçilərə TƏŞƏKKÜR EDİRİK! <a href=\"https://translate.openfoodfacts.org/\">Bu qlobal səydə bizə qoşula bilərsiniz: bu, heç bir texniki bilik tələb etmir.</a>"
 
 msgctxt "translators_renewal_notice"
 msgid "Please note that this table is refreshed nightly and might be out of date."
@@ -3509,7 +3504,7 @@ msgstr "Məhsul məlumatları ilə birlikdə elektron cədvəl faylı (Excel fay
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "import_data_file_format"
 msgid "You can upload a table with the columns Open Food Facts import format, or you can upload a table in any format and then select the columns to import."
-msgstr "Siz \"Açıq Qida Faktları\" sütunlarını idxal formatında cədvəl yükləyə və ya istənilən formatda cədvəl yükləyib idxal ediləcək sütunları seçə bilərsiniz."
+msgstr "Siz \"Open Food Facts\" sütunlarını idxal formatında cədvəl yükləyə və ya istənilən formatda cədvəl yükləyib idxal ediləcək sütunları seçə bilərsiniz."
 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "upload_product_data_file"
@@ -3738,17 +3733,17 @@ msgstr "İstehsalçılar üçün platforma"
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_description"
 msgid "The platform for producers allows manufacturers to easily manage their product photos and data on Open Food Facts."
-msgstr "İstehsalçılar üçün platforma istehsalçılara məhsul şəkillərini və məlumatlarını Açıq Qida Faktları üzərindən asanlıqla idarə etməyə imkan verir."
+msgstr "İstehsalçılar üçün platforma istehsalçılara məhsul şəkillərini və məlumatlarını Open Food Facts üzərindən asanlıqla idarə etməyə imkan verir."
 
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_private_database"
 msgid "The product data and photos you send on the platform for producers are stored in a private database. You will be able to check that all the data is correct before making it available on the public Open Food Facts database."
-msgstr "İstehsalçılar üçün platformada göndərdiyiniz məhsul məlumatları və fotoşəkillər şəxsi verilənlər bazasında saxlanılır. Bütün məlumatları açıq Açıq Qida Faktları verilənlər bazasında təqdim etməzdən əvvəl onların düzgünlüyünü yoxlaya biləcəksiniz."
+msgstr "İstehsalçılar üçün platformada göndərdiyiniz məhsul məlumatları və fotoşəkillər şəxsi verilənlər bazasında saxlanılır. Bütün məlumatları açıq Open Food Facts verilənlər bazasında təqdim etməzdən əvvəl onların düzgünlüyünü yoxlaya biləcəksiniz."
 
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_licence"
 msgid "The product data and photos will become publicly available in the Open Food Facts database, under the <a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">Open Database License</a>. Individual contents of the database are available under the <a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">Database Contents License</a> and products images are available under the <a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike licence</a>."
-msgstr "Məhsul məlumatları və fotoşəkilləri Açıq Qida Faktları verilənlər bazasında <a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">Açıq Verilənlər Bazası Lisenziyası</a>altında ictimaiyyətə açıq olacaq. Verilənlər bazasının fərdi məzmunu <a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">Verilənlər Bazası Məzmun Lisenziyası</a> altında, məhsul şəkilləri isə <a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike lisenziyası</a> altında mövcuddur."
+msgstr "Məhsul məlumatları və fotoşəkilləri Open Food Facts verilənlər bazasında <a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">Açıq Verilənlər Bazası Lisenziyası</a>altında ictimaiyyətə açıq olacaq. Verilənlər bazasının fərdi məzmunu <a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">Verilənlər Bazası Məzmun Lisenziyası</a> altında, məhsul şəkilləri isə <a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike lisenziyası</a> altında mövcuddur."
 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "import_product_data"
@@ -4170,7 +4165,7 @@ msgstr "Nutri-Score"
 # free as in not costing something
 msgctxt "donate_free_and_independent"
 msgid "Open Food Facts is 100% free and independent."
-msgstr "Açıq Qida Faktları 100% pulsuz və müstəqildir."
+msgstr "Open Food Facts 100% pulsuz və müstəqildir."
 
 # leave empty link
 msgctxt "donate_help_and_donations"
@@ -4573,7 +4568,7 @@ msgstr "İstehsalçı tərəfindən məhsulun müəyyən bir versiyası dəyişd
 
 msgctxt "categories_import_note"
 msgid "Providing a category is very important to make the product easy to search for, and to compute the Nutri-Score"
-msgstr "Məhsulun axtarışını asanlaşdırmaq və Nutri-Balı hesablamaq üçün kateqoriya təqdim etmək çox vacibdir."
+msgstr "Məhsulun axtarışını asanlaşdırmaq və Nutri-Score hesablamaq üçün kateqoriya təqdim etmək çox vacibdir."
 
 msgctxt "labels_import_note"
 msgid "Some labels such as the organic label are used to filter and/or rank search results, so it is strongly recommended to specify them."
@@ -4720,7 +4715,7 @@ msgstr "Nutri-Score məlum deyil"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
 msgid "Missing data to compute the Nutri-Score"
-msgstr "Nutri-Skorunu hesablamaq üçün çatışmayan məlumatlar"
+msgstr "Nutri-Score hesablamaq üçün çatışmayan məlumatlar"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
@@ -4954,11 +4949,11 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "Ətraf mühitə aşağı təsir (Yaşıl bal)"
+msgstr "Ətraf mühitə aşağı təsir (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Yaşıl Bal, qida məhsullarının ətraf mühitə təsirini müqayisə etməyi asanlaşdıran A+ ilə F arasında dəyişən ətraf mühit balıdır."
+msgstr "Green-Score, qida məhsullarının ətraf mühitə təsirini müqayisə etməyi asanlaşdıran A+ ilə F arasında dəyişən ətraf mühit balıdır."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4967,16 +4962,16 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "Ətraf mühitə aşağı təsir (Yaşıl bal)"
+msgstr "Ətraf mühitə aşağı təsir (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Yaşıl Bal, qida məhsullarının ətraf mühitə təsirini müqayisə etməyi asanlaşdıran A+ ilə F arasında dəyişən ətraf mühit balıdır."
+msgstr "Green-Score, qida məhsullarının ətraf mühitə təsirini müqayisə etməyi asanlaşdıran A+ ilə F arasında dəyişən ətraf mühit balıdır."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Yaşıl Hesab %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5162,22 +5157,22 @@ msgstr "Ətraf mühitə təsir"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "Yaşıl Hesab hesabı"
+msgstr "Green-Score hesabı"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "Yaşıl bal dərəcəsi"
+msgstr "Green-Score dərəcəsi"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "Yaşıl Hesabın hesablanmasının təfərrüatları"
+msgstr "Green-Scoren hesablanmasının təfərrüatları"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "Yaşıl Hesab haqqında məlumat"
+msgstr "Green-Score haqqında məlumat"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5478,7 +5473,7 @@ msgstr "Ən yaxşı Nutri-Score göstəricisinə malik məhsullar"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "Ən yaxşı Yaşıl Hesaba malik Məhsullar"
+msgstr "Ən yaxşı Green-Scorea malik Məhsullar"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5532,7 +5527,7 @@ msgstr "İstifadəçi silinir. Bu, bir neçə dəqiqə çəkə bilər."
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "Yaşıl bal tətbiq olunmur"
+msgstr "Green-Score tətbiq olunmur"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5545,11 +5540,11 @@ msgstr "{category} kateqoriyası üçün hələlik tətbiq olunmur"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "Yaşıl Hesab hələlik bu kateqoriya üçün tətbiq olunmur, lakin biz ona dəstək əlavə etmək üzərində işləyirik."
+msgstr "Green-Score hələlik bu kateqoriya üçün tətbiq olunmur, lakin biz ona dəstək əlavə etmək üzərində işləyirik."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Yaşıl Hesab hesablanmayıb"
+msgstr "Green-Score hesablanmayıb"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5561,7 +5556,7 @@ msgstr "Dəqiq kateqoriya yoxdur"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "Bu məhsulun Yaşıl Balını hesablaya bilmədik, çünki bəzi məlumatlar çatışmır, onu tamamlamağa kömək edə bilərsinizmi?"
+msgstr "Bu məhsulun Green-Scoreını hesablaya bilmədik, çünki bəzi məlumatlar çatışmır, onu tamamlamağa kömək edə bilərsinizmi?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5669,7 +5664,7 @@ msgstr "%s məhsullarının bəzi məlumatları %s-dan götürülmüşdür."
 
 msgctxt "data_source_database_note_about_the_producers_platform"
 msgid "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_url>\">free plaform for producers</a> to access and complete this data, and to obtain reports, analysis and product improvements opportunities (e.g. better Nutri-Score)."
-msgstr "İstehsalçılar bu məlumatlara daxil olmaq və onları tamamlamaq, hesabatlar, təhlillər və məhsul təkmilləşdirmə imkanları (məsələn, daha yaxşı Nutri-Score) əldə etmək üçün Açıq Qida Faktları <a href=\"<producers_platform_url>\"\"istehsalçılar üçün pulsuz platforma</a> -dan istifadə edə bilərlər."
+msgstr "İstehsalçılar bu məlumatlara daxil olmaq və onları tamamlamaq, hesabatlar, təhlillər və məhsul təkmilləşdirmə imkanları (məsələn, daha yaxşı Nutri-Score) əldə etmək üçün Open Food Facts <a href=\"<producers_platform_url>\"\"istehsalçılar üçün pulsuz platforma</a> -dan istifadə edə bilərlər."
 
 # variable names between { } must not be translated
 msgctxt "f_data_source_database_provider"
@@ -5691,7 +5686,7 @@ msgstr "Meşə izi, becərilməsi meşələrin qırılması ilə əlaqəli olan 
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "Yaşıl Bal yalnız məhsulun kifayət qədər dəqiq bir kateqoriyası olduqda hesablana bilər."
+msgstr "Green-Score yalnız məhsulun kifayət qədər dəqiq bir kateqoriyası olduqda hesablana bilər."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5703,7 +5698,7 @@ msgstr "Əgər bu məhsulun istehsalçısısınızsa, məlumatı istehsalçılar
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "Xəbərdarlıq: Yaşıl Hesabı dəqiq hesablamaq üçün lazım olan bəzi məlumatlar təqdim edilməyib (aşağıdakı hesablamanın təfərrüatlarına baxın)."
+msgstr "Xəbərdarlıq: Green-Score dəqiq hesablamaq üçün lazım olan bəzi məlumatlar təqdim edilməyib (aşağıdakı hesablamanın təfərrüatlarına baxın)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5858,12 +5853,12 @@ msgstr "Bu məhsulun qablaşdırılması haqqında məlumat kifayət qədər də
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "Yaşıl Balın daha dəqiq hesablanması üçün məhsul səhifəsini dəyişdirə və əlavə edə bilərsiniz."
+msgstr "Green-Scoreın daha dəqiq hesablanması üçün məhsul səhifəsini dəyişdirə və əlavə edə bilərsiniz."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "Yaşıl Balın daha dəqiq hesablanması üçün məhsul səhifəsini redaktə edə və əlavə edə bilərsiniz."
+msgstr "Green-Scoreın daha dəqiq hesablanması üçün məhsul səhifəsini redaktə edə və əlavə edə bilərsiniz."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5885,17 +5880,17 @@ msgstr "Əgər bu məhsulun istehsalçısısınızsa, məlumatı istehsalçılar
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "<a href=\"/green-score\">Yaşıl Bal</a> qida məhsullarının ətraf mühitə təsirlərini ümumiləşdirən eksperimental baldır."
+msgstr "<a href=\"/green-score\">Green-Score</a> qida məhsullarının ətraf mühitə təsirlərini ümumiləşdirən eksperimental baldır."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
 msgid "The Green-Score formula is subject to change as it is regularly improved to make it more precise."
-msgstr "Yaşıl Hesab düsturu daha dəqiq olması üçün müntəzəm olaraq təkmilləşdirildiyindən dəyişdirilə bilər."
+msgstr "Green-Score düsturu daha dəqiq olması üçün müntəzəm olaraq təkmilləşdirildiyindən dəyişdirilə bilər."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Yaşıl Hesab əvvəlcə Fransa üçün hazırlanmış və hazırda digər Avropa ölkələrinə də tətbiq olunur. Yaşıl Hesab düsturu daha dəqiq və hər bir ölkəyə daha uyğun olması üçün müntəzəm olaraq təkmilləşdirildiyi üçün dəyişdirilə bilər."
+msgstr "Green-Score əvvəlcə Fransa üçün hazırlanmış və hazırda digər Avropa ölkələrinə də tətbiq olunur. Green-Score düsturu daha dəqiq və hər bir ölkəyə daha uyğun olması üçün müntəzəm olaraq təkmilləşdirildiyi üçün dəyişdirilə bilər."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6054,7 +6049,7 @@ msgstr "2026-cı ili başa vurmaq üçün hələ də 120.000 avroya ehtiyacımı
 
 msgctxt "donation_title_2026"
 msgid "Become an Open Food Facts patron"
-msgstr "Açıq Qida Faktları himayədarı olun"
+msgstr "Open Food Facts himayədarı olun"
 
 msgctxt "donation_list_2026_main"
 msgid "Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:"
@@ -6062,7 +6057,7 @@ msgstr "Hər ay 8 milyon ziyarətçiyə xidmət göstəririk və bunun dəfələ
 
 msgctxt "donation_list_2026_first"
 msgid "keep Open Food Facts open & available to all,"
-msgstr "Açıq Qida Məlumatlarını hamı üçün açıq və əlçatan saxlayın,"
+msgstr "Open Food Facts hamı üçün açıq və əlçatan saxlayın,"
 
 msgctxt "donation_list_2026_first_sub"
 msgid "support infrastructure, the website, mobile app and API with a small permanent team"
@@ -6218,7 +6213,7 @@ msgstr "Bonuslar və çatışmazlıqlar"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Bu məhsul üçün Yaşıl Hesab"
+msgstr "Bu məhsul üçün Green-Score"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6497,7 +6492,7 @@ msgstr ""
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "Yaşıl Hesab haqqında daha çox məlumat əldə edin"
+msgstr "Green-Score haqqında daha çox məlumat əldə edin"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6547,11 +6542,11 @@ msgstr "Nutri-Score hesablamaq üçün lazım olan məlumatları əlavə edə bi
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Yaşıl Hesabı hesablaya bilməyimiz üçün dəqiq bir məhsul kateqoriyası əlavə edə bilərsinizmi?"
+msgstr "Green-Score hesablaya bilməyimiz üçün dəqiq bir məhsul kateqoriyası əlavə edə bilərsinizmi?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Bu məhsul üçün sahib olduğumuz kateqoriya Yaşıl Hesabı hesablamaq üçün kifayət qədər dəqiq deyil. Daha dəqiq bir məhsul kateqoriyası əlavə edə bilərsinizmi?"
+msgstr "Bu məhsul üçün sahib olduğumuz kateqoriya Green-Score hesablamaq üçün kifayət qədər dəqiq deyil. Daha dəqiq bir məhsul kateqoriyası əlavə edə bilərsinizmi?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7004,7 +6999,7 @@ msgstr "Zəhmət olmasa, 0 ilə {max} arasında bir dəyər daxil edin."
 
 msgctxt "please_ask_users_create_account_first"
 msgid "Please ask the following users to create an Open Food Facts account first:"
-msgstr "Zəhmət olmasa, aşağıdakı istifadəçilərdən əvvəlcə Açıq Qida Faktları hesabı yaratmalarını xahiş edin:"
+msgstr "Zəhmət olmasa, aşağıdakı istifadəçilərdən əvvəlcə Open Food Facts hesabı yaratmalarını xahiş edin:"
 
 msgctxt "users_added_successfully"
 msgid "Users added to the organization successfully:"
@@ -7204,7 +7199,7 @@ msgstr "Bu loqonun nümayişi şirkətlər üçün heç bir öhdəlik olmadan ic
 
 msgctxt "nutriscore_explanation_title"
 msgid "What is the Nutri-Score?"
-msgstr "Nutri-Balı nədir?"
+msgstr "Nutri-Score nədir?"
 
 msgctxt "nutrient_info_energy_risk"
 msgid "Energy intakes above energy requirements are associated with increased risks of weight gain, overweight, obesity, and consequently risk of diet-related chronic diseases."
@@ -7298,7 +7293,7 @@ msgstr "Məlumat qablaşdırmadakı məlumatlarla uyğun gəlmirsə, onu tamamla
 
 msgctxt "incomplete_or_incorrect_data_content_correct_off"
 msgid "Open Food Facts is a collaborative database, and every contribution is useful for all."
-msgstr "Açıq Qida Faktları əməkdaşlıq bazasıdır və hər bir töhfə hamı üçün faydalıdır."
+msgstr "Open Food Facts əməkdaşlıq bazasıdır və hər bir töhfə hamı üçün faydalıdır."
 
 msgctxt "report_to_nutripatrol_explain"
 msgid "If you want to report vandalism, inappropriate content or erroneous data you can't fix yourself, report it to our moderators team."
@@ -7706,7 +7701,7 @@ msgstr "Lilo axtarış sistemi"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Robotların şiddətli sui-istifadəsi səbəbindən biz bu səhifəni naməlum istifadəçilərə təqdim edə bilmirik. Bütün Açıq Qida Faktlarına daxil olmaq üçün pulsuz Açıq Qida Faktları hesabı yaradın."
+msgstr "Robotların şiddətli sui-istifadəsi səbəbindən biz bu səhifəni naməlum istifadəçilərə təqdim edə bilmirik. Bütün Open Food Facts daxil olmaq üçün pulsuz Open Food Facts hesabı yaradın."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7820,7 +7815,7 @@ msgstr "Biz aşkar etmədik: {unwanted_ingredients}. Bəzi inqrediyentləri qaç
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "Bu üstünlüklər Açıq Qida Faktlarının inqrediyentlər siyahısı haqqında anlayışına əsaslanır və onun dəqiq və ya tam olmama ehtimalı həmişə var, həmişə məhsulu özünüz yoxlayın."
+msgstr "Bu üstünlüklər Open Food Factsnın inqrediyentlər siyahısı haqqında anlayışına əsaslanır və onun dəqiq və ya tam olmama ehtimalı həmişə var, həmişə məhsulu özünüz yoxlayın."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/be.po
+++ b/po/common/be.po
@@ -1762,11 +1762,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4942,7 +4937,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "«Зялёны бал» — гэта экалагічны бал ад A+ да F, які дазваляе лёгка параўноўваць уплыў харчовых прадуктаў на навакольнае асяроддзе."
+msgstr "Green-Score — гэта экалагічны бал ад A+ да F, які дазваляе лёгка параўноўваць уплыў харчовых прадуктаў на навакольнае асяроддзе."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4955,7 +4950,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "«Зялёны бал» — гэта экалагічны бал ад A+ да F, які дазваляе лёгка параўноўваць уплыў харчовых прадуктаў на навакольнае асяроддзе."
+msgstr "Green-Score — гэта экалагічны бал ад A+ да F, які дазваляе лёгка параўноўваць уплыў харчовых прадуктаў на навакольнае асяроддзе."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5879,7 +5874,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "«Зялёны бал» быў першапачаткова распрацаваны для Францыі, і цяпер ён распаўсюджваецца на іншыя еўрапейскія краіны. Формула «Зялёнага бала» можа змяняцца, бо яна рэгулярна ўдасканальваецца, каб зрабіць яе больш дакладнай і лепшай для кожнай краіны."
+msgstr "Green-Score быў першапачаткова распрацаваны для Францыі, і цяпер ён распаўсюджваецца на іншыя еўрапейскія краіны. Формула Green-Score можа змяняцца, бо яна рэгулярна ўдасканальваецца, каб зрабіць яе больш дакладнай і лепшай для кожнай краіны."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."

--- a/po/common/ber.po
+++ b/po/common/ber.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/bg.po
+++ b/po/common/bg.po
@@ -166,7 +166,7 @@ msgstr "Съставки, алергени, добавки, хранителни
 
 msgctxt "search_description_opensearch_opff"
 msgid "Open Pet Food Facts product search"
-msgstr "Отворете търсенето на продукти в Pet Food Facts"
+msgstr "Отворете търсенето на продукти в Open Pet Food Facts"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1765,11 +1765,6 @@ msgstr "Хранителни оценки"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Хранителна оценка"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4950,7 +4945,7 @@ msgstr "Околна среда"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "Зелен-Резултат"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4958,12 +4953,12 @@ msgstr "Ниско въздействие върху околната среда
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Зеленият рейтинг е екологична оценка от A+ до F, която улеснява сравняването на въздействието на хранителните продукти върху околната среда."
+msgstr "Green-Score е екологична оценка от A+ до F, която улеснява сравняването на въздействието на хранителните продукти върху околната среда."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "Зелен-Резултат"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4971,12 +4966,12 @@ msgstr "Ниско въздействие върху околната среда
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Зеленият рейтинг е екологична оценка от A+ до F, която улеснява сравняването на въздействието на хранителните продукти върху околната среда."
+msgstr "Green-Score е екологична оценка от A+ до F, която улеснява сравняването на въздействието на хранителните продукти върху околната среда."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Зелен-Резултат %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5162,22 +5157,22 @@ msgstr "Влияние върху околната среда"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "Резултат Зелен-Резултат"
+msgstr "Резултат Green-Score"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "Степен Зелен-Резултат"
+msgstr "Степен Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "Подробности за изчисляването на Зелен-Резултат"
+msgstr "Подробности за изчисляването на Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "Информация за Зелен-Резултат"
+msgstr "Информация за Green-Score"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5214,19 +5209,19 @@ msgstr "Липсващи хранителни факти за приготвен
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "Зелен-Резултат"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "Зелен-Резултат"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "Зелен-Резултат"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "Зелен-Резултат"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5895,7 +5890,7 @@ msgstr "Формулата на Green-Score подлежи на промяна, 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Зеленият рейтинг първоначално е разработен за Франция и се разширява и в други европейски страни. Формулата за Зелен рейтинг подлежи на промяна, тъй като редовно се усъвършенства, за да стане по-точна и по-подходяща за всяка страна."
+msgstr "Green-Score първоначално е разработен за Франция и се разширява и в други европейски страни. Формулата за Зелен рейтинг подлежи на промяна, тъй като редовно се усъвършенства, за да стане по-точна и по-подходяща за всяка страна."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6493,7 +6488,7 @@ msgstr "Премахнете избора на изображение"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Благодаря ти"
+msgstr "Научи повече за Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"

--- a/po/common/bm.po
+++ b/po/common/bm.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/bn.po
+++ b/po/common/bn.po
@@ -63,7 +63,7 @@ msgstr "এবং অবদানকারীদের জন্য <a href=\"ht
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ওপেন বিউটি ফ্যাক্টস পণ্য অনুসন্ধান"
+msgstr "Open Beauty Facts পণ্য অনুসন্ধান"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "এই পণ্যের পৃষ্ঠাটি সম্পূর্ণ নয়। আপনি এটি সম্পাদনা করে এবং আমাদের কাছে থাকা ছবিগুলি থেকে আরও ডেটা যোগ করে এটি সম্পূর্ণ করতে সাহায্য করতে পারেন, অথবা <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> অথবা <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>এর জন্য সর্বজনীন ওপেন ফুড ফ্যাক্টস অ্যাপ ব্যবহার করে আরও ছবি তুলে। ধন্যবাদ!"
+msgstr "এই পণ্যের পৃষ্ঠাটি সম্পূর্ণ নয়। আপনি এটি সম্পাদনা করে এবং আমাদের কাছে থাকা ছবিগুলি থেকে আরও ডেটা যোগ করে এটি সম্পূর্ণ করতে সাহায্য করতে পারেন, অথবা <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> অথবা <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>এর জন্য সর্বজনীন Open Food Facts অ্যাপ ব্যবহার করে আরও ছবি তুলে। ধন্যবাদ!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "এই পণ্যের পৃষ্ঠাটি সম্পূর্ণ নয়। আপনি এটি সম্পাদনা করে এবং আমাদের কাছে থাকা ছবিগুলি থেকে আরও ডেটা যোগ করে এটি সম্পূর্ণ করতে সাহায্য করতে পারেন, অথবা <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> অথবা <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>এর জন্য সর্বজনীন ওপেন ফুড ফ্যাক্টস অ্যাপ ব্যবহার করে আরও ছবি তুলে। ধন্যবাদ!"
+msgstr "এই পণ্যের পৃষ্ঠাটি সম্পূর্ণ নয়। আপনি এটি সম্পাদনা করে এবং আমাদের কাছে থাকা ছবিগুলি থেকে আরও ডেটা যোগ করে এটি সম্পূর্ণ করতে সাহায্য করতে পারেন, অথবা <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> অথবা <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>এর জন্য সর্বজনীন Open Food Facts অ্যাপ ব্যবহার করে আরও ছবি তুলে। ধন্যবাদ!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -448,7 +448,7 @@ msgstr "বারকোড সংখ্যা"
 
 msgctxt "you_can_also_help_us"
 msgid "You can also help to fund the Open Food Facts project"
-msgstr "আপনি ওপেন ফুড ফ্যাক্টস প্রকল্পটি তহবিল করতে সহায়তা করতে পারেন"
+msgstr "আপনি Open Food Facts প্রকল্পটি তহবিল করতে সহায়তা করতে পারেন"
 
 msgctxt "producers_administration_manual"
 msgid "Producers Admin manual"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4705,7 +4700,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "নিউট্রি-স্কোর প্রযোজ্য নয়"
+msgstr "Nutri-Score প্রযোজ্য নয়"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4939,7 +4934,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "গ্রিন-স্কোর হল A+ থেকে F পর্যন্ত একটি পরিবেশগত স্কোর যা পরিবেশের উপর খাদ্য পণ্যের প্রভাব তুলনা করা সহজ করে তোলে।"
+msgstr "Green-Score হল A+ থেকে F পর্যন্ত একটি পরিবেশগত স্কোর যা পরিবেশের উপর খাদ্য পণ্যের প্রভাব তুলনা করা সহজ করে তোলে।"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4952,7 +4947,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "গ্রিন-স্কোর হল A+ থেকে F পর্যন্ত একটি পরিবেশগত স্কোর যা পরিবেশের উপর খাদ্য পণ্যের প্রভাব তুলনা করা সহজ করে তোলে।"
+msgstr "Green-Score হল A+ থেকে F পর্যন্ত একটি পরিবেশগত স্কোর যা পরিবেশের উপর খাদ্য পণ্যের প্রভাব তুলনা করা সহজ করে তোলে।"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5876,7 +5871,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "গ্রিন-স্কোর প্রাথমিকভাবে ফ্রান্সের জন্য তৈরি করা হয়েছিল এবং এটি অন্যান্য ইউরোপীয় দেশগুলিতে সম্প্রসারিত হচ্ছে। গ্রিন-স্কোর সূত্রটি পরিবর্তন সাপেক্ষে কারণ এটি নিয়মিতভাবে উন্নত করা হচ্ছে যাতে এটি আরও সুনির্দিষ্ট এবং প্রতিটি দেশের জন্য আরও উপযুক্ত হয়।"
+msgstr "Green-Score প্রাথমিকভাবে ফ্রান্সের জন্য তৈরি করা হয়েছিল এবং এটি অন্যান্য ইউরোপীয় দেশগুলিতে সম্প্রসারিত হচ্ছে। Green-Score সূত্রটি পরিবর্তন সাপেক্ষে কারণ এটি নিয়মিতভাবে উন্নত করা হচ্ছে যাতে এটি আরও সুনির্দিষ্ট এবং প্রতিটি দেশের জন্য আরও উপযুক্ত হয়।"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6532,7 +6527,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "এই পণ্যের জন্য আমাদের কাছে যে বিভাগটি আছে তা গ্রিন-স্কোর গণনা করার জন্য যথেষ্ট সুনির্দিষ্ট নয়। আপনি কি আরও সুনির্দিষ্ট পণ্য বিভাগ যোগ করতে পারেন?"
+msgstr "এই পণ্যের জন্য আমাদের কাছে যে বিভাগটি আছে তা Green-Score গণনা করার জন্য যথেষ্ট সুনির্দিষ্ট নয়। আপনি কি আরও সুনির্দিষ্ট পণ্য বিভাগ যোগ করতে পারেন?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7671,7 +7666,7 @@ msgstr "এই ছবিটি আমাদের মডারেটরদের
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "নিউট্রি-স্কোর গণনা করার জন্য আমাদের কাছে পরিবেশন আকারের মান এবং/অথবা একক অনুপস্থিত।"
+msgstr "Nutri-Score গণনা করার জন্য আমাদের কাছে পরিবেশন আকারের মান এবং/অথবা একক অনুপস্থিত।"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
@@ -7773,7 +7768,7 @@ msgstr "অবাঞ্ছিত উপাদান"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "এই পছন্দটি ওপেন ফুড ফ্যাক্টসের উপাদান তালিকার বোঝার উপর ভিত্তি করে এবং সঠিক নাও হতে পারে, সর্বদা নিজেই পণ্যটি পরীক্ষা করে দেখুন।"
+msgstr "এই পছন্দটি Open Food Factsের উপাদান তালিকার বোঝার উপর ভিত্তি করে এবং সঠিক নাও হতে পারে, সর্বদা নিজেই পণ্যটি পরীক্ষা করে দেখুন।"
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7801,7 +7796,7 @@ msgstr "আমরা সনাক্ত করতে পারিনি: {unwant
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "এই পছন্দগুলি ওপেন ফুড ফ্যাক্টসের উপাদান তালিকার বোঝার উপর ভিত্তি করে তৈরি এবং সর্বদা এটি সঠিক বা সম্পূর্ণ নাও হতে পারে, সর্বদা নিজেই পণ্যটি পরীক্ষা করে দেখুন।"
+msgstr "এই পছন্দগুলি Open Food Factsের উপাদান তালিকার বোঝার উপর ভিত্তি করে তৈরি এবং সর্বদা এটি সঠিক বা সম্পূর্ণ নাও হতে পারে, সর্বদা নিজেই পণ্যটি পরীক্ষা করে দেখুন।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/bo.po
+++ b/po/common/bo.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/br.po
+++ b/po/common/br.po
@@ -9,7 +9,7 @@ msgstr ""
 "Last-Translator: \n"
 "POT-Creation-Date: \n"
 "X-Generator: Poedit 2.1\n"
-"Plural-Forms: nplurals=5; plural=(n%10==1 && (n%100!=11 || n%100!=71 || n%100!=91) ? 0 : n%10==2 && (n%100!=12 || n%100!=72 || n%100!=92) ? 1 : ((n%10>=3 && n%10<=4) || n%10==9) && ((n%100 < 10 || n%100 > 19) || (n%100 < 70 || n%100 > 79) || (n%100 < 90 || n%100 > 99)) ? 2 : (n!=0 && n%1;\n"
+"Plural-Forms: nplurals=5; plural=(n%10==1 && n%100!=11 && n%100!=71 && n%100!=91 ? 0 : n%10==2 && n%100!=12 && n%100!=72 && n%100!=92 ? 1 : (n%10==3 || n%10==4 || n%10==9) && n%100!=13 && n%100!=14 && n%100!=19 && n%100!=73 && n%100!=74 && n%100!=79 && n%100!=93 && n%100!=94 && n%100!=99 ? 2 : n%1000000==0 && n!=0 ? 3 : 4);\n"
 "X-Crowdin-Project: openfoodfacts\n"
 "X-Crowdin-Project-ID: 243092\n"
 "X-Crowdin-Language: br-FR\n"
@@ -63,7 +63,7 @@ msgstr "hag ar strollad Facebook <a href=\"https://www.facebook.com/groups/OpenB
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Digeriñ klask produioù Beauty Facts"
+msgstr "Digeriñ klask produioù Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language

--- a/po/common/bs.po
+++ b/po/common/bs.po
@@ -154,7 +154,7 @@ msgstr "Kolaborativna, besplatna i otvorena baza podataka o sastojcima, nutritiv
 
 msgctxt "tagline_opff"
 msgid "Open Pet Food Facts gathers information and data on pet food products from around the world."
-msgstr "Open Products Facts prikuplja informacije i podatke o širokom spektru proizvoda za kućne ljubimce iz cijelog svijeta."
+msgstr "Open Pet Food Facts prikuplja informacije i podatke o širokom spektru proizvoda za kućne ljubimce iz cijelog svijeta."
 
 msgctxt "footer_tagline_opff"
 msgid "A collaborative, free and open database of pet food products from around the world."
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Zeleni rezultat je ekološka ocjena od A+ do F koja olakšava poređenje utjecaja prehrambenih proizvoda na okoliš."
+msgstr "Green-Score je ekološka ocjena od A+ do F koja olakšava poređenje utjecaja prehrambenih proizvoda na okoliš."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Zeleni rezultat je ekološka ocjena od A+ do F koja olakšava poređenje utjecaja prehrambenih proizvoda na okoliš."
+msgstr "Green-Score je ekološka ocjena od A+ do F koja olakšava poređenje utjecaja prehrambenih proizvoda na okoliš."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Zeleni rezultat je prvobitno razvijen za Francusku, a proširuje se i na druge evropske zemlje. Formula Zelenog rezultata podložna je promjenama jer se redovno poboljšava kako bi bila preciznija i bolje prilagođena svakoj zemlji."
+msgstr "Green-Score je prvobitno razvijen za Francusku, a proširuje se i na druge evropske zemlje. Formula Green-Score podložna je promjenama jer se redovno poboljšava kako bi bila preciznija i bolje prilagođena svakoj zemlji."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."

--- a/po/common/ca.po
+++ b/po/common/ca.po
@@ -1767,11 +1767,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Grau de nutrició"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4976,7 +4971,7 @@ msgstr "El Green-Score és una puntuació ambiental de la A+ a la F que facilita
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Eco-puntuació %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5549,7 +5544,7 @@ msgstr "El Green-Score encara no és aplicable per a aquesta categoria, però es
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Puntuació ecològica no calculada"
+msgstr "Green-Score no calculada"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5703,7 +5698,7 @@ msgstr "Si sou el fabricant d'aquest producte, podeu enviar-nos la informació a
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "Advertiment: no es proporciona part de la informació necessària per calcular la puntuació ecològica amb precisió (vegeu els detalls del càlcul a continuació)."
+msgstr "Advertiment: no es proporciona part de la informació necessària per calcular la Green-Score amb precisió (vegeu els detalls del càlcul a continuació)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -6551,7 +6546,7 @@ msgstr "Podries afegir una categoria del producte més precisa perquè puguem ca
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "La categoria que tenim per a aquest producte no és prou precisa per calcular la puntuació verda. Podríeu afegir una categoria de producte més precisa?"
+msgstr "La categoria que tenim per a aquest producte no és prou precisa per calcular la Green-Score. Podríeu afegir una categoria de producte més precisa?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/ce.po
+++ b/po/common/ce.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/chr.po
+++ b/po/common/chr.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/co.po
+++ b/po/common/co.po
@@ -63,7 +63,7 @@ msgstr "è u gruppu Facebook <a href=\"https://www.facebook.com/groups/OpenBeaut
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Apri a ricerca di prudutti di bellezza"
+msgstr "Apri a ricerca di Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language

--- a/po/common/common.pot
+++ b/po/common/common.pot
@@ -1765,11 +1765,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/crs.po
+++ b/po/common/crs.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/cs.po
+++ b/po/common/cs.po
@@ -63,7 +63,7 @@ msgstr "a facebooková skupina <a href=\"https://www.facebook.com/groups/OpenBea
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Hledání produktů na Open Products Facts"
+msgstr "Hledání produktů na Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1760,11 +1760,6 @@ msgstr "Nutriční hodnoty"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Výživová hodnota"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4719,7 +4714,7 @@ msgstr "Chybějící data pro výpočet Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Nutriční skóre se nepoužije"
+msgstr "Nutri-Score se nepoužije"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4945,11 +4940,11 @@ msgstr "Životní prostředí"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "Eco-score"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "Nízký dopad na životní prostředí (Eko-skóre)"
+msgstr "Nízký dopad na životní prostředí (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
@@ -4958,11 +4953,11 @@ msgstr "Green-Score je environmentální skóre od A+ do F, které usnadňuje po
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "Eco-score"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "Nízký dopad na životní prostředí (Eko-skóre)"
+msgstr "Nízký dopad na životní prostředí (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
@@ -5209,19 +5204,19 @@ msgstr "Chybějící nutriční hodnoty u připraveného produktu"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "Eco-score"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "Eco-score"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "Eco-score"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "Eco-score"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5544,7 +5539,7 @@ msgstr "Green-Score ještě není pro tuto kategorii použitelný, ale pracujeme
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Eko-skóre není vypočítáno"
+msgstr "Green-Score není vypočítáno"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5698,7 +5693,7 @@ msgstr "Pokud jste výrobcem tohoto produktu, můžete nám zaslat informace pro
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "Upozornění: Některé informace potřebné k přesnému výpočtu Eco-score nejsou poskytnuty (viz podrobnosti výpočtu níže)."
+msgstr "Upozornění: Některé informace potřebné k přesnému výpočtu Green-Score nejsou poskytnuty (viz podrobnosti výpočtu níže)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5858,7 +5853,7 @@ msgstr "Pro přesnější výpočet Green-Score můžete upravit stránku produk
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "Pro přesnější výpočet Eko-skóre můžete upravit stránku produktu a přidat je."
+msgstr "Pro přesnější výpočet Green-Score můžete upravit stránku produktu a přidat je."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -6488,7 +6483,7 @@ msgstr "Zrušit výběr obrázku"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Děkujeme"
+msgstr "Zjistěte více o Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"

--- a/po/common/cv.po
+++ b/po/common/cv.po
@@ -63,7 +63,7 @@ msgstr "тата <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">Ф
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Beauty Facts продукт шыравне уҫӑр"
+msgstr "Open Beauty Facts продукт шыравне уҫӑр"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language

--- a/po/common/cy.po
+++ b/po/common/cy.po
@@ -63,7 +63,7 @@ msgstr "a'r grŵp Facebook <a href=\"https://www.facebook.com/groups/OpenBeautyF
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Chwilio cynnyrch Ffeithiau Harddwch Agored"
+msgstr "Chwilio cynnyrch Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4705,7 +4700,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Sgôr Maeth ddim yn berthnasol"
+msgstr "Nutri-Score ddim yn berthnasol"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4939,7 +4934,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Sgôr amgylcheddol o A+ i F yw'r Sgôr Gwyrdd sy'n ei gwneud hi'n hawdd cymharu effaith cynhyrchion bwyd ar yr amgylchedd."
+msgstr "Sgôr amgylcheddol o A+ i F yw'r Green-Score sy'n ei gwneud hi'n hawdd cymharu effaith cynhyrchion bwyd ar yr amgylchedd."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4952,7 +4947,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Sgôr amgylcheddol o A+ i F yw'r Sgôr Gwyrdd sy'n ei gwneud hi'n hawdd cymharu effaith cynhyrchion bwyd ar yr amgylchedd."
+msgstr "Sgôr amgylcheddol o A+ i F yw'r Green-Score sy'n ei gwneud hi'n hawdd cymharu effaith cynhyrchion bwyd ar yr amgylchedd."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5876,7 +5871,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Datblygwyd y Sgôr Werdd yn wreiddiol ar gyfer Ffrainc ac mae'n cael ei hymestyn i wledydd Ewropeaidd eraill. Mae fformiwla'r Sgôr Werdd yn destun newid wrth iddi gael ei gwella'n rheolaidd i'w gwneud yn fwy manwl gywir ac yn fwy addas i bob gwlad."
+msgstr "Datblygwyd y Green-Score yn wreiddiol ar gyfer Ffrainc ac mae'n cael ei hymestyn i wledydd Ewropeaidd eraill. Mae fformiwla'r Green-Score yn destun newid wrth iddi gael ei gwella'n rheolaidd i'w gwneud yn fwy manwl gywir ac yn fwy addas i bob gwlad."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6532,7 +6527,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Nid yw'r categori sydd gennym ar gyfer y cynnyrch hwn yn ddigon manwl gywir i gyfrifo'r Sgôr Werdd. A allech chi ychwanegu categori cynnyrch mwy manwl gywir?"
+msgstr "Nid yw'r categori sydd gennym ar gyfer y cynnyrch hwn yn ddigon manwl gywir i gyfrifo'r Green-Score. A allech chi ychwanegu categori cynnyrch mwy manwl gywir?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7671,7 +7666,7 @@ msgstr "Adroddwch y ddelwedd hon i'n cymedrolwyr"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Mae gwerth a/neu uned maint y dogn ar goll i gyfrifo'r Sgôr Maeth"
+msgstr "Mae gwerth a/neu uned maint y dogn ar goll i gyfrifo'r Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/da.po
+++ b/po/common/da.po
@@ -1765,11 +1765,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Ernæringskvalitet"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -2974,11 +2969,11 @@ msgstr "Enhed"
 
 msgctxt "nova_groups_s"
 msgid "NOVA group"
-msgstr "Nova-gruppe"
+msgstr "NOVA-gruppe"
 
 msgctxt "nova_groups_p"
 msgid "NOVA groups"
-msgstr "Nova-grupper"
+msgstr "NOVA-grupper"
 
 # Title for the link to the explanation of what a NOVA Group is
 msgctxt "nova_groups_info"
@@ -3999,7 +3994,7 @@ msgstr "Denne tabel viser muligheder for forbedring af ernæringskvaliteten, Nut
 
 msgctxt "improvements_facet_description_2"
 msgid "In order to get relevant results, please make sure the product data is complete (nutrition facts with values for fiber and fruits and vegetables to compute the Nutri-Score, and a precise category to compare each product to similar products)."
-msgstr "For at opnå relevante resultater, så sørg for, at produktdataene er komplette (ernæringsfakta med værdier for fiber, frugt og grøntsager til beregning af Nutri-score, og en præcis kategori til sammenligning af hvert produkt med lignende produkter)."
+msgstr "For at opnå relevante resultater, så sørg for, at produktdataene er komplette (ernæringsfakta med værdier for fiber, frugt og grøntsager til beregning af Nutri-Score, og en præcis kategori til sammenligning af hvert produkt med lignende produkter)."
 
 # "product photos" in this sentence means photos for many products, not just one product
 msgctxt "import_photos_title"
@@ -4761,7 +4756,7 @@ msgstr "Fødevareforarbejdning"
 
 msgctxt "attribute_nova_name"
 msgid "NOVA group"
-msgstr "Nova-gruppe"
+msgstr "NOVA-gruppe"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
@@ -4823,7 +4818,7 @@ msgstr "Forespørgselsfilter"
 
 msgctxt "nova_group_producer"
 msgid "NOVA group"
-msgstr "Nova-gruppe"
+msgstr "NOVA-gruppe"
 
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
@@ -4948,7 +4943,7 @@ msgstr "Miljø"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "Øko-Score"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4961,7 +4956,7 @@ msgstr "Green-Score er en miljøscore fra A+ til F, som gør det nemt at sammenl
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "Øko-Score"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -5212,19 +5207,19 @@ msgstr "Manglende næringsindhold for færdiglavet produkt"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "Øko-Score"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "Øko-Score"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "Øko-Score"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "Øko-Score"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5543,7 +5538,7 @@ msgstr "Endnu ikke anvendelig for flg. kategori: {category}"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "Øko-Score endnu ikke anvendelig for denne kategori, men der arbejdes på at den bliver understøttet."
+msgstr "Green-Score endnu ikke anvendelig for denne kategori, men der arbejdes på at den bliver understøttet."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
@@ -6216,7 +6211,7 @@ msgstr "Pluspoint og negative point"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Øko-score for dette produkt"
+msgstr "Green-Score for dette produkt"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6491,11 +6486,11 @@ msgstr "Afmarér foto"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Tak"
+msgstr "Få mere at vide om Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "Få mere at vide om Øko-Score"
+msgstr "Få mere at vide om Green-Score"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6533,7 +6528,7 @@ msgstr "Brug standardpræferencer"
 
 msgctxt "reset_preferences_details"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "Nutri-Score, Øko-Score og fødevareforarbejdningsniveau (NOVA)"
+msgstr "Nutri-Score, Green-Score og fødevareforarbejdningsniveau (NOVA)"
 
 msgctxt "actions_add_ingredients"
 msgid "Could you add the ingredients list?"
@@ -6545,7 +6540,7 @@ msgstr "Kan du tilføje de nødvendige oplysninger til at beregne Nutri-Score?"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Kan du kategorisere produktet præcist, så Øko-Score kan beregnes?"
+msgstr "Kan du kategorisere produktet præcist, så Green-Score kan beregnes?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
@@ -7672,7 +7667,7 @@ msgstr "Økologisk landbrug og fair trade"
 
 msgctxt "reset_preferences_details_food"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "Nutri-Score, Øko-Score og fødevareforarbejdningsniveau (NOVA)"
+msgstr "Nutri-Score, Green-Score og fødevareforarbejdningsniveau (NOVA)"
 
 msgctxt "reset_preferences_details_product"
 msgid "Good repairability"
@@ -7688,7 +7683,7 @@ msgstr "Rapportér dette billede til vores moderatorer"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Vi mangler portionsstørrelsen og/eller enheden for at beregne næringsscoren."
+msgstr "Vi mangler portionsstørrelsen og/eller enheden for at beregne Nutri-Score."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/de.po
+++ b/po/common/de.po
@@ -1073,7 +1073,7 @@ msgstr "https://world-de.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "Open Food Fakten für Produzenten"
+msgstr "Open Food Facts für Produzenten"
 
 msgctxt "for"
 msgid "for"
@@ -1764,11 +1764,6 @@ msgstr "Nährwertqualitäten"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Nährwertqualität"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -2974,11 +2969,11 @@ msgstr "Einheit"
 
 msgctxt "nova_groups_s"
 msgid "NOVA group"
-msgstr "Nova-Gruppe"
+msgstr "NOVA-Gruppe"
 
 msgctxt "nova_groups_p"
 msgid "NOVA groups"
-msgstr "Nova-Gruppen"
+msgstr "NOVA-Gruppen"
 
 # Title for the link to the explanation of what a NOVA Group is
 msgctxt "nova_groups_info"
@@ -4761,7 +4756,7 @@ msgstr "Lebensmittelverarbeitung"
 
 msgctxt "attribute_nova_name"
 msgid "NOVA group"
-msgstr "Nova-Gruppe"
+msgstr "NOVA-Gruppe"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
@@ -4823,7 +4818,7 @@ msgstr "Abfragefilter"
 
 msgctxt "nova_group_producer"
 msgid "NOVA group"
-msgstr "Nova-Gruppe"
+msgstr "NOVA-Gruppe"
 
 msgctxt "error_unknown_org"
 msgid "Unknown organization."

--- a/po/common/el.po
+++ b/po/common/el.po
@@ -1765,11 +1765,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Διατροφικός βαθμός"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/en.po
+++ b/po/common/en.po
@@ -1766,11 +1766,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Nutrition grade"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/en_AU.po
+++ b/po/common/en_AU.po
@@ -1766,11 +1766,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Nutrition grade"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/en_GB.po
+++ b/po/common/en_GB.po
@@ -1766,11 +1766,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Nutrition grade"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/eo.po
+++ b/po/common/eo.po
@@ -63,7 +63,7 @@ msgstr "kaj la <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">Face
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Malfermu serĉon de produktoj pri Belecaj Faktoj"
+msgstr "Malfermu serĉon de produktoj pri Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -688,7 +688,7 @@ msgstr "Forigita:"
 
 msgctxt "donate"
 msgid "Donate to Open Food Facts"
-msgstr "Donacu al Malfermaj Manĝaĵoj"
+msgstr "Donacu al Open Food Facts"
 
 msgctxt "donate_link"
 msgid "https://world.openfoodfacts.org/donate-to-open-food-facts"
@@ -1065,7 +1065,7 @@ msgstr "https://wiki.openfoodfacts.org"
 # Do not translate Open Beauty Facts but do translate Cosmetics
 msgctxt "footer_obf"
 msgid "Open Beauty Facts - Cosmetics"
-msgstr "Malfermaj Belecaj Faktoj - Kosmetikaĵoj"
+msgstr "Open Beauty Facts - Kosmetikaĵoj"
 
 msgctxt "footer_obf_link"
 msgid "https://world.openbeautyfacts.org"
@@ -1073,7 +1073,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "Malfermaj Manĝaĵaj Faktoj por Produktantoj"
+msgstr "Open Food Facts por Produktantoj"
 
 msgctxt "for"
 msgid "for"
@@ -1756,7 +1756,7 @@ msgstr "La tabelo defaŭlte listigas nutraĵojn, kiuj ofte estas specifitaj. Las
 
 msgctxt "nutrition_data_table_asterisk"
 msgid "Essential nutrients to calculate the Nutri-Score."
-msgstr "Esencaj nutraĵoj por kalkuli la Nutri-Poentaron."
+msgstr "Esencaj nutraĵoj por kalkuli la Nutri-Score."
 
 msgctxt "nutrition_grades_p"
 msgid "Nutrition grades"
@@ -1765,11 +1765,6 @@ msgstr ""
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -2904,7 +2899,7 @@ msgstr "Niaj tradukistoj"
 
 msgctxt "translators_lead"
 msgid "We would like to say THANK YOU to the awesome translators that make it possible to present Open Food Facts, Open Beauty Facts, and Open Pet Food Facts to you in all these different languages! <a href=\"https://translate.openfoodfacts.org/\">You can join us in this global effort: it doesn't require any technical knowledge.</a>"
-msgstr "Ni ŝatus diri DANKON al la mirindaj tradukistoj, kiuj ebligas prezenti Malfermajn Faktojn pri Manĝaĵoj, Malfermajn Faktojn pri Beleco, kaj Malfermajn Faktojn pri Dorlotbesta Manĝaĵo al vi en ĉiuj ĉi tiuj diversaj lingvoj! <a href=\"https://translate.openfoodfacts.org/\">Vi povas aliĝi al ni en ĉi tiu tutmonda klopodo: ĝi ne postulas ian ajn teknikan scion.</a>"
+msgstr "Ni ŝatus diri DANKON al la mirindaj tradukistoj, kiuj ebligas prezenti Open Food Facts, Open Beauty Facts, kaj Open Pet Food Facts al vi en ĉiuj ĉi tiuj diversaj lingvoj! <a href=\"https://translate.openfoodfacts.org/\">Vi povas aliĝi al ni en ĉi tiu tutmonda klopodo: ĝi ne postulas ian ajn teknikan scion.</a>"
 
 msgctxt "translators_renewal_notice"
 msgid "Please note that this table is refreshed nightly and might be out of date."
@@ -4001,7 +3996,7 @@ msgstr "Ĉi tiu tabelo listigas eblajn ŝancojn plibonigi la nutran kvaliton, la
 
 msgctxt "improvements_facet_description_2"
 msgid "In order to get relevant results, please make sure the product data is complete (nutrition facts with values for fiber and fruits and vegetables to compute the Nutri-Score, and a precise category to compare each product to similar products)."
-msgstr "Por akiri koncernajn rezultojn, bonvolu certigi, ke la produktaj datumoj estas kompletaj (nutraj faktoj kun valoroj por fibro kaj fruktoj kaj legomoj por kalkuli la Nutri-Poentaron, kaj preciza kategorio por kompari ĉiun produkton kun similaj produktoj)."
+msgstr "Por akiri koncernajn rezultojn, bonvolu certigi, ke la produktaj datumoj estas kompletaj (nutraj faktoj kun valoroj por fibro kaj fruktoj kaj legomoj por kalkuli la Nutri-Score, kaj preciza kategorio por kompari ĉiun produkton kun similaj produktoj)."
 
 # "product photos" in this sentence means photos for many products, not just one product
 msgctxt "import_photos_title"
@@ -4070,15 +4065,15 @@ msgstr "Dosiero ricevita"
 
 msgctxt "nutriscore_calculation_details"
 msgid "Details of the calculation of the Nutri-Score"
-msgstr "Detaloj pri la kalkulado de la Nutri-Poentaro"
+msgstr "Detaloj pri la kalkulado de la Nutri-Score"
 
 msgctxt "nutriscore_is_beverage"
 msgid "This product is considered a beverage for the calculation of the Nutri-Score."
-msgstr "Ĉi tiu produkto estas konsiderata trinkaĵo por la kalkulado de la Nutri-Poentaro."
+msgstr "Ĉi tiu produkto estas konsiderata trinkaĵo por la kalkulado de la Nutri-Score."
 
 msgctxt "nutriscore_is_not_beverage"
 msgid "This product is not considered a beverage for the calculation of the Nutri-Score."
-msgstr "Ĉi tiu produkto ne estas konsiderata trinkaĵo por la kalkulado de la Nutri-Poentaro."
+msgstr "Ĉi tiu produkto ne estas konsiderata trinkaĵo por la kalkulado de la Nutri-Score."
 
 msgctxt "nutriscore_positive_points"
 msgid "Positive points"
@@ -4155,7 +4150,7 @@ msgstr "Nutra poentaro"
 # Do not translate
 msgctxt "nutriscore_grade"
 msgid "Nutri-Score"
-msgstr "Nutri-Poentaro"
+msgstr "Nutri-Score"
 
 # This is not the Nutri-Score grade with letters, but the Nutri-Score number score used to compute the grade. Translate score but not Nutri-Score.
 msgctxt "nutriscore_score_producer"
@@ -4165,7 +4160,7 @@ msgstr "Nutri-Score-poentaro"
 # Do not translate
 msgctxt "nutriscore_grade_producer"
 msgid "Nutri-Score"
-msgstr "Nutri-Poentaro"
+msgstr "Nutri-Score"
 
 # free as in not costing something
 msgctxt "donate_free_and_independent"
@@ -4197,7 +4192,7 @@ msgstr "Meza valoro por la kategorio %s"
 # Keep the %s
 msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
-msgstr "La Nutri-Poentaro povas esti ŝanĝita de %s al %s ŝanĝante la valoron %s de %s al %s (procenta diferenco%s )."
+msgstr "La Nutri-Score povas esti ŝanĝita de %s al %s ŝanĝante la valoron %s de %s al %s (procenta diferenco%s )."
 
 msgctxt "export_products_to_public_database_email"
 msgid "The platform for producers is still under development and we make manual checks before importing products to the public database. Please e-mail us at <a href=\"mailto:producers@openfoodfacts.org\">producers@openfoodfacts.org</a> to update the public database."
@@ -4573,7 +4568,7 @@ msgstr "Interna kodo uzata de la produktanto por identigi specifan version de pr
 
 msgctxt "categories_import_note"
 msgid "Providing a category is very important to make the product easy to search for, and to compute the Nutri-Score"
-msgstr "Provizi kategorion estas tre grave por faciligi la serĉadon de la produkto kaj por kalkuli la Nutri-Poentaron."
+msgstr "Provizi kategorion estas tre grave por faciligi la serĉadon de la produkto kaj por kalkuli la Nutri-Score."
 
 msgctxt "labels_import_note"
 msgid "Some labels such as the organic label are used to filter and/or rank search results, so it is strongly recommended to specify them."
@@ -4699,7 +4694,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_name"
 msgid "Nutri-Score"
-msgstr "Nutri-Poentaro"
+msgstr "Nutri-Score"
 
 msgctxt "attribute_nutriscore_setting_name"
 msgid "Good nutritional quality (Nutri-Score)"
@@ -4707,24 +4702,24 @@ msgstr "Bona nutra kvalito (Nutri-Score)"
 
 msgctxt "attribute_nutriscore_setting_note"
 msgid "The Nutri-Score is computed and can be taken into account for all products, even if is not displayed on the packaging."
-msgstr "La Nutri-Poentaro estas kalkulita kaj povas esti konsiderata por ĉiuj produktoj, eĉ se ne estas montrata sur la pakaĵo."
+msgstr "La Nutri-Score estas kalkulita kaj povas esti konsiderata por ĉiuj produktoj, eĉ se ne estas montrata sur la pakaĵo."
 
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "Nutri-Poentaro %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
-msgstr "Nutri-Poentaro nekonata"
+msgstr "Nutri-Score nekonata"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
 msgid "Missing data to compute the Nutri-Score"
-msgstr "Mankas datumoj por kalkuli la Nutri-Poentaron"
+msgstr "Mankas datumoj por kalkuli la Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Nutri-Poentaro ne aplikebla"
+msgstr "Nutri-Score ne aplikebla"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4837,19 +4832,19 @@ msgstr "Nekonata uzanto."
 
 msgctxt "attribute_low_salt_setting_note"
 msgid "The salt level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low salt diet."
-msgstr "La salnivelo estas konsiderata de la Nutri-Poentaro. Uzu ĉi tiun agordon nur se vi specife sekvas malalt-san dieton."
+msgstr "La salnivelo estas konsiderata de la Nutri-Score. Uzu ĉi tiun agordon nur se vi specife sekvas malalt-san dieton."
 
 msgctxt "attribute_low_sugars_setting_note"
 msgid "The sugars level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low sugars diet."
-msgstr "La sukernivelo estas konsiderata de la Nutri-Poentaro. Uzu ĉi tiun agordon nur se vi specife sekvas malalt-sukera dieton."
+msgstr "La sukernivelo estas konsiderata de la Nutri-Score. Uzu ĉi tiun agordon nur se vi specife sekvas malalt-sukera dieton."
 
 msgctxt "attribute_low_fat_setting_note"
 msgid "The fat level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low fat diet."
-msgstr "La grasnivelo estas konsiderata de la Nutri-Poentaro. Uzu ĉi tiun agordon nur se vi specife sekvas malaltgrasan dieton."
+msgstr "La grasnivelo estas konsiderata de la Nutri-Score. Uzu ĉi tiun agordon nur se vi specife sekvas malaltgrasan dieton."
 
 msgctxt "attribute_low_saturated_fat_setting_note"
 msgid "The saturated fat level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low saturated fat diet."
-msgstr "La nivelo de saturita graso estas konsiderata de la Nutri-Poentaro. Uzu ĉi tiun agordon nur se vi specife sekvas dieton kun malalta saturita graso."
+msgstr "La nivelo de saturita graso estas konsiderata de la Nutri-Score. Uzu ĉi tiun agordon nur se vi specife sekvas dieton kun malalta saturita graso."
 
 msgctxt "attribute_group_allergens_name"
 msgid "Allergens"
@@ -4950,33 +4945,33 @@ msgstr "Medio"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "Verda-Poentaro"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "Malalta media efiko (Verda-Poentaro)"
+msgstr "Malalta media efiko (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "La Verda Poentaro estas media poentaro de A+ ĝis F, kiu faciligas kompari la efikon de nutraĵoj sur la medion."
+msgstr "La Green-Score estas media poentaro de A+ ĝis F, kiu faciligas kompari la efikon de nutraĵoj sur la medion."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "Verda-Poentaro"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "Malalta media efiko (Verda-Poentaro)"
+msgstr "Malalta media efiko (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "La Verda Poentaro estas media poentaro de A+ ĝis F, kiu faciligas kompari la efikon de nutraĵoj sur la medion."
+msgstr "La Green-Score estas media poentaro de A+ ĝis F, kiu faciligas kompari la efikon de nutraĵoj sur la medion."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Verda-Poentaro %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5162,22 +5157,22 @@ msgstr "Media efiko"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "Verda-Score-poentaro"
+msgstr "Green-Score"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "Verda-Poentara grado"
+msgstr "Green-Score grado"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "Detaloj pri la kalkulo de la Verda-Poentaro"
+msgstr "Detaloj pri la kalkulo de la Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "Informoj pri la Verda-Poentaro"
+msgstr "Informoj pri la Green-Score"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5214,19 +5209,19 @@ msgstr "Mankas nutraj informoj por preta produkto"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "Verda-Poentaro"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "Verda-Poentaro"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "Verda-Poentaro"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "Verda-Poentaro"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5474,11 +5469,11 @@ msgstr "Plej multaj skanitaj produktoj"
 
 msgctxt "sort_by_nutriscore_score"
 msgid "Products with the best Nutri-Score"
-msgstr "Produktoj kun la plej bona Nutri-Poentaro"
+msgstr "Produktoj kun la plej bona Nutri-Score"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "Produktoj kun la plej bona Verda Poentaro"
+msgstr "Produktoj kun la plej bona Green-Score"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5532,7 +5527,7 @@ msgstr "Uzanto estas forigata. Tio povas daŭri kelkajn minutojn."
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "Verda-Poentaro ne aplikebla"
+msgstr "Green-Score ne aplikebla"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5545,11 +5540,11 @@ msgstr "Ankoraŭ ne aplikebla por la kategorio: {category}"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "La Verda Poentaro ankoraŭ ne aplikeblas por ĉi tiu kategorio, sed ni laboras por aldoni subtenon por ĝi."
+msgstr "La Green-Score ankoraŭ ne aplikeblas por ĉi tiu kategorio, sed ni laboras por aldoni subtenon por ĝi."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Verda-Poentaro ne kalkulita"
+msgstr "Green-Score ne kalkulita"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5561,7 +5556,7 @@ msgstr "Mankas preciza kategorio"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "Ni ne povis kalkuli la Verdan Poentaron de ĉi tiu produkto ĉar al ĝi mankas iuj datumoj, ĉu vi povus helpi kompletigi ĝin?"
+msgstr "Ni ne povis kalkuli la Green-Score de ĉi tiu produkto ĉar al ĝi mankas iuj datumoj, ĉu vi povus helpi kompletigi ĝin?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5691,7 +5686,7 @@ msgstr "La arbara spuro estas kalkulata per konsidero de la ingrediencoj, kies p
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "La Verda Poentaro povas esti kalkulita nur se la produkto havas sufiĉe precizan kategorion."
+msgstr "La Green-Score povas esti kalkulita nur se la produkto havas sufiĉe precizan kategorion."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5703,7 +5698,7 @@ msgstr "Se vi estas la fabrikanto de ĉi tiu produkto, vi povas sendi al ni la i
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "Averto: iuj informoj necesaj por precize kalkuli la Verdan Poentaron ne estas provizitaj (vidu la detalojn de la kalkulo sube)."
+msgstr "Averto: iuj informoj necesaj por precize kalkuli la Green-Score ne estas provizitaj (vidu la detalojn de la kalkulo sube)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5858,12 +5853,12 @@ msgstr "La informoj pri la pakaĵo de ĉi tiu produkto ne estas sufiĉe precizaj
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "Por pli preciza kalkulo de la Verda-Poentaro, vi povas modifi la produktan paĝon kaj aldoni ilin."
+msgstr "Por pli preciza kalkulo de la Green-Score, vi povas modifi la produktan paĝon kaj aldoni ilin."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "Por pli preciza kalkulo de la Verda-Poentaro, vi povas redakti la produktan paĝon kaj aldoni ilin."
+msgstr "Por pli preciza kalkulo de la Green-Score, vi povas redakti la produktan paĝon kaj aldoni ilin."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5885,7 +5880,7 @@ msgstr "Se vi estas la fabrikanto de ĉi tiu produkto, vi povas sendi al ni la i
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "La <a href=\"/green-score\">Verda-Poentaro</a> estas eksperimenta poentaro kiu resumas la mediajn efikojn de nutraĵproduktoj."
+msgstr "La <a href=\"/green-score\">Green-Score</a> estas eksperimenta poentaro kiu resumas la mediajn efikojn de nutraĵproduktoj."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
@@ -5895,7 +5890,7 @@ msgstr "La formulo de Green-Score povas ŝanĝiĝi, ĉar ĝi estas regule plibon
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "La Verda Poentaro estis komence evoluigita por Francio kaj ĝi estas etendita al aliaj eŭropaj landoj. La formulo de la Verda Poentaro povas ŝanĝiĝi, ĉar ĝi estas regule plibonigata por igi ĝin pli preciza kaj pli taŭga por ĉiu lando."
+msgstr "La Green-Score estis komence evoluigita por Francio kaj ĝi estas etendita al aliaj eŭropaj landoj. La formulo de la Green-Score povas ŝanĝiĝi, ĉar ĝi estas regule plibonigata por igi ĝin pli preciza kaj pli taŭga por ĉiu lando."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -5907,7 +5902,7 @@ msgstr "La plena efiko de transportado al via lando estas nuntempe nekonata."
 
 msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Green-Score and more!"
-msgstr "Skanu strekkodojn por ricevi la Nutri-Poentaron, la Verdan-Poentaron kaj pli!"
+msgstr "Skanu strekkodojn por ricevi la Nutri-Score, la Green-Score kaj pli!"
 
 msgctxt "org_gs1_product_name_is_abbreviated"
 msgid "GS1 product names for this manufacturer are abbreviated."
@@ -5981,7 +5976,7 @@ msgstr "meza"
 
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
-msgstr "Noto: la Nutri-Poentaro de teoj kaj herbaj teoj respondas al la produkto preparita nur kun akvo, sen sukero aŭ lakto."
+msgstr "Noto: la Nutri-Score de teoj kaj herbaj teoj respondas al la produkto preparita nur kun akvo, sen sukero aŭ lakto."
 
 msgctxt "g_per_100g"
 msgid "%s g / 100 g"
@@ -6218,7 +6213,7 @@ msgstr "Gratifikoj kaj malbonusoj"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Verda Poentaro por ĉi tiu produkto"
+msgstr "Green-Score por ĉi tiu produkto"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6250,11 +6245,11 @@ msgstr "Nutri-Score ne aplikeblas por ĉi tiu produkta kategorio."
 
 msgctxt "nutriscore_missing_category"
 msgid "The category of the product must be specified in order to compute the Nutri-Score."
-msgstr "La kategorio de la produkto devas esti specifita por kalkuli la Nutri-Poentaron."
+msgstr "La kategorio de la produkto devas esti specifita por kalkuli la Nutri-Score."
 
 msgctxt "nutriscore_missing_nutrition_data"
 msgid "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
-msgstr "La nutraj informoj de la produkto devas esti specifitaj por kalkuli la Nutri-Poentaron."
+msgstr "La nutraj informoj de la produkto devas esti specifitaj por kalkuli la Nutri-Score."
 
 msgctxt "nutriscore_missing_nutrition_data_details"
 msgid "Missing nutrition facts:"
@@ -6266,7 +6261,7 @@ msgstr "Mankas nutraj informoj por la preta produkto:"
 
 msgctxt "nutriscore_missing_category_and_nutrition_data"
 msgid "The category and the nutrition facts of the product must be specified in order to compute the Nutri-Score."
-msgstr "La kategorio kaj la nutraj informoj de la produkto devas esti specifitaj por kalkuli la Nutri-Poentaron."
+msgstr "La kategorio kaj la nutraj informoj de la produkto devas esti specifitaj por kalkuli la Nutri-Score."
 
 msgctxt "health"
 msgid "Health"
@@ -6497,7 +6492,7 @@ msgstr ""
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "Lernu pli pri la Verda-Poentaro"
+msgstr "Lernu pli pri la Green-Score"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6543,15 +6538,15 @@ msgstr "Ĉu vi povus aldoni la liston de ingrediencoj?"
 
 msgctxt "actions_to_compute_nutriscore"
 msgid "Could you add the information needed to compute the Nutri-Score?"
-msgstr "Ĉu vi povus aldoni la informojn necesajn por kalkuli la Nutri-Poentaron?"
+msgstr "Ĉu vi povus aldoni la informojn necesajn por kalkuli la Nutri-Score?"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Ĉu vi povus aldoni precizan produktan kategorion por ke ni povu kalkuli la Verdan Poentaron?"
+msgstr "Ĉu vi povus aldoni precizan produktan kategorion por ke ni povu kalkuli la Green-Score?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "La kategorio, kiun ni havas por ĉi tiu produkto, ne estas sufiĉe preciza por kalkuli la Verdan Poentaron. Ĉu vi povus aldoni pli precizan produktokategorion?"
+msgstr "La kategorio, kiun ni havas por ĉi tiu produkto, ne estas sufiĉe preciza por kalkuli la Green-Score. Ĉu vi povus aldoni pli precizan produktokategorion?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7136,11 +7131,11 @@ msgstr "Foresto"
 
 msgctxt "nutriscore_is_water"
 msgid "This product is considered to be water for the calculation of the Nutri-Score."
-msgstr "Ĉi tiu produkto estas konsiderata akvo por la kalkulado de la Nutri-Poentaro."
+msgstr "Ĉi tiu produkto estas konsiderata akvo por la kalkulado de la Nutri-Score."
 
 msgctxt "nutriscore_is_fat_oil_nuts_seeds"
 msgid "This product is considered to be fat, oil, nuts or seeds for the calculation of the Nutri-Score."
-msgstr "Ĉi tiu produkto estas konsiderata kiel graso, oleo, nuksoj aŭ semoj por la kalkulo de la Nutri-Poentaro."
+msgstr "Ĉi tiu produkto estas konsiderata kiel graso, oleo, nuksoj aŭ semoj por la kalkulo de la Nutri-Score."
 
 msgctxt "nutriscore_is_cheese"
 msgid "This product is considered to be cheese for the calculation of the Nutri-Score."
@@ -7148,7 +7143,7 @@ msgstr "Ĉi tiu produkto estas konsiderata fromaĝo por la kalkulado de la Nutri
 
 msgctxt "nutriscore_is_red_meat_product"
 msgid "This product is considered to be a red meat product for the calculation of the Nutri-Score."
-msgstr "Ĉi tiu produkto estas konsiderata ruĝvianda produkto por la kalkulo de la Nutri-Poentaro."
+msgstr "Ĉi tiu produkto estas konsiderata ruĝvianda produkto por la kalkulo de la Nutri-Score."
 
 msgctxt "nutriscore_count_proteins_reason_beverage"
 msgid "Points for proteins are counted because the product is considered to be a beverage."
@@ -7180,7 +7175,7 @@ msgstr "Malkovru la novan Nutri-Score!"
 
 msgctxt "nutriscore_new_computation_description"
 msgid "<p>The computation of the Nutri-Score is evolving to provide better recommendations based on the latest scientific evidence.</p><p>Main improvements:</p><ul><li>Better score for some fatty fish and oils rich in good fats</li><li>Better score for whole products rich in fiber</li><li>Worse score for products containing a lot of salt or sugar</li><li>Worse score for red meat (compared to poultry)</li></ul>"
-msgstr "<p>La kalkulado de la Nutri-Poentaro evoluas por provizi pli bonajn rekomendojn bazitajn sur la plej novaj sciencaj pruvoj.</p><p>Ĉefaj plibonigoj:</p><ul><li>Pli bona poentaro por iuj grasaj fiŝoj kaj oleoj riĉaj je bonaj grasoj</li><li>Pli bona poentaro por tutaj produktoj riĉaj je fibro</li><li>Pli malbona poentaro por produktoj enhavantaj multe da salo aŭ sukero</li><li>Pli malbona poentaro por ruĝa viando (kompare kun kokaĵo)</li></ul>"
+msgstr "<p>La kalkulado de la Nutri-Score evoluas por provizi pli bonajn rekomendojn bazitajn sur la plej novaj sciencaj pruvoj.</p><p>Ĉefaj plibonigoj:</p><ul><li>Pli bona poentaro por iuj grasaj fiŝoj kaj oleoj riĉaj je bonaj grasoj</li><li>Pli bona poentaro por tutaj produktoj riĉaj je fibro</li><li>Pli malbona poentaro por produktoj enhavantaj multe da salo aŭ sukero</li><li>Pli malbona poentaro por ruĝa viando (kompare kun kokaĵo)</li></ul>"
 
 msgctxt "nutriscore_new_computation_link_text"
 msgid "Discover all the improvements of the new Nutri-Score"
@@ -7188,7 +7183,7 @@ msgstr "Malkovru ĉiujn plibonigojn de la nova Nutri-Score"
 
 msgctxt "nutriscore_explanation_what_it_is"
 msgid "The Nutri-Score is a logo on the overall nutritional quality of products."
-msgstr "La Nutri-Poentaro estas emblemo pri la ĝenerala nutra kvalito de produktoj."
+msgstr "La Nutri-Score estas emblemo pri la ĝenerala nutra kvalito de produktoj."
 
 msgctxt "nutriscore_explanation_what_it_takes_into_account"
 msgid "The score from A to E is calculated based on nutrients and foods to favor (proteins, fiber, fruits, vegetables and legumes ...) and nutrients to limit (calories, saturated fat, sugars, salt)."
@@ -7204,7 +7199,7 @@ msgstr "La montrado de ĉi tiu emblemo estas rekomendata de publikasanaj aŭtori
 
 msgctxt "nutriscore_explanation_title"
 msgid "What is the Nutri-Score?"
-msgstr "Kio estas la Nutri-Poentaro?"
+msgstr "Kio estas la Nutri-Score?"
 
 msgctxt "nutrient_info_energy_risk"
 msgid "Energy intakes above energy requirements are associated with increased risks of weight gain, overweight, obesity, and consequently risk of diet-related chronic diseases."
@@ -7690,7 +7685,7 @@ msgstr "Raporti ĉi tiun bildon al niaj moderigantoj"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Mankas al ni la valoro de la porcio kaj/aŭ unuo por kalkuli la Nutri-Poentaron."
+msgstr "Mankas al ni la valoro de la porcio kaj/aŭ unuo por kalkuli la Nutri-Score."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/es.po
+++ b/po/common/es.po
@@ -166,7 +166,7 @@ msgstr "Ingredientes, alérgenos, aditivos, información nutricional, etiquetado
 
 msgctxt "search_description_opensearch_opff"
 msgid "Open Pet Food Facts product search"
-msgstr "Búsqueda de productos en Open Pets Food Facts"
+msgstr "Búsqueda de productos en Open Pet Food Facts"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1764,11 +1764,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Grado de nutrición"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -2973,11 +2968,11 @@ msgstr "Unidad"
 
 msgctxt "nova_groups_s"
 msgid "NOVA group"
-msgstr "Grupo Nova"
+msgstr "Grupo NOVA"
 
 msgctxt "nova_groups_p"
 msgid "NOVA groups"
-msgstr "Grupos Nova"
+msgstr "Grupos NOVA"
 
 # Title for the link to the explanation of what a NOVA Group is
 msgctxt "nova_groups_info"
@@ -4700,7 +4695,7 @@ msgstr "Nutri-Score"
 
 msgctxt "attribute_nutriscore_setting_name"
 msgid "Good nutritional quality (Nutri-Score)"
-msgstr "Buena información nutricional (Nutri-score)"
+msgstr "Buena información nutricional (Nutri-Score)"
 
 msgctxt "attribute_nutriscore_setting_note"
 msgid "The Nutri-Score is computed and can be taken into account for all products, even if is not displayed on the packaging."
@@ -4760,7 +4755,7 @@ msgstr "Procesamiento de alimentos"
 
 msgctxt "attribute_nova_name"
 msgid "NOVA group"
-msgstr "Grupo Nova"
+msgstr "Grupo NOVA"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
@@ -4822,7 +4817,7 @@ msgstr "Filtro de consulta"
 
 msgctxt "nova_group_producer"
 msgid "NOVA group"
-msgstr "Grupo Nova"
+msgstr "Grupo NOVA"
 
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
@@ -5666,7 +5661,7 @@ msgstr "La información y datos sobre porcentajes %s provienen de %s."
 
 msgctxt "data_source_database_note_about_the_producers_platform"
 msgid "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_url>\">free plaform for producers</a> to access and complete this data, and to obtain reports, analysis and product improvements opportunities (e.g. better Nutri-Score)."
-msgstr "Los fabricantes o comercializadores pueden utilizar la <a href=\"<producers_platform_url>\"> para que los productores</a> complementen la información del producto y tengan acceso a informes, análisis e indicadores que ofrezcan oportunidades de mejora continua de su productos (por ejemplo: Obtener mejor Nutri-Score)."
+msgstr "Los fabricantes o comercializadores pueden utilizar la plataforma de Open Food Facts <a href=\"<producers_platform_url>\"> para que los productores</a> complementen la información del producto y tengan acceso a informes, análisis e indicadores que ofrezcan oportunidades de mejora continua de su productos (por ejemplo: Obtener mejor Nutri-Score)."
 
 # variable names between { } must not be translated
 msgctxt "f_data_source_database_provider"
@@ -5855,12 +5850,12 @@ msgstr "La información sobre el envase de este producto no está suficientement
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "Para un cálculo más preciso de la puntuación ecológica, puede modificar la página del producto y añadirlas."
+msgstr "Para un cálculo más preciso de la Green-Score, puede modificar la página del producto y añadirlas."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "Para un cálculo más preciso de la puntuación ecológica, puedes editar la página del producto y añadirlas."
+msgstr "Para un cálculo más preciso de la Green-Score, puedes editar la página del producto y añadirlas."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -6215,7 +6210,7 @@ msgstr "Bonificaciones y penalizaciones"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Eco-puntuación para este producto"
+msgstr "Green-Score para este producto"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -7295,7 +7290,7 @@ msgstr "Si la información no coincide con la información del envase, puedes co
 
 msgctxt "incomplete_or_incorrect_data_content_correct_off"
 msgid "Open Food Facts is a collaborative database, and every contribution is useful for all."
-msgstr "Open Food Facts es una base de datos colaborativa, por lo que cada contribución es útil para todas las personas."
+msgstr "Open Food Facts es una base de datos colaborativa, por lo que cada contribución es útil para todas las personas."
 
 msgctxt "report_to_nutripatrol_explain"
 msgid "If you want to report vandalism, inappropriate content or erroneous data you can't fix yourself, report it to our moderators team."

--- a/po/common/et.po
+++ b/po/common/et.po
@@ -63,7 +63,7 @@ msgstr "ja <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">Facebook
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Ava Beauty Factsi tooteotsing"
+msgstr "Ava Open Beauty Factsi tooteotsing"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1758,11 +1758,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4948,7 +4943,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Roheline tulemus on keskkonnahinnang skaalal A+ kuni F, mis teeb toiduainete keskkonnamõju võrdlemise lihtsaks."
+msgstr "Green-Score on keskkonnahinnang skaalal A+ kuni F, mis teeb toiduainete keskkonnamõju võrdlemise lihtsaks."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4961,7 +4956,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Roheline tulemus on keskkonnahinnang skaalal A+ kuni F, mis teeb toiduainete keskkonnamõju võrdlemise lihtsaks."
+msgstr "Green-Score on keskkonnahinnang skaalal A+ kuni F, mis teeb toiduainete keskkonnamõju võrdlemise lihtsaks."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5885,7 +5880,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Rohelise Skoori süsteem töötati algselt välja Prantsusmaa jaoks ja seda laiendatakse ka teistele Euroopa riikidele. Rohelise Skoori valemit võidakse pidevalt täiustada, et see oleks täpsem ja iga riigi jaoks paremini sobiv."
+msgstr "Green-Score süsteem töötati algselt välja Prantsusmaa jaoks ja seda laiendatakse ka teistele Euroopa riikidele. Green-Score valemit võidakse pidevalt täiustada, et see oleks täpsem ja iga riigi jaoks paremini sobiv."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6541,7 +6536,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Selle toote kategooria pole rohelise skoori arvutamiseks piisavalt täpne. Kas saaksite lisada täpsema tootekategooria?"
+msgstr "Selle toote kategooria pole Green-Score arvutamiseks piisavalt täpne. Kas saaksite lisada täpsema tootekategooria?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7680,7 +7675,7 @@ msgstr "Teata sellest pildist meie moderaatoritele"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Toitumisalase skoori arvutamiseks puudub portsjoni suuruse väärtus ja/või ühik."
+msgstr "Nutri-Score arvutamiseks puudub portsjoni suuruse väärtus ja/või ühik."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/eu.po
+++ b/po/common/eu.po
@@ -1759,11 +1759,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/fa.po
+++ b/po/common/fa.po
@@ -42,7 +42,7 @@ msgstr "یک پایگاه داده مشارکتی، رایگان و باز از 
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "«حقایق زیبایی باز» اطلاعات و داده‌های مربوط به محصولات آرایشی را از سراسر جهان جمع‌آوری می‌کند."
+msgstr "«Open Beauty Facts» اطلاعات و داده‌های مربوط به محصولات آرایشی را از سراسر جهان جمع‌آوری می‌کند."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "و گروه فیسبوک <a href=\"https://www.facebook.com/groups/OpenB
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "جستجوی محصول «اطلاعات زیبایی» را باز کنید"
+msgstr "جستجوی محصول «Open Beauty Facts» را باز کنید"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -154,7 +154,7 @@ msgstr "یک پایگاه داده مشارکتی، رایگان و باز از 
 
 msgctxt "tagline_opff"
 msgid "Open Pet Food Facts gathers information and data on pet food products from around the world."
-msgstr "«آمار غذای حیوانات خانگی باز» اطلاعات و داده‌های مربوط به محصولات غذای حیوانات خانگی را از سراسر جهان جمع‌آوری می‌کند."
+msgstr "«Open Pet Food Facts» اطلاعات و داده‌های مربوط به محصولات غذای حیوانات خانگی را از سراسر جهان جمع‌آوری می‌کند."
 
 msgctxt "footer_tagline_opff"
 msgid "A collaborative, free and open database of pet food products from around the world."
@@ -448,7 +448,7 @@ msgstr "شماره بارکد:"
 
 msgctxt "you_can_also_help_us"
 msgid "You can also help to fund the Open Food Facts project"
-msgstr "شما همچنین می‌توانید به تأمین مالی پروژه «حقایق غذای آزاد» کمک کنید."
+msgstr "شما همچنین می‌توانید به تأمین مالی پروژه «Open Food Facts» کمک کنید."
 
 msgctxt "producers_administration_manual"
 msgid "Producers Admin manual"
@@ -688,7 +688,7 @@ msgstr "حذف شده:"
 
 msgctxt "donate"
 msgid "Donate to Open Food Facts"
-msgstr "برای باز کردن حقایق غذایی کمک مالی کنید"
+msgstr "برای باز کردن Open Food Facts کمک مالی کنید"
 
 msgctxt "donate_link"
 msgid "https://world.openfoodfacts.org/donate-to-open-food-facts"
@@ -1065,7 +1065,7 @@ msgstr "https://wiki.openfoodfacts.org"
 # Do not translate Open Beauty Facts but do translate Cosmetics
 msgctxt "footer_obf"
 msgid "Open Beauty Facts - Cosmetics"
-msgstr "حقایق زیبایی را آزاد کنید - لوازم آرایشی"
+msgstr "Open Beauty Facts - لوازم آرایشی"
 
 msgctxt "footer_obf_link"
 msgid "https://world.openbeautyfacts.org"
@@ -1073,7 +1073,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "حقایق غذایی آزاد برای تولیدکنندگان"
+msgstr "Open Food Facts برای تولیدکنندگان"
 
 msgctxt "for"
 msgid "for"
@@ -1756,7 +1756,7 @@ msgstr "جدول به طور پیش‌فرض مواد مغذی‌ای را که 
 
 msgctxt "nutrition_data_table_asterisk"
 msgid "Essential nutrients to calculate the Nutri-Score."
-msgstr "مواد مغذی ضروری برای محاسبه امتیاز تغذیه‌ای."
+msgstr "مواد مغذی ضروری برای محاسبه Nutri-Score."
 
 msgctxt "nutrition_grades_p"
 msgid "Nutrition grades"
@@ -1765,11 +1765,6 @@ msgstr ""
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -2903,7 +2898,7 @@ msgstr "مترجمان ما"
 
 msgctxt "translators_lead"
 msgid "We would like to say THANK YOU to the awesome translators that make it possible to present Open Food Facts, Open Beauty Facts, and Open Pet Food Facts to you in all these different languages! <a href=\"https://translate.openfoodfacts.org/\">You can join us in this global effort: it doesn't require any technical knowledge.</a>"
-msgstr "مایلیم از مترجمان فوق‌العاده‌ای که ارائه‌ی «حقایق غذای آزاد»، «حقایق زیبایی آزاد» و «حقایق غذای حیوانات خانگی آزاد» را به زبان‌های مختلف برای شما امکان‌پذیر کرده‌اند، تشکر کنیم! <a href=\"https://translate.openfoodfacts.org/\">شما می‌توانید در این تلاش جهانی به ما بپیوندید: این کار به هیچ دانش فنی نیاز ندارد.</a>"
+msgstr "مایلیم از مترجمان فوق‌العاده‌ای که ارائه‌ی «Open Food Facts»، «Open Beauty Facts» و «Open Pet Food Facts» را به زبان‌های مختلف برای شما امکان‌پذیر کرده‌اند، تشکر کنیم! <a href=\"https://translate.openfoodfacts.org/\">شما می‌توانید در این تلاش جهانی به ما بپیوندید: این کار به هیچ دانش فنی نیاز ندارد.</a>"
 
 msgctxt "translators_renewal_notice"
 msgid "Please note that this table is refreshed nightly and might be out of date."
@@ -2975,11 +2970,11 @@ msgstr "واحد"
 
 msgctxt "nova_groups_s"
 msgid "NOVA group"
-msgstr "گروه نوا"
+msgstr "گروه NOVA"
 
 msgctxt "nova_groups_p"
 msgid "NOVA groups"
-msgstr "گروه‌های نوا"
+msgstr "گروه‌های NOVA"
 
 # Title for the link to the explanation of what a NOVA Group is
 msgctxt "nova_groups_info"
@@ -3996,11 +3991,11 @@ msgstr "تعداد محصولات دارای فرصت‌های بهبود"
 
 msgctxt "improvements_facet_description_1"
 msgid "This table lists possible opportunities to improve the nutritional quality, the Nutri-Score and the composition of food products."
-msgstr "این جدول فهرستی از فرصت‌های ممکن برای بهبود کیفیت تغذیه‌ای، امتیاز تغذیه‌ای و ترکیب محصولات غذایی را ارائه می‌دهد."
+msgstr "این جدول فهرستی از فرصت‌های ممکن برای بهبود کیفیت تغذیه‌ای، Nutri-Score و ترکیب محصولات غذایی را ارائه می‌دهد."
 
 msgctxt "improvements_facet_description_2"
 msgid "In order to get relevant results, please make sure the product data is complete (nutrition facts with values for fiber and fruits and vegetables to compute the Nutri-Score, and a precise category to compare each product to similar products)."
-msgstr "برای دریافت نتایج مرتبط، لطفاً مطمئن شوید که اطلاعات محصول کامل است (اطلاعات تغذیه‌ای به همراه مقادیر فیبر و میوه‌ها و سبزیجات برای محاسبه امتیاز تغذیه‌ای، و یک دسته‌بندی دقیق برای مقایسه هر محصول با محصولات مشابه)."
+msgstr "برای دریافت نتایج مرتبط، لطفاً مطمئن شوید که اطلاعات محصول کامل است (اطلاعات تغذیه‌ای به همراه مقادیر فیبر و میوه‌ها و سبزیجات برای محاسبه Nutri-Score، و یک دسته‌بندی دقیق برای مقایسه هر محصول با محصولات مشابه)."
 
 # "product photos" in this sentence means photos for many products, not just one product
 msgctxt "import_photos_title"
@@ -4069,7 +4064,7 @@ msgstr "فایل دریافت شد"
 
 msgctxt "nutriscore_calculation_details"
 msgid "Details of the calculation of the Nutri-Score"
-msgstr "جزئیات محاسبه امتیاز تغذیه‌ای"
+msgstr "جزئیات محاسبه Nutri-Score"
 
 msgctxt "nutriscore_is_beverage"
 msgid "This product is considered a beverage for the calculation of the Nutri-Score."
@@ -4077,7 +4072,7 @@ msgstr "این محصول برای محاسبه‌ی امتیاز تغذیه‌�
 
 msgctxt "nutriscore_is_not_beverage"
 msgid "This product is not considered a beverage for the calculation of the Nutri-Score."
-msgstr "این محصول برای محاسبه امتیاز تغذیه‌ای، نوشیدنی محسوب نمی‌شود."
+msgstr "این محصول برای محاسبه Nutri-Score، نوشیدنی محسوب نمی‌شود."
 
 msgctxt "nutriscore_positive_points"
 msgid "Positive points"
@@ -4154,22 +4149,22 @@ msgstr "امتیاز تغذیه‌ای"
 # Do not translate
 msgctxt "nutriscore_grade"
 msgid "Nutri-Score"
-msgstr "امتیاز تغذیه‌ای"
+msgstr "Nutri-Score"
 
 # This is not the Nutri-Score grade with letters, but the Nutri-Score number score used to compute the grade. Translate score but not Nutri-Score.
 msgctxt "nutriscore_score_producer"
 msgid "Nutri-Score score"
-msgstr "امتیاز تغذیه‌ای"
+msgstr "Nutri-Score"
 
 # Do not translate
 msgctxt "nutriscore_grade_producer"
 msgid "Nutri-Score"
-msgstr "امتیاز تغذیه‌ای"
+msgstr "Nutri-Score"
 
 # free as in not costing something
 msgctxt "donate_free_and_independent"
 msgid "Open Food Facts is 100% free and independent."
-msgstr "اطلاعات غذایی آزاد ۱۰۰٪ رایگان و مستقل است."
+msgstr "Open Food Facts ۱۰۰٪ رایگان و مستقل است."
 
 # leave empty link
 msgctxt "donate_help_and_donations"
@@ -4196,7 +4191,7 @@ msgstr "مقدار میانگین برای دسته %s"
 # Keep the %s
 msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
-msgstr "با تغییر مقدار %s از %s به %s (اختلاف%s درصد)، می‌توان امتیاز تغذیه‌ای را از %s به %s تغییر داد."
+msgstr "با تغییر مقدار %s از %s به %s (اختلاف%s درصد)، می‌توان Nutri-Score را از %s به %s تغییر داد."
 
 msgctxt "export_products_to_public_database_email"
 msgid "The platform for producers is still under development and we make manual checks before importing products to the public database. Please e-mail us at <a href=\"mailto:producers@openfoodfacts.org\">producers@openfoodfacts.org</a> to update the public database."
@@ -4339,7 +4334,7 @@ msgstr "امتیاز Nutri-Score از تولیدکننده"
 
 msgctxt "nutri_score_score_calculated"
 msgid "Calculated Nutri-Score score"
-msgstr "امتیاز تغذیه‌ای محاسبه‌شده"
+msgstr "Nutri-Score محاسبه‌شده"
 
 msgctxt "nutri_score_grade_from_producer"
 msgid "Nutri-Score grade from producer"
@@ -4347,7 +4342,7 @@ msgstr "درجه Nutri-Score از تولیدکننده"
 
 msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
-msgstr "نمره تغذیه‌ای محاسبه‌شده"
+msgstr "Nutri-Score محاسبه‌شده"
 
 msgctxt "scanned_code"
 msgid "Scanned code"
@@ -4596,7 +4591,7 @@ msgstr "Open Food Facts بر اساس اطلاعات ارائه شده (اطلا
 
 msgctxt "nutriscore_score_producer_note"
 msgid "Nutri-Score score (numeric value from which the A to E grade is derived)"
-msgstr "امتیاز تغذیه‌ای (مقدار عددی که درجه A تا E از آن مشتق می‌شود)"
+msgstr "Nutri-Score (مقدار عددی که درجه A تا E از آن مشتق می‌شود)"
 
 msgctxt "nutriscore_score_producer_import_note"
 msgid "Open Food Facts computes the Nutri-Score score based on the information provided (nutrition facts and category). If the score we compute is different from the score you provide, you will get a private notification on the producers platform so that the difference can be resolved."
@@ -4698,11 +4693,11 @@ msgstr "کیفیت تغذیه‌ای"
 
 msgctxt "attribute_nutriscore_name"
 msgid "Nutri-Score"
-msgstr "امتیاز تغذیه‌ای"
+msgstr "Nutri-Score"
 
 msgctxt "attribute_nutriscore_setting_name"
 msgid "Good nutritional quality (Nutri-Score)"
-msgstr "کیفیت تغذیه‌ای خوب (امتیاز تغذیه‌ای)"
+msgstr "کیفیت تغذیه‌ای خوب (Nutri-Score)"
 
 msgctxt "attribute_nutriscore_setting_note"
 msgid "The Nutri-Score is computed and can be taken into account for all products, even if is not displayed on the packaging."
@@ -4711,19 +4706,19 @@ msgstr "امتیاز تغذیه‌ای (Nutri-Score) برای همه محصول�
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "امتیاز تغذیه‌ای %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
-msgstr "امتیاز تغذیه‌ای ناشناخته"
+msgstr "Nutri-Score ناشناخته"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
 msgid "Missing data to compute the Nutri-Score"
-msgstr "داده‌های از دست رفته برای محاسبه امتیاز تغذیه‌ای"
+msgstr "داده‌های از دست رفته برای محاسبه Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "امتیاز تغذیه‌ای قابل اجرا نیست"
+msgstr "Nutri-Score قابل اجرا نیست"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4762,7 +4757,7 @@ msgstr "فارسی"
 
 msgctxt "attribute_nova_name"
 msgid "NOVA group"
-msgstr "گروه نوا"
+msgstr "گروه NOVA"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
@@ -4783,7 +4778,7 @@ msgstr "برای تعیین سطح فرآوری یک محصول، ما به فه
 # keep %s, it will be replaced by the group 1, 2, 3 or 4
 msgctxt "attribute_nova_group_title"
 msgid "NOVA %s"
-msgstr "نوا %s"
+msgstr "NOVA %s"
 
 msgctxt "attribute_nova_1_description_short"
 msgid "Unprocessed or minimally processed foods"
@@ -4824,7 +4819,7 @@ msgstr "فیلتر پرس و جو"
 
 msgctxt "nova_group_producer"
 msgid "NOVA group"
-msgstr "گروه نوا"
+msgstr "گروه NOVA"
 
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
@@ -4949,33 +4944,33 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "امتیاز سبز"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "تأثیر کم بر محیط زیست (امتیاز سبز)"
+msgstr "تأثیر کم بر محیط زیست (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "امتیاز سبز، امتیازی زیست‌محیطی از A+ تا F است که مقایسه تأثیر محصولات غذایی بر محیط زیست را آسان می‌کند."
+msgstr "Green-Score، امتیازی زیست‌محیطی از A+ تا F است که مقایسه تأثیر محصولات غذایی بر محیط زیست را آسان می‌کند."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "امتیاز سبز"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "تأثیر کم بر محیط زیست (امتیاز سبز)"
+msgstr "تأثیر کم بر محیط زیست (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "امتیاز سبز، امتیازی زیست‌محیطی از A+ تا F است که مقایسه تأثیر محصولات غذایی بر محیط زیست را آسان می‌کند."
+msgstr "Green-Score، امتیازی زیست‌محیطی از A+ تا F است که مقایسه تأثیر محصولات غذایی بر محیط زیست را آسان می‌کند."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "امتیاز سبز %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5161,22 +5156,22 @@ msgstr "تأثیر محیطی"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "امتیاز گرین"
+msgstr "Green-Score"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "نمره گرین اسکور"
+msgstr "نمره Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "جزئیات محاسبه امتیاز سبز"
+msgstr "جزئیات محاسبه Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "اطلاعات مربوط به امتیاز سبز"
+msgstr "اطلاعات مربوط به Green-Score"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5213,19 +5208,19 @@ msgstr "اطلاعات تغذیه‌ای موجود در محصول آماده�
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "امتیاز سبز"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "امتیاز سبز"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "امتیاز سبز"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "امتیاز سبز"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5473,11 +5468,11 @@ msgstr "بیشترین محصولات اسکن شده"
 
 msgctxt "sort_by_nutriscore_score"
 msgid "Products with the best Nutri-Score"
-msgstr "محصولاتی با بهترین امتیاز تغذیه‌ای"
+msgstr "محصولاتی با بهترین Nutri-Score"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "محصولاتی با بهترین امتیاز سبز"
+msgstr "محصولاتی با بهترین Green-Score"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5531,7 +5526,7 @@ msgstr "کاربر در حال حذف است. این ممکن است چند دق
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "امتیاز سبز اعمال نمی‌شود"
+msgstr "Green-Score اعمال نمی‌شود"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5544,11 +5539,11 @@ msgstr "هنوز برای این دسته قابل استفاده نیست: {cat
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "امتیاز سبز هنوز برای این دسته قابل اجرا نیست، اما ما در حال تلاش برای اضافه کردن پشتیبانی برای آن هستیم."
+msgstr "Green-Score هنوز برای این دسته قابل اجرا نیست، اما ما در حال تلاش برای اضافه کردن پشتیبانی برای آن هستیم."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "امتیاز سبز محاسبه نشده است"
+msgstr "Green-Score محاسبه نشده است"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5560,7 +5555,7 @@ msgstr "فاقد یک دسته بندی دقیق"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "ما نتوانستیم امتیاز سبز این محصول را محاسبه کنیم زیرا برخی از داده‌ها از دست رفته است، آیا می‌توانید در تکمیل آن کمک کنید؟"
+msgstr "ما نتوانستیم Green-Score این محصول را محاسبه کنیم زیرا برخی از داده‌ها از دست رفته است، آیا می‌توانید در تکمیل آن کمک کنید؟"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5668,7 +5663,7 @@ msgstr "برخی از داده‌های مربوط به حاصلضرب‌های 
 
 msgctxt "data_source_database_note_about_the_producers_platform"
 msgid "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_url>\">free plaform for producers</a> to access and complete this data, and to obtain reports, analysis and product improvements opportunities (e.g. better Nutri-Score)."
-msgstr "تولیدکنندگان می‌توانند از «اطلاعات عمومی مواد غذایی» <a href=\"<producers_platform_url>\">پلتفرم رایگان برای تولیدکنندگان</a> برای دسترسی و تکمیل این داده‌ها و دریافت گزارش‌ها، تحلیل‌ها و فرصت‌های بهبود محصول (مثلاً امتیاز تغذیه‌ای بهتر) استفاده کنند."
+msgstr "تولیدکنندگان می‌توانند از «Open Food Facts» <a href=\"<producers_platform_url>\">پلتفرم رایگان برای تولیدکنندگان</a> برای دسترسی و تکمیل این داده‌ها و دریافت گزارش‌ها، تحلیل‌ها و فرصت‌های بهبود محصول (مثلاً Nutri-Score بهتر) استفاده کنند."
 
 # variable names between { } must not be translated
 msgctxt "f_data_source_database_provider"
@@ -5690,7 +5685,7 @@ msgstr "ردپای جنگلی با در نظر گرفتن موادی که تول
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "امتیاز سبز فقط در صورتی قابل محاسبه است که محصول دارای دسته‌بندی به اندازه کافی دقیقی باشد."
+msgstr "Green-Score فقط در صورتی قابل محاسبه است که محصول دارای دسته‌بندی به اندازه کافی دقیقی باشد."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5702,7 +5697,7 @@ msgstr "اگر شما تولیدکننده این محصول هستید، می�
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "هشدار: برخی از اطلاعات لازم برای محاسبه دقیق امتیاز گرین ارائه نشده است (جزئیات محاسبه را در زیر ببینید)."
+msgstr "هشدار: برخی از اطلاعات لازم برای محاسبه دقیق Green-Score ارائه نشده است (جزئیات محاسبه را در زیر ببینید)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5857,12 +5852,12 @@ msgstr "اطلاعات مربوط به بسته‌بندی این محصول ب�
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "برای محاسبه دقیق‌تر امتیاز سبز، می‌توانید صفحه محصول را تغییر داده و آنها را اضافه کنید."
+msgstr "برای محاسبه دقیق‌تر Green-Score، می‌توانید صفحه محصول را تغییر داده و آنها را اضافه کنید."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "برای محاسبه دقیق‌تر امتیاز سبز، می‌توانید صفحه محصول را ویرایش کرده و آنها را اضافه کنید."
+msgstr "برای محاسبه دقیق‌تر Green-Score، می‌توانید صفحه محصول را ویرایش کرده و آنها را اضافه کنید."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5889,12 +5884,12 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
 msgid "The Green-Score formula is subject to change as it is regularly improved to make it more precise."
-msgstr "فرمول گرین-اسکور ممکن است تغییر کند زیرا مرتباً برای دقیق‌تر شدن بهبود می‌یابد."
+msgstr "فرمول Green-Score ممکن است تغییر کند زیرا مرتباً برای دقیق‌تر شدن بهبود می‌یابد."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "امتیاز گرین در ابتدا برای فرانسه توسعه داده شد و در حال گسترش به سایر کشورهای اروپایی است. فرمول امتیاز گرین با بهبود منظم آن برای دقیق‌تر شدن و مناسب‌تر شدن برای هر کشور، ممکن است تغییر کند."
+msgstr "Green-Score در ابتدا برای فرانسه توسعه داده شد و در حال گسترش به سایر کشورهای اروپایی است. فرمول Green-Score با بهبود منظم آن برای دقیق‌تر شدن و مناسب‌تر شدن برای هر کشور، ممکن است تغییر کند."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -5906,7 +5901,7 @@ msgstr "تأثیر کامل حمل و نقل بر کشور شما در حال ح
 
 msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Green-Score and more!"
-msgstr "بارکدها را اسکن کنید تا امتیاز تغذیه‌ای، امتیاز سبز و موارد دیگر را دریافت کنید!"
+msgstr "بارکدها را اسکن کنید تا Nutri-Score، Green-Score و موارد دیگر را دریافت کنید!"
 
 msgctxt "org_gs1_product_name_is_abbreviated"
 msgid "GS1 product names for this manufacturer are abbreviated."
@@ -5980,7 +5975,7 @@ msgstr "متوسط"
 
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
-msgstr "توجه: امتیاز تغذیه‌ای چای‌ها و دمنوش‌های گیاهی مربوط به محصولی است که فقط با آب و بدون شکر یا شیر تهیه شده باشد."
+msgstr "توجه: Nutri-Score چای‌ها و دمنوش‌های گیاهی مربوط به محصولی است که فقط با آب و بدون شکر یا شیر تهیه شده باشد."
 
 msgctxt "g_per_100g"
 msgid "%s g / 100 g"
@@ -6217,7 +6212,7 @@ msgstr "پاداش‌ها و جریمه‌ها"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "امتیاز سبز برای این محصول"
+msgstr "Green-Score برای این محصول"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6245,15 +6240,15 @@ msgstr "امتیاز محصولاتی که مواد بسته‌بندی آنها
 
 msgctxt "nutriscore_not_applicable"
 msgid "Nutri-Score not applicable for this product category."
-msgstr "امتیاز تغذیه‌ای برای این دسته از محصولات قابل استفاده نیست."
+msgstr "Nutri-Score برای این دسته از محصولات قابل استفاده نیست."
 
 msgctxt "nutriscore_missing_category"
 msgid "The category of the product must be specified in order to compute the Nutri-Score."
-msgstr "برای محاسبه امتیاز تغذیه‌ای، باید دسته محصول مشخص شود."
+msgstr "برای محاسبه Nutri-Score، باید دسته محصول مشخص شود."
 
 msgctxt "nutriscore_missing_nutrition_data"
 msgid "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
-msgstr "برای محاسبه امتیاز تغذیه‌ای، باید اطلاعات تغذیه‌ای محصول مشخص شود."
+msgstr "برای محاسبه Nutri-Score، باید اطلاعات تغذیه‌ای محصول مشخص شود."
 
 msgctxt "nutriscore_missing_nutrition_data_details"
 msgid "Missing nutrition facts:"
@@ -6265,7 +6260,7 @@ msgstr "اطلاعات تغذیه‌ای موجود در محصول آماده:"
 
 msgctxt "nutriscore_missing_category_and_nutrition_data"
 msgid "The category and the nutrition facts of the product must be specified in order to compute the Nutri-Score."
-msgstr "برای محاسبه امتیاز تغذیه‌ای، باید دسته بندی و اطلاعات تغذیه‌ای محصول مشخص شود."
+msgstr "برای محاسبه Nutri-Score، باید دسته بندی و اطلاعات تغذیه‌ای محصول مشخص شود."
 
 msgctxt "health"
 msgid "Health"
@@ -6496,7 +6491,7 @@ msgstr ""
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "درباره گرین اسکور بیشتر بدانید"
+msgstr "درباره Green-Score بیشتر بدانید"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6534,7 +6529,7 @@ msgstr "استفاده از تنظیمات پیش‌فرض"
 
 msgctxt "reset_preferences_details"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "امتیاز تغذیه‌ای، امتیاز سبز و سطح فرآوری مواد غذایی (NOVA)"
+msgstr "Nutri-Score، Green-Score و سطح فرآوری مواد غذایی (NOVA)"
 
 msgctxt "actions_add_ingredients"
 msgid "Could you add the ingredients list?"
@@ -6542,15 +6537,15 @@ msgstr "میشه لیست مواد لازم رو هم اضافه کنید؟"
 
 msgctxt "actions_to_compute_nutriscore"
 msgid "Could you add the information needed to compute the Nutri-Score?"
-msgstr "میشه اطلاعات لازم برای محاسبه امتیاز تغذیه‌ای رو اضافه کنید؟"
+msgstr "میشه اطلاعات لازم برای محاسبه Nutri-Score رو اضافه کنید؟"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "میشه یه دسته بندی دقیق از محصولات اضافه کنید تا بتونیم امتیاز سبز رو محاسبه کنیم؟"
+msgstr "میشه یه دسته بندی دقیق از محصولات اضافه کنید تا بتونیم Green-Score رو محاسبه کنیم؟"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "دسته‌بندی که برای این محصول داریم به اندازه کافی دقیق نیست تا امتیاز سبز را محاسبه کند. آیا می‌توانید دسته‌بندی دقیق‌تری برای محصول اضافه کنید؟"
+msgstr "دسته‌بندی که برای این محصول داریم به اندازه کافی دقیق نیست تا Green-Score را محاسبه کند. آیا می‌توانید دسته‌بندی دقیق‌تری برای محصول اضافه کنید؟"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7139,11 +7134,11 @@ msgstr "این محصول برای محاسبه امتیاز تغذیه‌ای (
 
 msgctxt "nutriscore_is_fat_oil_nuts_seeds"
 msgid "This product is considered to be fat, oil, nuts or seeds for the calculation of the Nutri-Score."
-msgstr "این محصول برای محاسبه‌ی امتیاز تغذیه‌ای، به عنوان چربی، روغن، آجیل یا دانه در نظر گرفته می‌شود."
+msgstr "این محصول برای محاسبه‌ی Nutri-Score، به عنوان چربی، روغن، آجیل یا دانه در نظر گرفته می‌شود."
 
 msgctxt "nutriscore_is_cheese"
 msgid "This product is considered to be cheese for the calculation of the Nutri-Score."
-msgstr "این محصول برای محاسبه‌ی امتیاز تغذیه‌ای، پنیر محسوب می‌شود."
+msgstr "این محصول برای محاسبه‌ی Nutri-Score، پنیر محسوب می‌شود."
 
 msgctxt "nutriscore_is_red_meat_product"
 msgid "This product is considered to be a red meat product for the calculation of the Nutri-Score."
@@ -7175,11 +7170,11 @@ msgstr "امتیاز پروتئین‌ها محاسبه نمی‌شود زیرا
 
 msgctxt "nutriscore_new_computation_title"
 msgid "Discover the new Nutri-Score!"
-msgstr "نوتری-اسکور جدید را کشف کنید!"
+msgstr "Nutri-Score جدید را کشف کنید!"
 
 msgctxt "nutriscore_new_computation_description"
 msgid "<p>The computation of the Nutri-Score is evolving to provide better recommendations based on the latest scientific evidence.</p><p>Main improvements:</p><ul><li>Better score for some fatty fish and oils rich in good fats</li><li>Better score for whole products rich in fiber</li><li>Worse score for products containing a lot of salt or sugar</li><li>Worse score for red meat (compared to poultry)</li></ul>"
-msgstr "<p>محاسبه‌ی امتیاز تغذیه‌ای در حال تکامل است تا توصیه‌های بهتری را بر اساس آخرین شواهد علمی ارائه دهد.</p><p>پیشرفت‌های اصلی:</p><ul><li>امتیاز بهتر برای برخی از ماهی‌های چرب و روغن‌های غنی از چربی‌های خوب</li><li>امتیاز بهتر برای محصولات کامل غنی از فیبر</li><li>امتیاز بدتر برای محصولاتی که حاوی مقدار زیادی نمک یا شکر هستند</li><li>امتیاز بدتر برای گوشت قرمز (در مقایسه با مرغ)</li></ul>"
+msgstr "<p>محاسبه‌ی Nutri-Score در حال تکامل است تا توصیه‌های بهتری را بر اساس آخرین شواهد علمی ارائه دهد.</p><p>پیشرفت‌های اصلی:</p><ul><li>امتیاز بهتر برای برخی از ماهی‌های چرب و روغن‌های غنی از چربی‌های خوب</li><li>امتیاز بهتر برای محصولات کامل غنی از فیبر</li><li>امتیاز بدتر برای محصولاتی که حاوی مقدار زیادی نمک یا شکر هستند</li><li>امتیاز بدتر برای گوشت قرمز (در مقایسه با مرغ)</li></ul>"
 
 msgctxt "nutriscore_new_computation_link_text"
 msgid "Discover all the improvements of the new Nutri-Score"
@@ -7203,7 +7198,7 @@ msgstr "نمایش این لوگو توسط مقامات بهداشت عمومی
 
 msgctxt "nutriscore_explanation_title"
 msgid "What is the Nutri-Score?"
-msgstr "امتیاز تغذیه‌ای چیست؟"
+msgstr "Nutri-Score چیست؟"
 
 msgctxt "nutrient_info_energy_risk"
 msgid "Energy intakes above energy requirements are associated with increased risks of weight gain, overweight, obesity, and consequently risk of diet-related chronic diseases."
@@ -7445,7 +7440,7 @@ msgstr "فایلی حاوی اطلاعات محصول را انتخاب کنید
 
 msgctxt "number_of_products_without_nutriscore"
 msgid "Number of products without Nutri-Score"
-msgstr "تعداد محصولات بدون امتیاز تغذیه‌ای"
+msgstr "تعداد محصولات بدون Nutri-Score"
 
 msgctxt "percent_of_products_with_nutriscore"
 msgid "% of products where Nutri-Score is computed"
@@ -7673,7 +7668,7 @@ msgstr "کشاورزی ارگانیک و تجارت عادلانه"
 
 msgctxt "reset_preferences_details_food"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "امتیاز تغذیه‌ای، امتیاز سبز و سطح فرآوری مواد غذایی (NOVA)"
+msgstr "Nutri-Score، Green-Score و سطح فرآوری مواد غذایی (NOVA)"
 
 msgctxt "reset_preferences_details_product"
 msgid "Good repairability"
@@ -7689,7 +7684,7 @@ msgstr "این تصویر را به مدیران ما گزارش دهید"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "ما مقدار اندازه وعده و/یا واحد را برای محاسبه امتیاز تغذیه‌ای از دست داده‌ایم."
+msgstr "ما مقدار اندازه وعده و/یا واحد را برای محاسبه Nutri-Score از دست داده‌ایم."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/fi.po
+++ b/po/common/fi.po
@@ -1764,11 +1764,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Ravintoarvosana"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -6491,7 +6486,7 @@ msgstr "Poista kuvan valinta"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Kiitos"
+msgstr "Lue lisää Nutri-Scoresta"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"

--- a/po/common/fil.po
+++ b/po/common/fil.po
@@ -1624,11 +1624,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Marka ng nutrisyon"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/fo.po
+++ b/po/common/fo.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/fr.po
+++ b/po/common/fr.po
@@ -1767,11 +1767,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Note nutritionnelle"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/ga.po
+++ b/po/common/ga.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Ní bhaineann Scór Cothaitheach leis"
+msgstr "Ní bhaineann Nutri-Score leis"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Is scór comhshaoil ó A+ go F é an Scór Glas a fhágann go bhfuil sé éasca tionchar táirgí bia ar an gcomhshaol a chur i gcomparáid."
+msgstr "Is scór comhshaoil ó A+ go F é an Green-Score a fhágann go bhfuil sé éasca tionchar táirgí bia ar an gcomhshaol a chur i gcomparáid."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Is scór comhshaoil ó A+ go F é an Scór Glas a fhágann go bhfuil sé éasca tionchar táirgí bia ar an gcomhshaol a chur i gcomparáid."
+msgstr "Is scór comhshaoil ó A+ go F é an Green-Score a fhágann go bhfuil sé éasca tionchar táirgí bia ar an gcomhshaol a chur i gcomparáid."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Forbraíodh an Scór Glas ar dtús don Fhrainc agus tá sé á leathnú chuig tíortha Eorpacha eile. Tá foirmle an Scóir Ghlais faoi réir athraithe de réir mar a fheabhsaítear í go rialta chun í a dhéanamh níos cruinne agus níos oiriúnaí do gach tír."
+msgstr "Forbraíodh an Green-Score ar dtús don Fhrainc agus tá sé á leathnú chuig tíortha Eorpacha eile. Tá foirmle an Green-Score faoi réir athraithe de réir mar a fheabhsaítear í go rialta chun í a dhéanamh níos cruinne agus níos oiriúnaí do gach tír."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Níl an chatagóir atá againn don táirge seo cruinn go leor chun an Scór Glas a ríomh. An bhféadfá catagóir táirge níos cruinne a chur leis?"
+msgstr "Níl an chatagóir atá againn don táirge seo cruinn go leor chun an Green-Score a ríomh. An bhféadfá catagóir táirge níos cruinne a chur leis?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,7 +7665,7 @@ msgstr "Tuairiscigh an íomhá seo dár modhnóirí"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Tá luach agus/nó aonad an mhéid riar in easnamh orainn chun an Scór Cothaitheach a ríomh."
+msgstr "Tá luach agus/nó aonad an mhéid riar in easnamh orainn chun an Nutri-Score a ríomh."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/gd.po
+++ b/po/common/gd.po
@@ -63,7 +63,7 @@ msgstr "agus buidheann Facebook <a href=\"https://www.facebook.com/groups/OpenBe
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Fosgail rannsachadh toraidh Fiosrachadh Bòidhchead"
+msgstr "Fosgail rannsachadh toraidh Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Chan eil Sgòr Beathachaidh iomchaidh"
+msgstr "Chan eil Nutri-Score iomchaidh"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "’S e sgòr àrainneachdail bho A+ gu F a th’ anns an Sgòr Uaine a tha ga dhèanamh furasta coimeas a dhèanamh eadar buaidh thoraidhean bìdh air an àrainneachd."
+msgstr "’S e sgòr àrainneachdail bho A+ gu F a th’ anns an Green-Score a tha ga dhèanamh furasta coimeas a dhèanamh eadar buaidh thoraidhean bìdh air an àrainneachd."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "’S e sgòr àrainneachdail bho A+ gu F a th’ anns an Sgòr Uaine a tha ga dhèanamh furasta coimeas a dhèanamh eadar buaidh thoraidhean bìdh air an àrainneachd."
+msgstr "’S e sgòr àrainneachdail bho A+ gu F a th’ anns an Green-Score a tha ga dhèanamh furasta coimeas a dhèanamh eadar buaidh thoraidhean bìdh air an àrainneachd."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Chaidh an Sgòr Uaine a leasachadh an toiseach airson na Frainge agus tha e ga leudachadh gu dùthchannan Eòrpach eile. Tha foirmle an Sgòr Uaine buailteach atharrachadh oir tha e ga leasachadh gu cunbhalach gus a dhèanamh nas mionaidiche agus nas freagarraiche do gach dùthaich."
+msgstr "Chaidh an Green-Score a leasachadh an toiseach airson na Frainge agus tha e ga leudachadh gu dùthchannan Eòrpach eile. Tha foirmle an Green-Score buailteach atharrachadh oir tha e ga leasachadh gu cunbhalach gus a dhèanamh nas mionaidiche agus nas freagarraiche do gach dùthaich."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Chan eil an roinn a th’ againn airson an toraidh seo mionaideach gu leòr airson an Sgòr Uaine obrachadh a-mach. Am b’ urrainn dhut roinn toraidh nas mionaidiche a chur ris?"
+msgstr "Chan eil an roinn a th’ againn airson an toraidh seo mionaideach gu leòr airson an Green-Score obrachadh a-mach. Am b’ urrainn dhut roinn toraidh nas mionaidiche a chur ris?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/gl.po
+++ b/po/common/gl.po
@@ -63,7 +63,7 @@ msgstr "e o grupo de Facebook <a href=\"https://www.facebook.com/groups/OpenBeau
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Busca de produtos de beleza aberta"
+msgstr "Busca de Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1758,11 +1758,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4706,7 +4701,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Puntuación Nutricional non aplicable"
+msgstr "Nutri-Score non aplicable"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -6533,7 +6528,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "A categoría que temos para este produto non é o suficientemente precisa para calcular a puntuación ecolóxica. Poderías engadir unha categoría de produto máis precisa?"
+msgstr "A categoría que temos para este produto non é o suficientemente precisa para calcular a Green-Score. Poderías engadir unha categoría de produto máis precisa?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7672,7 +7667,7 @@ msgstr "Informar desta imaxe aos nosos moderadores"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Falta o valor da porción e/ou a unidade para calcular a puntuación Nutricional."
+msgstr "Falta o valor da porción e/ou a unidade para calcular a Nutri-Score."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/gu.po
+++ b/po/common/gu.po
@@ -42,7 +42,7 @@ msgstr "વિશ્વભરના કોસ્મેટિક ઉત્પા�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ઓપન બ્યુટી ફેક્ટ્સ વિશ્વભરના કોસ્મેટિક ઉત્પાદનો પર માહિતી અને ડેટા એકત્રિત કરે છે."
+msgstr "Open Beauty Facts વિશ્વભરના કોસ્મેટિક ઉત્પાદનો પર માહિતી અને ડેટા એકત્રિત કરે છે."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "અને <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">�
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "સૌંદર્ય તથ્યો ઉત્પાદન શોધ ખોલો"
+msgstr "Open Beauty Facts ઉત્પાદન શોધ ખોલો"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "આ પ્રોડક્ટ પેજ પૂર્ણ નથી. તમે તેને સંપાદિત કરીને અને અમારી પાસેના ફોટામાંથી વધુ ડેટા ઉમેરીને અથવા <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> અથવા <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>માટે યુનિવર્સલ ઓપન ફૂડ ફેક્ટ્સ એપ્લિકેશનનો ઉપયોગ કરીને વધુ ફોટા લઈને પૂર્ણ કરવામાં મદદ કરી શકો છો. આભાર!"
+msgstr "આ પ્રોડક્ટ પેજ પૂર્ણ નથી. તમે તેને સંપાદિત કરીને અને અમારી પાસેના ફોટામાંથી વધુ ડેટા ઉમેરીને અથવા <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> અથવા <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>માટે યુનિવર્સલ Open Food Facts એપ્લિકેશનનો ઉપયોગ કરીને વધુ ફોટા લઈને પૂર્ણ કરવામાં મદદ કરી શકો છો. આભાર!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "આ પ્રોડક્ટ પેજ પૂર્ણ નથી. તમે તેને સંપાદિત કરીને અને અમારી પાસેના ફોટામાંથી વધુ ડેટા ઉમેરીને અથવા <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> અથવા <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>માટે યુનિવર્સલ ઓપન ફૂડ ફેક્ટ્સ એપ્લિકેશનનો ઉપયોગ કરીને વધુ ફોટા લઈને પૂર્ણ કરવામાં મદદ કરી શકો છો. આભાર!"
+msgstr "આ પ્રોડક્ટ પેજ પૂર્ણ નથી. તમે તેને સંપાદિત કરીને અને અમારી પાસેના ફોટામાંથી વધુ ડેટા ઉમેરીને અથવા <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> અથવા <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>માટે યુનિવર્સલ Open Food Facts એપ્લિકેશનનો ઉપયોગ કરીને વધુ ફોટા લઈને પૂર્ણ કરવામાં મદદ કરી શકો છો. આભાર!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -448,7 +448,7 @@ msgstr "બારકોડ નંબર:"
 
 msgctxt "you_can_also_help_us"
 msgid "You can also help to fund the Open Food Facts project"
-msgstr "તમે ઓપન ફૂડ ફેક્ટ્સ પ્રોજેક્ટને ભંડોળ આપવામાં પણ મદદ કરી શકો છો"
+msgstr "તમે Open Food Facts પ્રોજેક્ટને ભંડોળ આપવામાં પણ મદદ કરી શકો છો"
 
 msgctxt "producers_administration_manual"
 msgid "Producers Admin manual"
@@ -688,7 +688,7 @@ msgstr "કાઢી નાખેલ:"
 
 msgctxt "donate"
 msgid "Donate to Open Food Facts"
-msgstr "ફૂડ ફેક્ટ્સ ખોલવા માટે દાન કરો"
+msgstr "Open Food Facts ખોલવા માટે દાન કરો"
 
 msgctxt "donate_link"
 msgid "https://world.openfoodfacts.org/donate-to-open-food-facts"
@@ -1759,11 +1759,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4707,7 +4702,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "ન્યુટ્રી-સ્કોર લાગુ પડતો નથી"
+msgstr "Nutri-Score લાગુ પડતો નથી"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4941,7 +4936,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ગ્રીન-સ્કોર એ A+ થી F સુધીનો પર્યાવરણીય સ્કોર છે જે પર્યાવરણ પર ખાદ્ય ઉત્પાદનોની અસરની તુલના કરવાનું સરળ બનાવે છે."
+msgstr "Green-Score એ A+ થી F સુધીનો પર્યાવરણીય સ્કોર છે જે પર્યાવરણ પર ખાદ્ય ઉત્પાદનોની અસરની તુલના કરવાનું સરળ બનાવે છે."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4954,7 +4949,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ગ્રીન-સ્કોર એ A+ થી F સુધીનો પર્યાવરણીય સ્કોર છે જે પર્યાવરણ પર ખાદ્ય ઉત્પાદનોની અસરની તુલના કરવાનું સરળ બનાવે છે."
+msgstr "Green-Score એ A+ થી F સુધીનો પર્યાવરણીય સ્કોર છે જે પર્યાવરણ પર ખાદ્ય ઉત્પાદનોની અસરની તુલના કરવાનું સરળ બનાવે છે."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5878,7 +5873,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ગ્રીન-સ્કોર શરૂઆતમાં ફ્રાન્સ માટે વિકસાવવામાં આવ્યો હતો અને તેને અન્ય યુરોપિયન દેશોમાં પણ વિસ્તારવામાં આવી રહ્યો છે. ગ્રીન-સ્કોર ફોર્મ્યુલામાં ફેરફાર થઈ શકે છે કારણ કે તેને નિયમિતપણે સુધારવામાં આવે છે જેથી તે દરેક દેશ માટે વધુ ચોક્કસ અને વધુ સારી રીતે અનુકૂળ બને."
+msgstr "Green-Score શરૂઆતમાં ફ્રાન્સ માટે વિકસાવવામાં આવ્યો હતો અને તેને અન્ય યુરોપિયન દેશોમાં પણ વિસ્તારવામાં આવી રહ્યો છે. Green-Score ફોર્મ્યુલામાં ફેરફાર થઈ શકે છે કારણ કે તેને નિયમિતપણે સુધારવામાં આવે છે જેથી તે દરેક દેશ માટે વધુ ચોક્કસ અને વધુ સારી રીતે અનુકૂળ બને."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6534,7 +6529,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "આ પ્રોડક્ટ માટે અમારી પાસે જે કેટેગરી છે તે ગ્રીન-સ્કોરની ગણતરી કરવા માટે પૂરતી ચોક્કસ નથી. શું તમે વધુ ચોક્કસ પ્રોડક્ટ કેટેગરી ઉમેરી શકો છો?"
+msgstr "આ પ્રોડક્ટ માટે અમારી પાસે જે કેટેગરી છે તે Green-Scoreની ગણતરી કરવા માટે પૂરતી ચોક્કસ નથી. શું તમે વધુ ચોક્કસ પ્રોડક્ટ કેટેગરી ઉમેરી શકો છો?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7673,15 +7668,15 @@ msgstr "આ છબીની જાણ અમારા મધ્યસ્થી�
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "ન્યુટ્રી-સ્કોરની ગણતરી કરવા માટે અમારી પાસે સર્વિંગ સાઈઝ વેલ્યુ અને/અથવા યુનિટ ખૂટે છે."
+msgstr "Nutri-Scoreની ગણતરી કરવા માટે અમારી પાસે સર્વિંગ સાઈઝ વેલ્યુ અને/અથવા યુનિટ ખૂટે છે."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> એક બિન-લાભકારી સંગઠન દ્વારા બનાવવામાં આવ્યું છે, જે ઉદ્યોગથી સ્વતંત્ર છે. તે બધા માટે બનાવવામાં આવ્યું છે, બધા દ્વારા, અને તે બધા દ્વારા ભંડોળ પૂરું પાડવામાં આવે છે. તમે ઓપન ફૂડ ફેક્ટ્સને દાન આપીને અમારા કાર્યને સમર્થન આપી શકો છો.<br/><b>આભાર!</b>"
+msgstr "<<site_name>> એક બિન-લાભકારી સંગઠન દ્વારા બનાવવામાં આવ્યું છે, જે ઉદ્યોગથી સ્વતંત્ર છે. તે બધા માટે બનાવવામાં આવ્યું છે, બધા દ્વારા, અને તે બધા દ્વારા ભંડોળ પૂરું પાડવામાં આવે છે. તમે Open Food Factsને દાન આપીને અમારા કાર્યને સમર્થન આપી શકો છો.<br/><b>આભાર!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> એક બિન-લાભકારી સંગઠન દ્વારા બનાવવામાં આવ્યું છે, જે ઉદ્યોગથી સ્વતંત્ર છે. તે બધા માટે બનાવવામાં આવ્યું છે, બધા દ્વારા, અને તે બધા દ્વારા ભંડોળ પૂરું પાડવામાં આવે છે. તમે ઓપન ફૂડ ફેક્ટ્સને દાન આપીને અને લિલો સર્ચ એન્જિનનો ઉપયોગ કરીને અમારા કાર્યને સમર્થન આપી શકો છો.<br/><b>આભાર!</b>"
+msgstr "<<site_name>> એક બિન-લાભકારી સંગઠન દ્વારા બનાવવામાં આવ્યું છે, જે ઉદ્યોગથી સ્વતંત્ર છે. તે બધા માટે બનાવવામાં આવ્યું છે, બધા દ્વારા, અને તે બધા દ્વારા ભંડોળ પૂરું પાડવામાં આવે છે. તમે Open Food Factsને દાન આપીને અને લિલો સર્ચ એન્જિનનો ઉપયોગ કરીને અમારા કાર્યને સમર્થન આપી શકો છો.<br/><b>આભાર!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7689,7 +7684,7 @@ msgstr "લિલો સર્ચ એન્જિન"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "રોબોટ્સ દ્વારા ભારે દુરુપયોગને કારણે, અમે આ પૃષ્ઠ અજાણ્યા વપરાશકર્તાઓને સેવા આપી શકતા નથી. બધા ઓપન ફૂડ ફેક્ટ્સને ઍક્સેસ કરવા માટે કૃપા કરીને એક મફત ઓપન ફૂડ ફેક્ટ્સ એકાઉન્ટ બનાવો."
+msgstr "રોબોટ્સ દ્વારા ભારે દુરુપયોગને કારણે, અમે આ પૃષ્ઠ અજાણ્યા વપરાશકર્તાઓને સેવા આપી શકતા નથી. બધા Open Food Factsને ઍક્સેસ કરવા માટે કૃપા કરીને એક મફત Open Food Facts એકાઉન્ટ બનાવો."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7775,7 +7770,7 @@ msgstr "અનિચ્છનીય ઘટકો"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "આ પસંદગી ઓપન ફૂડ ફેક્ટ્સની ઘટકોની સૂચિની સમજ પર આધારિત છે અને તે સચોટ ન પણ હોઈ શકે, હંમેશા ઉત્પાદન જાતે તપાસો."
+msgstr "આ પસંદગી Open Food Factsની ઘટકોની સૂચિની સમજ પર આધારિત છે અને તે સચોટ ન પણ હોઈ શકે, હંમેશા ઉત્પાદન જાતે તપાસો."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7803,7 +7798,7 @@ msgstr "અમને આ મળ્યું નથી: {unwanted_ingredients}. �
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "તે પસંદગીઓ ઓપન ફૂડ ફેક્ટ્સની ઘટકોની સૂચિની સમજ પર આધારિત છે અને હંમેશા એવી શક્યતા રહે છે કે તે સચોટ અથવા સંપૂર્ણ ન પણ હોય, હંમેશા ઉત્પાદન જાતે તપાસો."
+msgstr "તે પસંદગીઓ Open Food Factsની ઘટકોની સૂચિની સમજ પર આધારિત છે અને હંમેશા એવી શક્યતા રહે છે કે તે સચોટ અથવા સંપૂર્ણ ન પણ હોય, હંમેશા ઉત્પાદન જાતે તપાસો."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/ha.po
+++ b/po/common/ha.po
@@ -63,7 +63,7 @@ msgstr "da <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">rukunin 
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Binciken samfurin Buɗe Bayanan Kyau"
+msgstr "Binciken samfurin Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "Wannan shafin samfurin bai cika ba. Za ku iya taimakawa wajen kammala shi ta hanyar gyara shi da ƙara ƙarin bayanai daga hotunan da muke da su, ko kuma ta hanyar ɗaukar ƙarin hotuna ta amfani da manhajar Buɗe Abinci ta Duniya don <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> ko <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Na gode!"
+msgstr "Wannan shafin samfurin bai cika ba. Za ku iya taimakawa wajen kammala shi ta hanyar gyara shi da ƙara ƙarin bayanai daga hotunan da muke da su, ko kuma ta hanyar ɗaukar ƙarin hotuna ta amfani da manhajar Open Food Facts don <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> ko <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Na gode!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "Wannan shafin samfurin bai cika ba. Za ku iya taimakawa wajen kammala shi ta hanyar gyara shi da ƙara ƙarin bayanai daga hotunan da muke da su, ko kuma ta hanyar ɗaukar ƙarin hotuna ta amfani da manhajar Buɗe Abinci ta Duniya don <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> ko <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Na gode!"
+msgstr "Wannan shafin samfurin bai cika ba. Za ku iya taimakawa wajen kammala shi ta hanyar gyara shi da ƙara ƙarin bayanai daga hotunan da muke da su, ko kuma ta hanyar ɗaukar ƙarin hotuna ta amfani da manhajar Open Food Facts don <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> ko <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Na gode!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Maki na Kore maki ne na muhalli daga A+ zuwa F wanda ke sauƙaƙa kwatanta tasirin kayayyakin abinci akan muhalli."
+msgstr "Green-Score maki ne na muhalli daga A+ zuwa F wanda ke sauƙaƙa kwatanta tasirin kayayyakin abinci akan muhalli."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Maki na Kore maki ne na muhalli daga A+ zuwa F wanda ke sauƙaƙa kwatanta tasirin kayayyakin abinci akan muhalli."
+msgstr "Green-Score maki ne na muhalli daga A+ zuwa F wanda ke sauƙaƙa kwatanta tasirin kayayyakin abinci akan muhalli."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -7686,7 +7681,7 @@ msgstr "Yi amfani da injin bincike"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Saboda tsananin cin zarafi daga mutummutumi, ba za mu iya ba da damar wannan shafin ga masu amfani da ba a tantance ba. Da fatan za a ƙirƙiri asusun Buɗaɗɗen Bayanan Abinci kyauta don samun damar duk Buɗaɗɗen Bayanan Abinci."
+msgstr "Saboda tsananin cin zarafi daga mutummutumi, ba za mu iya ba da damar wannan shafin ga masu amfani da ba a tantance ba. Da fatan za a ƙirƙiri asusun Open Food Facts kyauta don samun damar duk Open Food Facts."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "Abubuwan da ba a so"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "Wannan zaɓin ya dogara ne akan Fahimtar Bayanan Gaskiyar Abinci na jerin abubuwan sinadarai kuma maiyuwa ba daidai bane, koyaushe duba samfurin da kanku."
+msgstr "Wannan zaɓin ya dogara ne akan Open Food Facts na jerin abubuwan sinadarai kuma maiyuwa ba daidai bane, koyaushe duba samfurin da kanku."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "Ba mu gano: {unwanted_ingredients}. Wataƙila mun rasa wasu sinadarai, d
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "Wadancan abubuwan da ake so sun dogara ne akan Fahimtar Fahimtar Bayanan Abinci na abubuwan sinadaran kuma koyaushe akwai yuwuwar cewa bazai yi daidai ko cikakke ba, koyaushe duba samfurin da kanka."
+msgstr "Wadancan abubuwan da ake so sun dogara ne akan Open Food Facts na abubuwan sinadaran kuma koyaushe akwai yuwuwar cewa bazai yi daidai ko cikakke ba, koyaushe duba samfurin da kanka."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/he.po
+++ b/po/common/he.po
@@ -1765,11 +1765,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "ערך תזונתי"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://il.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4722,7 +4717,7 @@ msgstr "חסרים נתונים לחישוב Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "ציון תזונתי לא רלוונטי"
+msgstr "Nutri-Score לא רלוונטי"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4956,7 +4951,7 @@ msgstr "השפעה סביבתית נמוכה (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "הציון הירוק הוא ציון סביבתי מ-A+ עד F, המאפשר להשוות בקלות את ההשפעה של מוצרי מזון על הסביבה."
+msgstr "Green-Score הוא ציון סביבתי מ-A+ עד F, המאפשר להשוות בקלות את ההשפעה של מוצרי מזון על הסביבה."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4969,7 +4964,7 @@ msgstr "השפעה סביבתית נמוכה (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "הציון הירוק הוא ציון סביבתי מ-A+ עד F, המאפשר להשוות בקלות את ההשפעה של מוצרי מזון על הסביבה."
+msgstr "Green-Score הוא ציון סביבתי מ-A+ עד F, המאפשר להשוות בקלות את ההשפעה של מוצרי מזון על הסביבה."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5476,7 +5471,7 @@ msgstr "מוצרים עם ה־Nutri-Score הטוב ביותר"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "מוצרים עם ה־Edo-Score הטוב ביותר"
+msgstr "מוצרים עם ה־Green-Score הטוב ביותר"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -6491,7 +6486,7 @@ msgstr "ביטול בחירת התמונה"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "תודה רבה"
+msgstr "מידע נוסף על Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
@@ -6549,7 +6544,7 @@ msgstr "נוכל לבקש ממך להוסיף קטגוריה מדויקת כדי
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "הקטגוריה שיש לנו עבור מוצר זה אינה מדויקת מספיק כדי לחשב את הציון הירוק. האם תוכל להוסיף קטגוריית מוצר מדויקת יותר?"
+msgstr "הקטגוריה שיש לנו עבור מוצר זה אינה מדויקת מספיק כדי לחשב את Green-Score. האם תוכל להוסיף קטגוריית מוצר מדויקת יותר?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7688,7 +7683,7 @@ msgstr "דיווח על התמונה הזאת למפקחים שלנו"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "חסר לנו ערך גודל מנה ו/או יחידה לחישוב הציון התזונתי"
+msgstr "חסר לנו ערך גודל מנה ו/או יחידה לחישוב Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/hi.po
+++ b/po/common/hi.po
@@ -21,7 +21,7 @@ msgstr "दुनिया भर के खाद्य उत्पादो�
 
 msgctxt "tagline_off"
 msgid "Open Food Facts gathers information and data on food products from around the world."
-msgstr "ओपन फूड फैक्ट्स दुनिया भर के खाद्य उत्पादों की जानकारी और डेटा इकट्ठा करते हैं।"
+msgstr "Open Food Facts दुनिया भर के खाद्य उत्पादों की जानकारी और डेटा इकट्ठा करते हैं।"
 
 msgctxt "footer_tagline_off"
 msgid "A collaborative, free and open database of food products from around the world."
@@ -42,7 +42,7 @@ msgstr "दुनिया भर के कॉस्मेटिक उत्�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ओपन ब्यूटी फैक्ट्स दुनिया भर के कॉस्मेटिक उत्पादों से संबंधित जानकारी और डेटा एकत्र करता है।"
+msgstr "ओपन Open Beauty Facts दुनिया भर के कॉस्मेटिक उत्पादों से संबंधित जानकारी और डेटा एकत्र करता है।"
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr ""
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ब्यूटी फैक्ट्स उत्पाद खोज खोलें"
+msgstr "Open Beauty Facts उत्पाद खोज खोलें"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4705,7 +4700,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "न्यूट्री-स्कोर लागू नहीं"
+msgstr "Nutri-Score लागू नहीं"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4939,7 +4934,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ग्रीन-स्कोर एक पर्यावरणीय स्कोर है जो A+ से लेकर F तक होता है और इससे खाद्य उत्पादों के पर्यावरण पर पड़ने वाले प्रभाव की तुलना करना आसान हो जाता है।"
+msgstr "Green-Score एक पर्यावरणीय स्कोर है जो A+ से लेकर F तक होता है और इससे खाद्य उत्पादों के पर्यावरण पर पड़ने वाले प्रभाव की तुलना करना आसान हो जाता है।"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4952,7 +4947,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ग्रीन-स्कोर एक पर्यावरणीय स्कोर है जो A+ से लेकर F तक होता है और इससे खाद्य उत्पादों के पर्यावरण पर पड़ने वाले प्रभाव की तुलना करना आसान हो जाता है।"
+msgstr "Green-Score एक पर्यावरणीय स्कोर है जो A+ से लेकर F तक होता है और इससे खाद्य उत्पादों के पर्यावरण पर पड़ने वाले प्रभाव की तुलना करना आसान हो जाता है।"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5876,7 +5871,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ग्रीन-स्कोर को मूल रूप से फ्रांस के लिए विकसित किया गया था और अब इसे अन्य यूरोपीय देशों में भी लागू किया जा रहा है। ग्रीन-स्कोर का फार्मूला समय-समय पर सुधार के अधीन है, ताकि इसे और अधिक सटीक बनाया जा सके और प्रत्येक देश के लिए बेहतर अनुकूल बनाया जा सके।"
+msgstr "Green-Score को मूल रूप से फ्रांस के लिए विकसित किया गया था और अब इसे अन्य यूरोपीय देशों में भी लागू किया जा रहा है। Green-Score का फार्मूला समय-समय पर सुधार के अधीन है, ताकि इसे और अधिक सटीक बनाया जा सके और प्रत्येक देश के लिए बेहतर अनुकूल बनाया जा सके।"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6532,7 +6527,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "इस उत्पाद के लिए हमारे पास जो श्रेणी है, वह ग्रीन-स्कोर की गणना करने के लिए पर्याप्त सटीक नहीं है। क्या आप कोई और सटीक उत्पाद श्रेणी जोड़ सकते हैं?"
+msgstr "इस उत्पाद के लिए हमारे पास जो श्रेणी है, वह Green-Score की गणना करने के लिए पर्याप्त सटीक नहीं है। क्या आप कोई और सटीक उत्पाद श्रेणी जोड़ सकते हैं?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7671,15 +7666,15 @@ msgstr "इस छवि की रिपोर्ट हमारे मॉड�
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "न्यूट्री-स्कोर की गणना करने के लिए हमें सर्विंग साइज़ मान और/या इकाई की जानकारी नहीं मिल रही है"
+msgstr "Nutri-Score की गणना करने के लिए हमें सर्विंग साइज़ मान और/या इकाई की जानकारी नहीं मिल रही है"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> एक गैर-लाभकारी संस्था द्वारा बनाया गया है, जो उद्योग से स्वतंत्र है। यह सभी के लिए, सभी द्वारा बनाया गया है, और सभी द्वारा वित्त पोषित है। आप ओपन फ़ूड फैक्ट्स को दान देकर हमारे काम का समर्थन कर सकते हैं।<br/><b>धन्यवाद!</b>"
+msgstr "<<site_name>> एक गैर-लाभकारी संस्था द्वारा बनाया गया है, जो उद्योग से स्वतंत्र है। यह सभी के लिए, सभी द्वारा बनाया गया है, और सभी द्वारा वित्त पोषित है। आप Open Food Facts को दान देकर हमारे काम का समर्थन कर सकते हैं।<br/><b>धन्यवाद!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> एक गैर-लाभकारी संस्था द्वारा बनाया गया है, जो उद्योग से स्वतंत्र है। यह सभी के लिए, सभी द्वारा बनाया गया है, और सभी द्वारा वित्त पोषित है। आप ओपन फ़ूड फ़ैक्ट्स को दान देकर और लिलो सर्च इंजन का उपयोग करके भी हमारे काम का समर्थन कर सकते हैं।<br/><b>धन्यवाद!</b>"
+msgstr "<<site_name>> एक गैर-लाभकारी संस्था द्वारा बनाया गया है, जो उद्योग से स्वतंत्र है। यह सभी के लिए, सभी द्वारा बनाया गया है, और सभी द्वारा वित्त पोषित है। आप Open Food Facts को दान देकर और लिलो सर्च इंजन का उपयोग करके भी हमारे काम का समर्थन कर सकते हैं।<br/><b>धन्यवाद!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7687,7 +7682,7 @@ msgstr "लिलो सर्च इंजन"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "रोबोट द्वारा भारी दुरुपयोग के कारण, हम इस पृष्ठ को अज्ञात उपयोगकर्ताओं को नहीं दिखा पा रहे हैं। कृपया ओपन फ़ूड फ़ैक्ट्स तक पहुँचने के लिए एक निःशुल्क ओपन फ़ूड फ़ैक्ट्स खाता बनाएँ।"
+msgstr "रोबोट द्वारा भारी दुरुपयोग के कारण, हम इस पृष्ठ को अज्ञात उपयोगकर्ताओं को नहीं दिखा पा रहे हैं। कृपया Open Food Facts तक पहुँचने के लिए एक निःशुल्क Open Food Facts खाता बनाएँ।"
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7773,7 +7768,7 @@ msgstr "अवांछित सामग्री"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "यह वरीयता ओपन फूड फैक्ट्स की घटक सूची की समझ पर आधारित है और सटीक नहीं भी हो सकती है, इसलिए हमेशा उत्पाद की जांच स्वयं करें।"
+msgstr "यह वरीयता Open Food Facts की घटक सूची की समझ पर आधारित है और सटीक नहीं भी हो सकती है, इसलिए हमेशा उत्पाद की जांच स्वयं करें।"
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7801,7 +7796,7 @@ msgstr "हमें पता नहीं चला: {unwanted_ingredients}।
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "ये प्राथमिकताएं ओपन फूड फैक्ट्स की सामग्री सूची की समझ पर आधारित होती हैं और हमेशा यह संभावना रहती है कि यह सटीक या पूर्ण न हो, इसलिए हमेशा उत्पाद की जांच स्वयं करें।"
+msgstr "ये प्राथमिकताएं Open Food Facts की सामग्री सूची की समझ पर आधारित होती हैं और हमेशा यह संभावना रहती है कि यह सटीक या पूर्ण न हो, इसलिए हमेशा उत्पाद की जांच स्वयं करें।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/hr.po
+++ b/po/common/hr.po
@@ -63,7 +63,7 @@ msgstr "i Facebook grupa <a href=\"https://www.facebook.com/groups/OpenBeautyFac
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Otvori pretragu proizvoda Beauty Facts"
+msgstr "Otvori pretragu proizvoda Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1065,7 +1065,7 @@ msgstr "https://wiki.openfoodfacts.org"
 # Do not translate Open Beauty Facts but do translate Cosmetics
 msgctxt "footer_obf"
 msgid "Open Beauty Facts - Cosmetics"
-msgstr "Otvorene činjenice o ljepoti - Kozmetika"
+msgstr "Open Open Beauty Facts - Kozmetika"
 
 msgctxt "footer_obf_link"
 msgid "https://world.openbeautyfacts.org"
@@ -1073,7 +1073,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "Otvorene činjenice o hrani za proizvođače"
+msgstr "Open Food Facts za proizvođače"
 
 msgctxt "for"
 msgid "for"
@@ -1765,11 +1765,6 @@ msgstr ""
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4958,7 +4953,7 @@ msgstr "Nizak utjecaj na okoliš (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Zeleni rezultat je ekološka ocjena od A+ do F koja olakšava usporedbu utjecaja prehrambenih proizvoda na okoliš."
+msgstr "Green-Score je ekološka ocjena od A+ do F koja olakšava usporedbu utjecaja prehrambenih proizvoda na okoliš."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4971,7 +4966,7 @@ msgstr "Nizak utjecaj na okoliš (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Zeleni rezultat je ekološka ocjena od A+ do F koja olakšava usporedbu utjecaja prehrambenih proizvoda na okoliš."
+msgstr "Green-Score je ekološka ocjena od A+ do F koja olakšava usporedbu utjecaja prehrambenih proizvoda na okoliš."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5478,7 +5473,7 @@ msgstr "Proizvodi s najboljim Nutri-Scoreom"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "Proizvodi s najboljim zelenim rezultatom"
+msgstr "Proizvodi s najboljim Green-Score"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5885,7 +5880,7 @@ msgstr "Ako ste proizvođač ovog proizvoda, možete nam poslati podatke putem n
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "<a href=\"/green-score\">Zeleni rezultat</a> je eksperimentalni rezultat koji sažima utjecaje prehrambenih proizvoda na okoliš."
+msgstr "<a href=\"/green-score\">Green-Score</a> je eksperimentalni rezultat koji sažima utjecaje prehrambenih proizvoda na okoliš."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
@@ -5895,7 +5890,7 @@ msgstr "Formula Green-Scorea podložna je promjenama jer se redovito poboljšava
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Zeleni rezultat izvorno je razvijen za Francusku, a proširuje se i na druge europske zemlje. Formula Zelenog rezultata podložna je promjenama jer se redovito poboljšava kako bi bila preciznija i bolje prilagođena svakoj zemlji."
+msgstr "Green-Score izvorno je razvijen za Francusku, a proširuje se i na druge europske zemlje. Formula Zelenog rezultata podložna je promjenama jer se redovito poboljšava kako bi bila preciznija i bolje prilagođena svakoj zemlji."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."

--- a/po/common/ht.po
+++ b/po/common/ht.po
@@ -63,7 +63,7 @@ msgstr "ak gwoup Facebook <a href=\"https://www.facebook.com/groups/OpenBeautyFa
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Louvri rechèch pwodwi Enfòmasyon sou Bote"
+msgstr "Louvri rechèch pwodwi Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language

--- a/po/common/hu.po
+++ b/po/common/hu.po
@@ -166,7 +166,7 @@ msgstr "Összetevők, allergének, adalékanyagok, tápértékadatok, címkék, 
 
 msgctxt "search_description_opensearch_opff"
 msgid "Open Pet Food Facts product search"
-msgstr "Open Food Facts termékkereső"
+msgstr "Open Pet Food Facts termékkereső"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1764,11 +1764,6 @@ msgstr "Táplálkozási osztályzat"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Táplálkozási osztályzat"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -5183,7 +5178,7 @@ msgstr "Jelenleg kiválasztott beállítások"
 
 msgctxt "preferences_locally_saved"
 msgid "Your preferences are kept in your browser and never sent to Open Food Facts or anyone else."
-msgstr "A preferenciáit a böngészője tárolja, és soha nem küldi el az OpenFoodFacts vagy bárki más számára."
+msgstr "A preferenciáit a böngészője tárolja, és soha nem küldi el az Open Food Facts vagy bárki más számára."
 
 msgctxt "preferences_edit_your_preferences"
 msgid "Edit your preferences"
@@ -5547,7 +5542,7 @@ msgstr "A Green-Score még nem alkalmazható erre a kategóriára, de dolgozunk 
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Az Eco-score nincs kiszámítva"
+msgstr "Az Green-Score nincs kiszámítva"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5689,7 +5684,7 @@ msgstr "Az erdőlábnyom kiszámításakor figyelembe vesszük azokat az összet
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "Az Eco-score csak akkor számítható ki, ha a termék kellően pontos kategóriával rendelkezik."
+msgstr "Az Green-Score csak akkor számítható ki, ha a termék kellően pontos kategóriával rendelkezik."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."

--- a/po/common/hy.po
+++ b/po/common/hy.po
@@ -42,7 +42,7 @@ msgstr "Աշխարհի տարբեր երկրներից բաղադրիչների 
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "«Բաց գեղեցկության փաստեր»-ը հավաքում է տեղեկատվություն և տվյալներ կոսմետիկ արտադրանքի մասին ամբողջ աշխարհից։"
+msgstr "Open Beauty Facts-ը հավաքում է տեղեկատվություն և տվյալներ կոսմետիկ արտադրանքի մասին ամբողջ աշխարհից։"
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "և <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">Ֆեյս
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Բացեք «Գեղեցկության փաստեր» ապրանքի որոնումը"
+msgstr "Բացեք Open Beauty Facts ապրանքի որոնումը"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Կանաչ գնահատականը A+-ից մինչև F շրջակա միջավայրի վրա ազդեցության համեմատությունը հեշտացնում է։"
+msgstr "Green-Score A+-ից մինչև F շրջակա միջավայրի վրա ազդեցության համեմատությունը հեշտացնում է։"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Կանաչ գնահատականը A+-ից մինչև F շրջակա միջավայրի վրա ազդեցության համեմատությունը հեշտացնում է։"
+msgstr "Green-Score A+-ից մինչև F շրջակա միջավայրի վրա ազդեցության համեմատությունը հեշտացնում է։"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Կանաչ միավորը սկզբնապես մշակվել է Ֆրանսիայի համար և այժմ տարածվում է նաև այլ եվրոպական երկրներում: Կանաչ միավորի բանաձևը կարող է փոփոխվել, քանի որ այն պարբերաբար կատարելագործվում է՝ այն ավելի ճշգրիտ և յուրաքանչյուր երկրին ավելի հարմար դարձնելու համար:"
+msgstr "Green-Score սկզբնապես մշակվել է Ֆրանսիայի համար և այժմ տարածվում է նաև այլ եվրոպական երկրներում: Կանաչ միավորի բանաձևը կարող է փոփոխվել, քանի որ այն պարբերաբար կատարելագործվում է՝ այն ավելի ճշգրիտ և յուրաքանչյուր երկրին ավելի հարմար դարձնելու համար:"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Այս ապրանքի համար մեր ունեցած կատեգորիան բավականաչափ ճշգրիտ չէ կանաչ միավորը հաշվարկելու համար: Կարո՞ղ եք ավելացնել ավելի ճշգրիտ ապրանքի կատեգորիա:"
+msgstr "Այս ապրանքի համար մեր ունեցած կատեգորիան բավականաչափ ճշգրիտ չէ Green-Score հաշվարկելու համար: Կարո՞ղ եք ավելացնել ավելի ճշգրիտ ապրանքի կատեգորիա:"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7800,7 +7795,7 @@ msgstr "Մենք չենք հայտնաբերել՝ {unwanted_ingredients}: Հն�
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "Այդ նախընտրությունները հիմնված են «Բաց սննդի փաստերի» կողմից բաղադրիչների ցանկի վերաբերյալ ունեցած գիտելիքների վրա, և միշտ կա հնարավորություն, որ այն ճշգրիտ կամ ամբողջական չէ, միշտ ինքներդ ստուգեք ապրանքը։"
+msgstr "Այդ նախընտրությունները հիմնված են Open Food Facts կողմից բաղադրիչների ցանկի վերաբերյալ ունեցած գիտելիքների վրա, և միշտ կա հնարավորություն, որ այն ճշգրիտ կամ ամբողջական չէ, միշտ ինքներդ ստուգեք ապրանքը։"
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/id.po
+++ b/po/common/id.po
@@ -63,7 +63,7 @@ msgstr "dan <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\"> grup F
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Open Food Facts pencarian produk"
+msgstr "Open Beauty Facts pencarian produk"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1765,11 +1765,6 @@ msgstr "Nilai - nilai gizi"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Nilai gizi"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -3507,7 +3502,7 @@ msgstr "Unggah berkas spreedsheet (berkas Excel atau berkas CSV dikodekan UTF-8 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "import_data_file_format"
 msgid "You can upload a table with the columns Open Food Facts import format, or you can upload a table in any format and then select the columns to import."
-msgstr "Anda dapat mengunggah tabel dengan kolom format impor Open Food Fact, atau Anda dapat mengunggah tabel dengan format apa saja dan kemudian memilih kolom-kolom tertentu untuk diimpor."
+msgstr "Anda dapat mengunggah tabel dengan kolom format impor Open Food Facts, atau Anda dapat mengunggah tabel dengan format apa saja dan kemudian memilih kolom-kolom tertentu untuk diimpor."
 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "upload_product_data_file"
@@ -4710,7 +4705,7 @@ msgstr "Nutri-Score dihitung dan dapat diperhitungkan untuk semua produk, meskip
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "Nutri-Skor %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
@@ -4722,7 +4717,7 @@ msgstr "Data yang hilang untuk menghitung Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Skor Nutrisi tidak berlaku"
+msgstr "Nutri-Score tidak berlaku"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5893,7 +5888,7 @@ msgstr "Formula Green-Score dapat berubah sewaktu - waktu karena ia secara regul
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Skor Hijau awalnya dikembangkan untuk Prancis dan sedang diperluas ke negara-negara Eropa lainnya. Rumus Skor Hijau dapat berubah karena secara berkala ditingkatkan agar lebih tepat dan lebih sesuai untuk setiap negara."
+msgstr "Green-Score awalnya dikembangkan untuk Prancis dan sedang diperluas ke negara-negara Eropa lainnya. Rumus Green-Score dapat berubah karena secara berkala ditingkatkan agar lebih tepat dan lebih sesuai untuk setiap negara."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6491,7 +6486,7 @@ msgstr "Batalkan pilihan Gambar"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Terima Kasih"
+msgstr "Pelajari lebih lanjut tentang Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
@@ -6545,11 +6540,11 @@ msgstr "Bisakah Anda menambahkan informasi yang diperlukan untuk menghitung Nutr
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Bisakah Anda menambahkan kategori produk yang tepat sehingga kami dapat menghitung Skor Ramah Lingkungan?"
+msgstr "Bisakah Anda menambahkan kategori produk yang tepat sehingga kami dapat menghitung Green-Score?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Kategori yang kami miliki untuk produk ini tidak cukup presisi untuk menghitung Skor Hijau. Bisakah Anda menambahkan kategori produk yang lebih presisi?"
+msgstr "Kategori yang kami miliki untuk produk ini tidak cukup presisi untuk menghitung Green-Score. Bisakah Anda menambahkan kategori produk yang lebih presisi?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7688,7 +7683,7 @@ msgstr "Laporkan gambar ini ke moderator kami"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Kami tidak memiliki nilai ukuran porsi dan/atau unit untuk menghitung Skor Nutrisi"
+msgstr "Kami tidak memiliki nilai ukuran porsi dan/atau unit untuk menghitung Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/ii.po
+++ b/po/common/ii.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/is.po
+++ b/po/common/is.po
@@ -63,7 +63,7 @@ msgstr "og Facebook-hópurinn <a href=\"https://www.facebook.com/groups/OpenBeau
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Opna vöruleit fyrir fegurðarupplýsingar"
+msgstr "Opna vöruleit fyrir Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Næringargildi á ekki við"
+msgstr "Nutri-Score á ekki við"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Græna stigið er umhverfiseinkunn frá A+ til F sem gerir það auðvelt að bera saman áhrif matvæla á umhverfið."
+msgstr "Green-Score er umhverfiseinkunn frá A+ til F sem gerir það auðvelt að bera saman áhrif matvæla á umhverfið."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Græna stigið er umhverfiseinkunn frá A+ til F sem gerir það auðvelt að bera saman áhrif matvæla á umhverfið."
+msgstr "Green-Score er umhverfiseinkunn frá A+ til F sem gerir það auðvelt að bera saman áhrif matvæla á umhverfið."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Græna stigakerfið var upphaflega þróað fyrir Frakkland og er verið að útvíkka það til annarra Evrópulanda. Formúlan fyrir Græna stigakerfið getur breyst þar sem hún er stöðugt bætt til að gera hana nákvæmari og betur hentug fyrir hvert land."
+msgstr "Green-Score var upphaflega þróað fyrir Frakkland og er verið að útvíkka það til annarra Evrópulanda. Formúlan fyrir Green-Score getur breyst þar sem hún er stöðugt bætt til að gera hana nákvæmari og betur hentug fyrir hvert land."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Flokkurinn sem við höfum fyrir þessa vöru er ekki nógu nákvæmur til að reikna út Græna stigið. Gætirðu bætt við nákvæmari vöruflokki?"
+msgstr "Flokkurinn sem við höfum fyrir þessa vöru er ekki nógu nákvæmur til að reikna út Green-Score. Gætirðu bætt við nákvæmari vöruflokki?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,7 +7665,7 @@ msgstr "Tilkynna þessa mynd til stjórnenda okkar"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Við vantar skammtastærðargildið og/eða eininguna til að reikna út næringargildið"
+msgstr "Við vantar skammtastærðargildið og/eða eininguna til að reikna út Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/it.po
+++ b/po/common/it.po
@@ -1766,11 +1766,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Punteggio nutrizionale"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -2976,7 +2971,7 @@ msgstr "Unità"
 
 msgctxt "nova_groups_s"
 msgid "NOVA group"
-msgstr "Gruppo Nova"
+msgstr "Gruppo NOVA"
 
 msgctxt "nova_groups_p"
 msgid "NOVA groups"
@@ -3509,7 +3504,7 @@ msgstr "Carica un foglio di calcolo (file Excel o una virgola o tab separato di 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "import_data_file_format"
 msgid "You can upload a table with the columns Open Food Facts import format, or you can upload a table in any format and then select the columns to import."
-msgstr "Puoi caricare una tabella con le colonne in formato di importazione Apri fatti alimentari, oppure puoi caricare una tabella in qualsiasi formato e quindi selezionare le colonne da importare."
+msgstr "Puoi caricare una tabella con le colonne in formato di importazione Open Food Facts, oppure puoi caricare una tabella in qualsiasi formato e quindi selezionare le colonne da importare."
 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "upload_product_data_file"
@@ -4763,7 +4758,7 @@ msgstr "Trasformazione alimentare"
 
 msgctxt "attribute_nova_name"
 msgid "NOVA group"
-msgstr "Gruppo Nova"
+msgstr "Gruppo NOVA"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
@@ -4825,7 +4820,7 @@ msgstr "Filtro query"
 
 msgctxt "nova_group_producer"
 msgid "NOVA group"
-msgstr "Gruppo Nova"
+msgstr "Gruppo NOVA"
 
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
@@ -6493,7 +6488,7 @@ msgstr "Deseleziona Immagine"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Ulteriori informazioni su Punteggio-Nutri"
+msgstr "Ulteriori informazioni su Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"

--- a/po/common/iu.po
+++ b/po/common/iu.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/ja.po
+++ b/po/common/ja.po
@@ -166,7 +166,7 @@ msgstr "原材料、アレルゲン、添加物、栄養成分表、ラベル、
 
 msgctxt "search_description_opensearch_opff"
 msgid "Open Pet Food Facts product search"
-msgstr "ペットフードファクト製品検索を開く"
+msgstr "Open Pet Food Facts製品検索を開く"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1073,7 +1073,7 @@ msgstr "https://world-ja.openbeautyfacts.org/"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "生産者向けのオープンフードファクト"
+msgstr "生産者向けのOpen Food Facts"
 
 msgctxt "for"
 msgid "for"
@@ -1755,7 +1755,7 @@ msgstr "多くの場合に指定されるデフォルトの栄養成分を表に
 
 msgctxt "nutrition_data_table_asterisk"
 msgid "Essential nutrients to calculate the Nutri-Score."
-msgstr "栄養スコアを計算するのに不可欠な栄養素。"
+msgstr "Nutri-Scoreを計算するのに不可欠な栄養素。"
 
 msgctxt "nutrition_grades_p"
 msgid "Nutrition grades"
@@ -1764,11 +1764,6 @@ msgstr "栄養グレード"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "栄養グレード"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4591,7 +4586,7 @@ msgstr "製品ラベルに表示されているAからEまでのNutri-Scoreの�
 
 msgctxt "nutriscore_grade_producer_import_note"
 msgid "Open Food Facts computes the Nutri-Score grade based on the information provided (nutrition facts and category). If the grade we compute is different from the grade you provide, you will get a private notification on the producers platform so that the difference can be resolved."
-msgstr "Open Food Facts は、提供された情報(栄養成分およびカテゴリ)に基づいて栄養スコアグレードを計算します。 計算するグレードが提供されるグレードと異なる場合 生産者のプラットフォームに個人的な通知が届き、違いが解決できるようにします。"
+msgstr "Open Food Facts は、提供された情報(栄養成分およびカテゴリ)に基づいてNutri-Scoreグレードを計算します。 計算するグレードが提供されるグレードと異なる場合 生産者のプラットフォームに個人的な通知が届き、違いが解決できるようにします。"
 
 msgctxt "nutriscore_score_producer_note"
 msgid "Nutri-Score score (numeric value from which the A to E grade is derived)"
@@ -4722,7 +4717,7 @@ msgstr "Nutri-Scoreの計算をするためのデータが不足しています"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "栄養スコアは適用されません"
+msgstr "Nutri-Scoreは適用されません"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4948,7 +4943,7 @@ msgstr "環境"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "グリーンスコア"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4956,12 +4951,12 @@ msgstr "低環境負荷（Green-Score）"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "グリーンスコアは、A+からFまでの環境スコアであり、食品が環境に与える影響を簡単に比較できます。"
+msgstr "Green-Scoreは、A+からFまでのGreen-Scoreであり、食品が環境に与える影響を簡単に比較できます。"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "グリーンスコア"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4969,12 +4964,12 @@ msgstr "低環境負荷（Green-Score）"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "グリーンスコアは、A+からFまでの環境スコアであり、食品が環境に与える影響を簡単に比較できます。"
+msgstr "Green-Scoreは、A+からFまでのGreen-Scoreであり、食品が環境に与える影響を簡単に比較できます。"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "グリーンスコア %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5160,22 +5155,22 @@ msgstr "環境への影響"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "グリーンスコアスコア"
+msgstr "Green-Scoreスコア"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "グリーンスコアグレード"
+msgstr "Green-Scoreグレード"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "グリーンスコアの計算の詳細"
+msgstr "Green-Scoreの計算の詳細"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "グリーンスコアに関する情報"
+msgstr "Green-Scoreに関する情報"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5212,19 +5207,19 @@ msgstr "調理済み製品の栄養成分表示が不足している"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "グリーンスコア"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "グリーンスコア"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "グリーンスコア"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "グリーンスコア"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5530,7 +5525,7 @@ msgstr "ユーザーが削除されています。これには数分かかる場
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "グリーンスコアは適用されません"
+msgstr "Green-Scoreは適用されません"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5543,7 +5538,7 @@ msgstr "カテゴリには適用されません: {category}"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "エコスコアはまだこのカテゴリには適用できませんが、サポートの追加に取り組んでいます。"
+msgstr "Green-Scoreはまだこのカテゴリには適用できませんが、サポートの追加に取り組んでいます。"
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
@@ -5893,7 +5888,7 @@ msgstr "Green-Scoreの計算式は、より正確なものにするために定�
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "グリーンスコアは当初フランス向けに開発され、現在他のヨーロッパ諸国にも拡大されています。グリーンスコアの算出式は、各国の状況により適した、より正確なものとなるよう定期的に改良されているため、変更される可能性があります。"
+msgstr "Green-Scoreは当初フランス向けに開発され、現在他のヨーロッパ諸国にも拡大されています。Green-Scoreの算出式は、各国の状況により適した、より正確なものとなるよう定期的に改良されているため、変更される可能性があります。"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6491,7 +6486,7 @@ msgstr "画像の選択を解除"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "栄養スコアの詳細"
+msgstr "Nutri-Scoreについて詳しく知る"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
@@ -6541,15 +6536,15 @@ msgstr "材料リストを追加してもらえますか？"
 
 msgctxt "actions_to_compute_nutriscore"
 msgid "Could you add the information needed to compute the Nutri-Score?"
-msgstr "ニュートリスコアの計算に必要な情報を追加していただけますか？"
+msgstr "Nutri-Scoreの計算に必要な情報を追加していただけますか？"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "エコスコアを計算できるように製品を分類していただけますか？"
+msgstr "Green-Scoreを計算できるように製品を分類していただけますか？"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "この商品のカテゴリーは、グリーンスコアを計算するには精度が足りません。より精度の高い商品カテゴリーを追加していただけますか？"
+msgstr "この商品のカテゴリーは、Green-Scoreを計算するには精度が足りません。より精度の高い商品カテゴリーを追加していただけますか？"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7138,7 +7133,7 @@ msgstr "この製品は、Nutri-Score の計算では水とみなされます。
 
 msgctxt "nutriscore_is_fat_oil_nuts_seeds"
 msgid "This product is considered to be fat, oil, nuts or seeds for the calculation of the Nutri-Score."
-msgstr "この製品は、栄養スコアの計算では脂肪、油、ナッツ、種子とみなされます。"
+msgstr "この製品は、Nutri-Scoreの計算では脂肪、油、ナッツ、種子とみなされます。"
 
 msgctxt "nutriscore_is_cheese"
 msgid "This product is considered to be cheese for the calculation of the Nutri-Score."
@@ -7186,7 +7181,7 @@ msgstr "新しいNutri-Scoreのすべての改善点をご覧ください"
 
 msgctxt "nutriscore_explanation_what_it_is"
 msgid "The Nutri-Score is a logo on the overall nutritional quality of products."
-msgstr "ニュートリスコアは、製品の総合的な栄養品質を示すロゴです。"
+msgstr "Nutri-Scoreは、製品の総合的な栄養品質を示すロゴです。"
 
 msgctxt "nutriscore_explanation_what_it_takes_into_account"
 msgid "The score from A to E is calculated based on nutrients and foods to favor (proteins, fiber, fruits, vegetables and legumes ...) and nutrients to limit (calories, saturated fat, sugars, salt)."

--- a/po/common/jv.po
+++ b/po/common/jv.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Skor Ijo minangka skor lingkungan saka A+ nganti F sing nggampangake kanggo mbandhingake dampak produk panganan marang lingkungan."
+msgstr "Green-Score minangka skor lingkungan saka A+ nganti F sing nggampangake kanggo mbandhingake dampak produk panganan marang lingkungan."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Skor Ijo minangka skor lingkungan saka A+ nganti F sing nggampangake kanggo mbandhingake dampak produk panganan marang lingkungan."
+msgstr "Green-Score minangka skor lingkungan saka A+ nganti F sing nggampangake kanggo mbandhingake dampak produk panganan marang lingkungan."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"

--- a/po/common/ka.po
+++ b/po/common/ka.po
@@ -63,7 +63,7 @@ msgstr "და <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">Face
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "გახსენით სილამაზის ფაქტების პროდუქტის ძიება"
+msgstr "გახსენით Open Beauty Facts პროდუქტის ძიება"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -448,7 +448,7 @@ msgstr "შტრიხკოდის ნომერი:"
 
 msgctxt "you_can_also_help_us"
 msgid "You can also help to fund the Open Food Facts project"
-msgstr "ასევე შეგიძლიათ დაეხმაროთ ღია საკვების ფაქტების პროექტის დაფინანსებაში"
+msgstr "ასევე შეგიძლიათ დაეხმაროთ Open Food Facts პროექტის დაფინანსებაში"
 
 msgctxt "producers_administration_manual"
 msgid "Producers Admin manual"
@@ -1063,7 +1063,7 @@ msgstr "https://wiki.openfoodfacts.org"
 # Do not translate Open Beauty Facts but do translate Cosmetics
 msgctxt "footer_obf"
 msgid "Open Beauty Facts - Cosmetics"
-msgstr "ღია სილამაზის ფაქტები - კოსმეტიკა"
+msgstr "ღია Open Beauty Facts - კოსმეტიკა"
 
 msgctxt "footer_obf_link"
 msgid "https://world.openbeautyfacts.org"
@@ -1071,7 +1071,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "ღია საკვების ფაქტები მწარმოებლებისთვის"
+msgstr "Open Food Facts მწარმოებლებისთვის"
 
 msgctxt "for"
 msgid "for"
@@ -1763,11 +1763,6 @@ msgstr ""
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -2973,7 +2968,7 @@ msgstr "ერთეული"
 
 msgctxt "nova_groups_s"
 msgid "NOVA group"
-msgstr "ნოვა ჯგუფი"
+msgstr "NOVA"
 
 msgctxt "nova_groups_p"
 msgid "NOVA groups"
@@ -3740,7 +3735,7 @@ msgstr "მწარმოებლებისთვის განკუთ�
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_private_database"
 msgid "The product data and photos you send on the platform for producers are stored in a private database. You will be able to check that all the data is correct before making it available on the public Open Food Facts database."
-msgstr "მწარმოებლებისთვის პლატფორმაზე თქვენს მიერ გაგზავნილი პროდუქტის მონაცემები და ფოტოები ინახება კერძო მონაცემთა ბაზაში. თქვენ შეძლებთ გადაამოწმოთ ყველა მონაცემის სისწორე, სანამ მათ საჯარო ღია საკვების ფაქტების მონაცემთა ბაზაში განთავსებას შეძლებთ."
+msgstr "მწარმოებლებისთვის პლატფორმაზე თქვენს მიერ გაგზავნილი პროდუქტის მონაცემები და ფოტოები ინახება კერძო მონაცემთა ბაზაში. თქვენ შეძლებთ გადაამოწმოთ ყველა მონაცემის სისწორე, სანამ მათ საჯარო Open Food Facts მონაცემთა ბაზაში განთავსებას შეძლებთ."
 
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_licence"
@@ -4713,7 +4708,7 @@ msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
-msgstr "კვებითი ღირებულება უცნობია"
+msgstr "Nutri-Score უცნობია"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
 msgid "Missing data to compute the Nutri-Score"
@@ -4760,7 +4755,7 @@ msgstr "საკვების გადამუშავება"
 
 msgctxt "attribute_nova_name"
 msgid "NOVA group"
-msgstr "ნოვა ჯგუფი"
+msgstr "NOVA"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
@@ -4781,7 +4776,7 @@ msgstr "პროდუქტის დამუშავების დონ�
 # keep %s, it will be replaced by the group 1, 2, 3 or 4
 msgctxt "attribute_nova_group_title"
 msgid "NOVA %s"
-msgstr "ნოვა %s"
+msgstr "NOVA %s"
 
 msgctxt "attribute_nova_1_description_short"
 msgid "Unprocessed or minimally processed foods"
@@ -4822,7 +4817,7 @@ msgstr "მოთხოვნის ფილტრი"
 
 msgctxt "nova_group_producer"
 msgid "NOVA group"
-msgstr "ნოვა ჯგუფი"
+msgstr "NOVA"
 
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
@@ -4947,33 +4942,33 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "მწვანე ქულა"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "დაბალი გარემოზე ზემოქმედება (მწვანე ქულა)"
+msgstr "დაბალი გარემოზე ზემოქმედება (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "მწვანე ქულა არის გარემოსდაცვითი ქულა A+-დან F-მდე, რაც აადვილებს საკვები პროდუქტების გარემოზე ზემოქმედების შედარებას."
+msgstr "Green-Score არის გარემოსდაცვითი ქულა A+-დან F-მდე, რაც აადვილებს საკვები პროდუქტების გარემოზე ზემოქმედების შედარებას."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "მწვანე ქულა"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "დაბალი გარემოზე ზემოქმედება (მწვანე ქულა)"
+msgstr "დაბალი გარემოზე ზემოქმედება (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "მწვანე ქულა არის გარემოსდაცვითი ქულა A+-დან F-მდე, რაც აადვილებს საკვები პროდუქტების გარემოზე ზემოქმედების შედარებას."
+msgstr "Green-Score არის გარემოსდაცვითი ქულა A+-დან F-მდე, რაც აადვილებს საკვები პროდუქტების გარემოზე ზემოქმედების შედარებას."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "მწვანე ქულა %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5159,7 +5154,7 @@ msgstr "გარემოზე ზემოქმედება"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "მწვანე ქულის ქულა"
+msgstr "Green-Score ქულა"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
@@ -5169,12 +5164,12 @@ msgstr "Green-Score შეფასება"
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "მწვანე ქულის გაანგარიშების დეტალები"
+msgstr "Green-Score გაანგარიშების დეტალები"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "ინფორმაცია მწვანე ქულის შესახებ"
+msgstr "ინფორმაცია Green-Score შესახებ"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5211,19 +5206,19 @@ msgstr "მომზადებული პროდუქტის კვე�
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "მწვანე ქულა"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "მწვანე ქულა"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "მწვანე ქულა"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "მწვანე ქულა"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5471,11 +5466,11 @@ msgstr "ყველაზე ხშირად დასკანირებ�
 
 msgctxt "sort_by_nutriscore_score"
 msgid "Products with the best Nutri-Score"
-msgstr "პროდუქტები საუკეთესო ნუტრიციული ინდექსით"
+msgstr "პროდუქტები საუკეთესო Nutri-Score"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "საუკეთესო მწვანე ქულის მქონე პროდუქტები"
+msgstr "საუკეთესო Green-Score მქონე პროდუქტები"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5529,7 +5524,7 @@ msgstr "მომხმარებელი იშლება. ამას �
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "მწვანე ქულა არ გამოიყენება"
+msgstr "Green-Score არ გამოიყენება"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5542,11 +5537,11 @@ msgstr "ჯერ არ არის შესაფერისი შემ�
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "მწვანე ქულა ჯერ არ არის გამოყენებული ამ კატეგორიაში, მაგრამ ჩვენ ვმუშაობთ მისი მხარდაჭერის დამატებაზე."
+msgstr "Green-Score ჯერ არ არის გამოყენებული ამ კატეგორიაში, მაგრამ ჩვენ ვმუშაობთ მისი მხარდაჭერის დამატებაზე."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "მწვანე ქულა არ არის გამოთვლილი"
+msgstr "Green-Score არ არის გამოთვლილი"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5558,7 +5553,7 @@ msgstr "ზუსტი კატეგორია აკლია"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "ამ პროდუქტის მწვანე ქულის გამოთვლა ვერ შევძელით, რადგან მას გარკვეული მონაცემები აკლია. შეგიძლიათ დაგვეხმაროთ მის შევსებაში?"
+msgstr "ამ პროდუქტის Green-Score გამოთვლა ვერ შევძელით, რადგან მას გარკვეული მონაცემები აკლია. შეგიძლიათ დაგვეხმაროთ მის შევსებაში?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5666,7 +5661,7 @@ msgstr "%s -ის პროდუქტების ზოგიერთი �
 
 msgctxt "data_source_database_note_about_the_producers_platform"
 msgid "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_url>\">free plaform for producers</a> to access and complete this data, and to obtain reports, analysis and product improvements opportunities (e.g. better Nutri-Score)."
-msgstr "მწარმოებლებს შეუძლიათ გამოიყენონ ღია კვების ფაქტები <a href=\"<producers_platform_url>\">უფასო პლატფორმა მწარმოებლებისთვის</a> ამ მონაცემებზე წვდომისა და მათი შევსების, ასევე ანგარიშების, ანალიზისა და პროდუქტის გაუმჯობესების შესაძლებლობების მისაღებად (მაგ., უკეთესი Nutri-Score)."
+msgstr "მწარმოებლებს შეუძლიათ გამოიყენონ Open Food Facts <a href=\"<producers_platform_url>\">უფასო პლატფორმა მწარმოებლებისთვის</a> ამ მონაცემებზე წვდომისა და მათი შევსების, ასევე ანგარიშების, ანალიზისა და პროდუქტის გაუმჯობესების შესაძლებლობების მისაღებად (მაგ., უკეთესი Nutri-Score)."
 
 # variable names between { } must not be translated
 msgctxt "f_data_source_database_provider"
@@ -5688,7 +5683,7 @@ msgstr "ტყის კვალი გამოითვლება იმ �
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "მწვანე ქულის გამოთვლა მხოლოდ იმ შემთხვევაშია შესაძლებელი, თუ პროდუქტს საკმარისად ზუსტი კატეგორია აქვს."
+msgstr "Green-Score გამოთვლა მხოლოდ იმ შემთხვევაშია შესაძლებელი, თუ პროდუქტს საკმარისად ზუსტი კატეგორია აქვს."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5700,7 +5695,7 @@ msgstr "თუ თქვენ ხართ ამ პროდუქტის �
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "გაფრთხილება: მწვანე ქულის ზუსტად გამოსათვლელად საჭირო ზოგიერთი ინფორმაცია არ არის მოცემული (გამოთვლის დეტალები იხილეთ ქვემოთ)."
+msgstr "გაფრთხილება: Green-Score ზუსტად გამოსათვლელად საჭირო ზოგიერთი ინფორმაცია არ არის მოცემული (გამოთვლის დეტალები იხილეთ ქვემოთ)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5855,12 +5850,12 @@ msgstr "ამ პროდუქტის შეფუთვის შესა
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "მწვანე ქულის უფრო ზუსტი გამოთვლისთვის, შეგიძლიათ შეცვალოთ პროდუქტის გვერდი და დაამატოთ ისინი."
+msgstr "Green-Score უფრო ზუსტი გამოთვლისთვის, შეგიძლიათ შეცვალოთ პროდუქტის გვერდი და დაამატოთ ისინი."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "მწვანე ქულის უფრო ზუსტი გამოთვლისთვის, შეგიძლიათ შეცვალოთ პროდუქტის გვერდი და დაამატოთ ისინი."
+msgstr "Green-Score უფრო ზუსტი გამოთვლისთვის, შეგიძლიათ შეცვალოთ პროდუქტის გვერდი და დაამატოთ ისინი."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5882,17 +5877,17 @@ msgstr "თუ თქვენ ხართ ამ პროდუქტის �
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "<a href=\"/green-score\">მწვანე ქულა</a> არის ექსპერიმენტული ქულა, რომელიც აჯამებს საკვები პროდუქტების გარემოზე ზემოქმედებას."
+msgstr "<a href=\"/green-score\">Green-Score</a> არის ექსპერიმენტული ქულა, რომელიც აჯამებს საკვები პროდუქტების გარემოზე ზემოქმედებას."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
 msgid "The Green-Score formula is subject to change as it is regularly improved to make it more precise."
-msgstr "მწვანე ქულის ფორმულა შეიძლება შეიცვალოს, რადგან ის რეგულარულად იხვეწება უფრო ზუსტი რომ იყოს."
+msgstr "Green-Score ფორმულა შეიძლება შეიცვალოს, რადგან ის რეგულარულად იხვეწება უფრო ზუსტი რომ იყოს."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "„მწვანე ქულის“ ფორმულა თავდაპირველად საფრანგეთისთვის შემუშავდა და ამჟამად სხვა ევროპულ ქვეყნებშიც ვრცელდება. „მწვანე ქულის“ ფორმულა შეიძლება შეიცვალოს, რადგან ის რეგულარულად იხვეწება, რათა უფრო ზუსტი და თითოეული ქვეყნისთვის უკეთ მორგებული გახდეს."
+msgstr "Green-Score ფორმულა თავდაპირველად საფრანგეთისთვის შემუშავდა და ამჟამად სხვა ევროპულ ქვეყნებშიც ვრცელდება. Green-Score ფორმულა შეიძლება შეიცვალოს, რადგან ის რეგულარულად იხვეწება, რათა უფრო ზუსტი და თითოეული ქვეყნისთვის უკეთ მორგებული გახდეს."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6215,7 +6210,7 @@ msgstr "ბონუსები და მალუსები"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "მწვანე ქულა ამ პროდუქტისთვის"
+msgstr "Green-Score ამ პროდუქტისთვის"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6548,7 +6543,7 @@ msgstr "შეგიძლიათ დაამატოთ პროდუქ�
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ამ პროდუქტისთვის ჩვენს მიერ შემუშავებული კატეგორია საკმარისად ზუსტი არ არის მწვანე ქულის გამოსათვლელად. შეგიძლიათ დაამატოთ უფრო ზუსტი პროდუქტის კატეგორია?"
+msgstr "ამ პროდუქტისთვის ჩვენს მიერ შემუშავებული კატეგორია საკმარისად ზუსტი არ არის Green-Score გამოსათვლელად. შეგიძლიათ დაამატოთ უფრო ზუსტი პროდუქტის კატეგორია?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7687,7 +7682,7 @@ msgstr "შეატყობინეთ ამ სურათის შეს
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "ნუტრი-ქულის გამოსათვლელად პორციის ზომის მნიშვნელობა და/ან ერთეული არ გვაქვს მითითებული."
+msgstr "Nutri-Score გამოსათვლელად პორციის ზომის მნიშვნელობა და/ან ერთეული არ გვაქვს მითითებული."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/kab.po
+++ b/po/common/kab.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/kk.po
+++ b/po/common/kk.po
@@ -1759,11 +1759,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4939,7 +4934,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Жасыл балл - бұл азық-түлік өнімдерінің қоршаған ортаға әсерін салыстыруды жеңілдететін A+-тан F-қа дейінгі экологиялық балл."
+msgstr "Green-Score - бұл азық-түлік өнімдерінің қоршаған ортаға әсерін салыстыруды жеңілдететін A+-тан F-қа дейінгі экологиялық балл."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4952,7 +4947,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Жасыл балл - бұл азық-түлік өнімдерінің қоршаған ортаға әсерін салыстыруды жеңілдететін A+-тан F-қа дейінгі экологиялық балл."
+msgstr "Green-Score - бұл азық-түлік өнімдерінің қоршаған ортаға әсерін салыстыруды жеңілдететін A+-тан F-қа дейінгі экологиялық балл."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5876,7 +5871,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Жасыл ұпай формуласы бастапқыда Франция үшін жасалған және басқа еуропалық елдерге де таратылуда. Жасыл ұпай формуласы әр елге дәлірек және жақсырақ сәйкес келетіндей етіп үнемі жетілдіріліп отыратындықтан, өзгеруі мүмкін."
+msgstr "Green-Score формуласы бастапқыда Франция үшін жасалған және басқа еуропалық елдерге де таратылуда. Green-Score формуласы әр елге дәлірек және жақсырақ сәйкес келетіндей етіп үнемі жетілдіріліп отыратындықтан, өзгеруі мүмкін."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6532,7 +6527,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Бұл өнім үшін бізде бар санат Жасыл ұпайды есептеу үшін жеткілікті дәл емес. Дәлірек өнім санатын қоса аласыз ба?"
+msgstr "Бұл өнім үшін бізде бар санат Green-Score есептеу үшін жеткілікті дәл емес. Дәлірек өнім санатын қоса аласыз ба?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/km.po
+++ b/po/common/km.po
@@ -63,7 +63,7 @@ msgstr "និងក្រុមហ្វេសប៊ុក <a href=\"https://ww
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "បើកការស្វែងរកផលិតផល Beauty Facts"
+msgstr "បើកការស្វែងរកផលិតផល Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ពិន្ទុបៃតង គឺជាពិន្ទុបរិស្ថានពី A+ ដល់ F ដែលធ្វើឱ្យវាងាយស្រួលក្នុងការប្រៀបធៀបផលប៉ះពាល់នៃផលិតផលអាហារទៅលើបរិស្ថាន។"
+msgstr "Green-Score គឺជាពិន្ទុបរិស្ថានពី A+ ដល់ F ដែលធ្វើឱ្យវាងាយស្រួលក្នុងការប្រៀបធៀបផលប៉ះពាល់នៃផលិតផលអាហារទៅលើបរិស្ថាន។"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ពិន្ទុបៃតង គឺជាពិន្ទុបរិស្ថានពី A+ ដល់ F ដែលធ្វើឱ្យវាងាយស្រួលក្នុងការប្រៀបធៀបផលប៉ះពាល់នៃផលិតផលអាហារទៅលើបរិស្ថាន។"
+msgstr "Green-Score គឺជាពិន្ទុបរិស្ថានពី A+ ដល់ F ដែលធ្វើឱ្យវាងាយស្រួលក្នុងការប្រៀបធៀបផលប៉ះពាល់នៃផលិតផលអាហារទៅលើបរិស្ថាន។"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ដំបូងឡើយ រូបមន្តពិន្ទុបៃតងត្រូវបានបង្កើតឡើងសម្រាប់ប្រទេសបារាំង ហើយវាកំពុងត្រូវបានពង្រីកដល់ប្រទេសដទៃទៀតនៅអឺរ៉ុប។ រូបមន្តពិន្ទុបៃតងអាចនឹងមានការផ្លាស់ប្តូរ ដោយសារវាត្រូវបានកែលម្អជាប្រចាំ ដើម្បីធ្វើឱ្យវាកាន់តែច្បាស់លាស់ និងសមស្របជាងមុនសម្រាប់ប្រទេសនីមួយៗ។"
+msgstr "ដំបូងឡើយ រូបមន្តGreen-Scoreត្រូវបានបង្កើតឡើងសម្រាប់ប្រទេសបារាំង ហើយវាកំពុងត្រូវបានពង្រីកដល់ប្រទេសដទៃទៀតនៅអឺរ៉ុប។ រូបមន្តGreen-Scoreអាចនឹងមានការផ្លាស់ប្តូរ ដោយសារវាត្រូវបានកែលម្អជាប្រចាំ ដើម្បីធ្វើឱ្យវាកាន់តែច្បាស់លាស់ និងសមស្របជាងមុនសម្រាប់ប្រទេសនីមួយៗ។"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ប្រភេទ​ដែល​យើង​មាន​សម្រាប់​ផលិតផល​នេះ​មិន​ច្បាស់លាស់​គ្រប់គ្រាន់​ដើម្បី​គណនា​ពិន្ទុ​បៃតង។ តើអ្នកអាចបន្ថែមប្រភេទផលិតផលច្បាស់លាស់ជាងនេះបានទេ?"
+msgstr "ប្រភេទ​ដែល​យើង​មាន​សម្រាប់​ផលិតផល​នេះ​មិន​ច្បាស់លាស់​គ្រប់គ្រាន់​ដើម្បី​គណនា​Green-Score។ តើអ្នកអាចបន្ថែមប្រភេទផលិតផលច្បាស់លាស់ជាងនេះបានទេ?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/kmr_TR.po
+++ b/po/common/kmr_TR.po
@@ -63,7 +63,7 @@ msgstr "û koma Facebookê ya <a href=\"https://www.facebook.com/groups/OpenBeau
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Lêgerîna hilberê ya Rastiyên Bedewiyê veke"
+msgstr "Lêgerîna hilberê ya Open Beauty Facts veke"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Pûana Kesk pûanek jîngehê ji A+ heta F e ku berawirdkirina bandora hilberên xwarinê li ser jîngehê hêsan dike."
+msgstr "Green-Score pûanek jîngehê ji A+ heta F e ku berawirdkirina bandora hilberên xwarinê li ser jîngehê hêsan dike."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Pûana Kesk pûanek jîngehê ji A+ heta F e ku berawirdkirina bandora hilberên xwarinê li ser jîngehê hêsan dike."
+msgstr "Green-Score pûanek jîngehê ji A+ heta F e ku berawirdkirina bandora hilberên xwarinê li ser jîngehê hêsan dike."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Pûana Kesk di destpêkê de ji bo Fransayê hate pêşxistin û niha ji bo welatên din ên Ewropî tê berfirehkirin. Formula Pûana Kesk dikare biguhere ji ber ku ew bi rêkûpêk tê baştirkirin da ku ew rasttir û li gorî her welatekî be."
+msgstr "Green-Score di destpêkê de ji bo Fransayê hate pêşxistin û niha ji bo welatên din ên Ewropî tê berfirehkirin. Formula Green-Score dikare biguhere ji ber ku ew bi rêkûpêk tê baştirkirin da ku ew rasttir û li gorî her welatekî be."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Kategoriya ku me ji bo vê hilberê heye têra xwe rast nîne ku Pûana Kesk hesab bike. Ma hûn dikarin kategoriyek hilberê ya rasttir lê zêde bikin?"
+msgstr "Kategoriya ku me ji bo vê hilberê heye têra xwe rast nîne ku Green-Score hesab bike. Ma hûn dikarin kategoriyek hilberê ya rasttir lê zêde bikin?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/kn.po
+++ b/po/common/kn.po
@@ -42,7 +42,7 @@ msgstr "ಪ್ರಪಂಚದಾದ್ಯಂತದ ಸೌಂದರ್ಯವರ�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ಓಪನ್ ಬ್ಯೂಟಿ ಫ್ಯಾಕ್ಟ್ಸ್ ಪ್ರಪಂಚದಾದ್ಯಂತದ ಸೌಂದರ್ಯವರ್ಧಕ ಉತ್ಪನ್ನಗಳ ಮಾಹಿತಿ ಮತ್ತು ಡೇಟಾವನ್ನು ಸಂಗ್ರಹಿಸುತ್ತದೆ."
+msgstr "ಓಪನ್ Open Beauty Facts ಪ್ರಪಂಚದಾದ್ಯಂತದ ಸೌಂದರ್ಯವರ್ಧಕ ಉತ್ಪನ್ನಗಳ ಮಾಹಿತಿ ಮತ್ತು ಡೇಟಾವನ್ನು ಸಂಗ್ರಹಿಸುತ್ತದೆ."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "ಮತ್ತು <a href=\"https://www.facebook.com/groups/OpenBeautyFact
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ಬ್ಯೂಟಿ ಫ್ಯಾಕ್ಟ್ಸ್ ಉತ್ಪನ್ನ ಹುಡುಕಾಟವನ್ನು ತೆರೆಯಿರಿ"
+msgstr "Open Beauty Facts ಉತ್ಪನ್ನ ಹುಡುಕಾಟವನ್ನು ತೆರೆಯಿರಿ"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ಈ ಉತ್ಪನ್ನ ಪುಟ ಪೂರ್ಣಗೊಂಡಿಲ್ಲ. ನೀವು ಅದನ್ನು ಸಂಪಾದಿಸುವ ಮೂಲಕ ಮತ್ತು ನಮ್ಮಲ್ಲಿರುವ ಫೋಟೋಗಳಿಂದ ಹೆಚ್ಚಿನ ಡೇಟಾವನ್ನು ಸೇರಿಸುವ ಮೂಲಕ ಅಥವಾ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ಆಂಡ್ರಾಯ್ಡ್</a> ಅಥವಾ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">ಐಫೋನ್/ಐಪ್ಯಾಡ್</a>ಗಾಗಿ ಸಾರ್ವತ್ರಿಕ ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್ಸ್ ಅಪ್ಲಿಕೇಶನ್ ಬಳಸಿ ಹೆಚ್ಚಿನ ಫೋಟೋಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳುವ ಮೂಲಕ ಅದನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ಸಹಾಯ ಮಾಡಬಹುದು. ಧನ್ಯವಾದಗಳು!"
+msgstr "ಈ ಉತ್ಪನ್ನ ಪುಟ ಪೂರ್ಣಗೊಂಡಿಲ್ಲ. ನೀವು ಅದನ್ನು ಸಂಪಾದಿಸುವ ಮೂಲಕ ಮತ್ತು ನಮ್ಮಲ್ಲಿರುವ ಫೋಟೋಗಳಿಂದ ಹೆಚ್ಚಿನ ಡೇಟಾವನ್ನು ಸೇರಿಸುವ ಮೂಲಕ ಅಥವಾ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ಆಂಡ್ರಾಯ್ಡ್</a> ಅಥವಾ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">ಐಫೋನ್/ಐಪ್ಯಾಡ್</a>ಗಾಗಿ ಸಾರ್ವತ್ರಿಕ Open Food Facts ಅಪ್ಲಿಕೇಶನ್ ಬಳಸಿ ಹೆಚ್ಚಿನ ಫೋಟೋಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳುವ ಮೂಲಕ ಅದನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ಸಹಾಯ ಮಾಡಬಹುದು. ಧನ್ಯವಾದಗಳು!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ಈ ಉತ್ಪನ್ನ ಪುಟ ಪೂರ್ಣಗೊಂಡಿಲ್ಲ. ನೀವು ಅದನ್ನು ಸಂಪಾದಿಸುವ ಮೂಲಕ ಮತ್ತು ನಮ್ಮಲ್ಲಿರುವ ಫೋಟೋಗಳಿಂದ ಹೆಚ್ಚಿನ ಡೇಟಾವನ್ನು ಸೇರಿಸುವ ಮೂಲಕ ಅಥವಾ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ಆಂಡ್ರಾಯ್ಡ್</a> ಅಥವಾ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">ಐಫೋನ್/ಐಪ್ಯಾಡ್</a>ಗಾಗಿ ಸಾರ್ವತ್ರಿಕ ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್ಸ್ ಅಪ್ಲಿಕೇಶನ್ ಬಳಸಿ ಹೆಚ್ಚಿನ ಫೋಟೋಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳುವ ಮೂಲಕ ಅದನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ಸಹಾಯ ಮಾಡಬಹುದು. ಧನ್ಯವಾದಗಳು!"
+msgstr "ಈ ಉತ್ಪನ್ನ ಪುಟ ಪೂರ್ಣಗೊಂಡಿಲ್ಲ. ನೀವು ಅದನ್ನು ಸಂಪಾದಿಸುವ ಮೂಲಕ ಮತ್ತು ನಮ್ಮಲ್ಲಿರುವ ಫೋಟೋಗಳಿಂದ ಹೆಚ್ಚಿನ ಡೇಟಾವನ್ನು ಸೇರಿಸುವ ಮೂಲಕ ಅಥವಾ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ಆಂಡ್ರಾಯ್ಡ್</a> ಅಥವಾ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">ಐಫೋನ್/ಐಪ್ಯಾಡ್</a>ಗಾಗಿ ಸಾರ್ವತ್ರಿಕ Open Food Facts ಅಪ್ಲಿಕೇಶನ್ ಬಳಸಿ ಹೆಚ್ಚಿನ ಫೋಟೋಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳುವ ಮೂಲಕ ಅದನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ಸಹಾಯ ಮಾಡಬಹುದು. ಧನ್ಯವಾದಗಳು!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "ನ್ಯೂಟ್ರಿ-ಸ್ಕೋರ್ ಅನ್ವಯಿಸುವುದಿಲ್ಲ"
+msgstr "Nutri-Score ಅನ್ವಯಿಸುವುದಿಲ್ಲ"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ಗ್ರೀನ್-ಸ್ಕೋರ್ ಎಂದರೆ A+ ನಿಂದ F ವರೆಗಿನ ಪರಿಸರ ಸ್ಕೋರ್ ಆಗಿದ್ದು, ಆಹಾರ ಉತ್ಪನ್ನಗಳ ಪರಿಸರದ ಮೇಲಿನ ಪರಿಣಾಮವನ್ನು ಹೋಲಿಸುವುದು ಸುಲಭವಾಗುತ್ತದೆ."
+msgstr "Green-Score ಎಂದರೆ A+ ನಿಂದ F ವರೆಗಿನ ಪರಿಸರ ಸ್ಕೋರ್ ಆಗಿದ್ದು, ಆಹಾರ ಉತ್ಪನ್ನಗಳ ಪರಿಸರದ ಮೇಲಿನ ಪರಿಣಾಮವನ್ನು ಹೋಲಿಸುವುದು ಸುಲಭವಾಗುತ್ತದೆ."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ಗ್ರೀನ್-ಸ್ಕೋರ್ ಎಂದರೆ A+ ನಿಂದ F ವರೆಗಿನ ಪರಿಸರ ಸ್ಕೋರ್ ಆಗಿದ್ದು, ಆಹಾರ ಉತ್ಪನ್ನಗಳ ಪರಿಸರದ ಮೇಲಿನ ಪರಿಣಾಮವನ್ನು ಹೋಲಿಸುವುದು ಸುಲಭವಾಗುತ್ತದೆ."
+msgstr "Green-Score ಎಂದರೆ A+ ನಿಂದ F ವರೆಗಿನ ಪರಿಸರ ಸ್ಕೋರ್ ಆಗಿದ್ದು, ಆಹಾರ ಉತ್ಪನ್ನಗಳ ಪರಿಸರದ ಮೇಲಿನ ಪರಿಣಾಮವನ್ನು ಹೋಲಿಸುವುದು ಸುಲಭವಾಗುತ್ತದೆ."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ಗ್ರೀನ್-ಸ್ಕೋರ್ ಅನ್ನು ಆರಂಭದಲ್ಲಿ ಫ್ರಾನ್ಸ್‌ಗಾಗಿ ಅಭಿವೃದ್ಧಿಪಡಿಸಲಾಯಿತು ಮತ್ತು ಅದನ್ನು ಇತರ ಯುರೋಪಿಯನ್ ದೇಶಗಳಿಗೂ ವಿಸ್ತರಿಸಲಾಗುತ್ತಿದೆ. ಗ್ರೀನ್-ಸ್ಕೋರ್ ಸೂತ್ರವನ್ನು ನಿಯಮಿತವಾಗಿ ಸುಧಾರಿಸುವುದರಿಂದ ಅದು ಬದಲಾವಣೆಗೆ ಒಳಪಟ್ಟಿರುತ್ತದೆ, ಏಕೆಂದರೆ ಇದನ್ನು ಪ್ರತಿ ದೇಶಕ್ಕೂ ಹೆಚ್ಚು ನಿಖರವಾಗಿ ಮತ್ತು ಉತ್ತಮವಾಗಿ ಹೊಂದಿಕೊಳ್ಳುವಂತೆ ಮಾಡಲಾಗುತ್ತದೆ."
+msgstr "Green-Score ಅನ್ನು ಆರಂಭದಲ್ಲಿ ಫ್ರಾನ್ಸ್‌ಗಾಗಿ ಅಭಿವೃದ್ಧಿಪಡಿಸಲಾಯಿತು ಮತ್ತು ಅದನ್ನು ಇತರ ಯುರೋಪಿಯನ್ ದೇಶಗಳಿಗೂ ವಿಸ್ತರಿಸಲಾಗುತ್ತಿದೆ. Green-Score ಸೂತ್ರವನ್ನು ನಿಯಮಿತವಾಗಿ ಸುಧಾರಿಸುವುದರಿಂದ ಅದು ಬದಲಾವಣೆಗೆ ಒಳಪಟ್ಟಿರುತ್ತದೆ, ಏಕೆಂದರೆ ಇದನ್ನು ಪ್ರತಿ ದೇಶಕ್ಕೂ ಹೆಚ್ಚು ನಿಖರವಾಗಿ ಮತ್ತು ಉತ್ತಮವಾಗಿ ಹೊಂದಿಕೊಳ್ಳುವಂತೆ ಮಾಡಲಾಗುತ್ತದೆ."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ಈ ಉತ್ಪನ್ನಕ್ಕಾಗಿ ನಾವು ಹೊಂದಿರುವ ವರ್ಗವು ಗ್ರೀನ್-ಸ್ಕೋರ್ ಅನ್ನು ಲೆಕ್ಕಾಚಾರ ಮಾಡುವಷ್ಟು ನಿಖರವಾಗಿಲ್ಲ. ನೀವು ಹೆಚ್ಚು ನಿಖರವಾದ ಉತ್ಪನ್ನ ವರ್ಗವನ್ನು ಸೇರಿಸಬಹುದೇ?"
+msgstr "ಈ ಉತ್ಪನ್ನಕ್ಕಾಗಿ ನಾವು ಹೊಂದಿರುವ ವರ್ಗವು Green-Score ಅನ್ನು ಲೆಕ್ಕಾಚಾರ ಮಾಡುವಷ್ಟು ನಿಖರವಾಗಿಲ್ಲ. ನೀವು ಹೆಚ್ಚು ನಿಖರವಾದ ಉತ್ಪನ್ನ ವರ್ಗವನ್ನು ಸೇರಿಸಬಹುದೇ?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,7 +7665,7 @@ msgstr "ಈ ಚಿತ್ರವನ್ನು ನಮ್ಮ ಮಾಡರೇಟರ್
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "ನ್ಯೂಟ್ರಿ-ಸ್ಕೋರ್ ಅನ್ನು ಲೆಕ್ಕಾಚಾರ ಮಾಡಲು ನಮಗೆ ಸರ್ವಿಂಗ್ ಗಾತ್ರದ ಮೌಲ್ಯ ಮತ್ತು/ಅಥವಾ ಘಟಕ ಕಾಣೆಯಾಗಿದೆ."
+msgstr "Nutri-Score ಅನ್ನು ಲೆಕ್ಕಾಚಾರ ಮಾಡಲು ನಮಗೆ ಸರ್ವಿಂಗ್ ಗಾತ್ರದ ಮೌಲ್ಯ ಮತ್ತು/ಅಥವಾ ಘಟಕ ಕಾಣೆಯಾಗಿದೆ."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
@@ -7686,7 +7681,7 @@ msgstr "ಲಿಲೋ ಸರ್ಚ್ ಎಂಜಿನ್"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "ರೋಬೋಟ್‌ಗಳ ಭಾರೀ ದುರುಪಯೋಗದಿಂದಾಗಿ, ಗುರುತಿಸಲಾಗದ ಬಳಕೆದಾರರಿಗೆ ಈ ಪುಟವನ್ನು ಒದಗಿಸಲು ನಮಗೆ ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ. ಎಲ್ಲಾ ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸಲು ದಯವಿಟ್ಟು ಉಚಿತ ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್‌ಗಳ ಖಾತೆಯನ್ನು ರಚಿಸಿ."
+msgstr "ರೋಬೋಟ್‌ಗಳ ಭಾರೀ ದುರುಪಯೋಗದಿಂದಾಗಿ, ಗುರುತಿಸಲಾಗದ ಬಳಕೆದಾರರಿಗೆ ಈ ಪುಟವನ್ನು ಒದಗಿಸಲು ನಮಗೆ ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ. ಎಲ್ಲಾ Open Food Facts ಪ್ರವೇಶಿಸಲು ದಯವಿಟ್ಟು ಉಚಿತ ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್‌ಗಳ ಖಾತೆಯನ್ನು ರಚಿಸಿ."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "ಬೇಡದ ಪದಾರ್ಥಗಳು"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "ಈ ಆದ್ಯತೆಯು ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್ಸ್‌ನ ಪದಾರ್ಥಗಳ ಪಟ್ಟಿಯ ತಿಳುವಳಿಕೆಯನ್ನು ಆಧರಿಸಿದೆ ಮತ್ತು ಅದು ನಿಖರವಾಗಿಲ್ಲದಿರಬಹುದು, ಯಾವಾಗಲೂ ಉತ್ಪನ್ನವನ್ನು ನೀವೇ ಪರಿಶೀಲಿಸಿ."
+msgstr "ಈ ಆದ್ಯತೆಯು Open Food Facts ಪದಾರ್ಥಗಳ ಪಟ್ಟಿಯ ತಿಳುವಳಿಕೆಯನ್ನು ಆಧರಿಸಿದೆ ಮತ್ತು ಅದು ನಿಖರವಾಗಿಲ್ಲದಿರಬಹುದು, ಯಾವಾಗಲೂ ಉತ್ಪನ್ನವನ್ನು ನೀವೇ ಪರಿಶೀಲಿಸಿ."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "ನಮಗೆ ಇದು ಪತ್ತೆಯಾಗಲಿಲ್ಲ: {unwante
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "ಆ ಆದ್ಯತೆಗಳು ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್ಸ್‌ನ ಪದಾರ್ಥಗಳ ಪಟ್ಟಿಯ ತಿಳುವಳಿಕೆಯನ್ನು ಆಧರಿಸಿವೆ ಮತ್ತು ಅದು ನಿಖರವಾಗಿ ಅಥವಾ ಪೂರ್ಣವಾಗಿರದಿರುವ ಸಾಧ್ಯತೆ ಯಾವಾಗಲೂ ಇರುತ್ತದೆ, ಯಾವಾಗಲೂ ಉತ್ಪನ್ನವನ್ನು ನೀವೇ ಪರಿಶೀಲಿಸಿ."
+msgstr "ಆ ಆದ್ಯತೆಗಳು Open Food Facts ಪದಾರ್ಥಗಳ ಪಟ್ಟಿಯ ತಿಳುವಳಿಕೆಯನ್ನು ಆಧರಿಸಿವೆ ಮತ್ತು ಅದು ನಿಖರವಾಗಿ ಅಥವಾ ಪೂರ್ಣವಾಗಿರದಿರುವ ಸಾಧ್ಯತೆ ಯಾವಾಗಲೂ ಇರುತ್ತದೆ, ಯಾವಾಗಲೂ ಉತ್ಪನ್ನವನ್ನು ನೀವೇ ಪರಿಶೀಲಿಸಿ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/ko.po
+++ b/po/common/ko.po
@@ -687,7 +687,7 @@ msgstr "삭제됨:"
 
 msgctxt "donate"
 msgid "Donate to Open Food Facts"
-msgstr "Open Beauty Facts에게 기부하기"
+msgstr "Open Food Facts에게 기부하기"
 
 msgctxt "donate_link"
 msgid "https://world.openfoodfacts.org/donate-to-open-food-facts"
@@ -1072,7 +1072,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "생산자를 위한 식품 정보 공개"
+msgstr "생산자를 위한 Open Food Facts"
 
 msgctxt "for"
 msgid "for"
@@ -1754,7 +1754,7 @@ msgstr "표에는 기본적으로 자주 지정되는 영양분이 나열되어 
 
 msgctxt "nutrition_data_table_asterisk"
 msgid "Essential nutrients to calculate the Nutri-Score."
-msgstr "뉴트리스코어 계산에 필요한 필수 영양소."
+msgstr "Nutri-Score 계산에 필요한 필수 영양소."
 
 msgctxt "nutrition_grades_p"
 msgid "Nutrition grades"
@@ -1763,11 +1763,6 @@ msgstr "영양 등급"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "영양 등급"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -2973,11 +2968,11 @@ msgstr "단위"
 
 msgctxt "nova_groups_s"
 msgid "NOVA group"
-msgstr "노바 그룹"
+msgstr "NOVA"
 
 msgctxt "nova_groups_p"
 msgid "NOVA groups"
-msgstr "노바 그룹"
+msgstr "NOVA"
 
 # Title for the link to the explanation of what a NOVA Group is
 msgctxt "nova_groups_info"
@@ -4194,7 +4189,7 @@ msgstr "%s 카테고리의 평균값"
 # Keep the %s
 msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
-msgstr "%s 값을 %s(%s 차이)에서 %s(%s 차이)로 변경하여 뉴트리-스코어를 %s에서 %s(%s 차이)로 변경할 수 있습니다."
+msgstr "%s 값을 %s(%s 차이)에서 %s(%s 차이)로 변경하여 Nutri-Score를 %s에서 %s(%s 차이)로 변경할 수 있습니다."
 
 msgctxt "export_products_to_public_database_email"
 msgid "The platform for producers is still under development and we make manual checks before importing products to the public database. Please e-mail us at <a href=\"mailto:producers@openfoodfacts.org\">producers@openfoodfacts.org</a> to update the public database."
@@ -4709,7 +4704,7 @@ msgstr "Nutri-Score는 포장에 표시되지 않더라도 모든 제품에 대�
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "뉴트리스코어 %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
@@ -4760,7 +4755,7 @@ msgstr "식품 가공"
 
 msgctxt "attribute_nova_name"
 msgid "NOVA group"
-msgstr "노바 그룹"
+msgstr "NOVA"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
@@ -4822,7 +4817,7 @@ msgstr "쿼리 필터"
 
 msgctxt "nova_group_producer"
 msgid "NOVA group"
-msgstr "노바 그룹"
+msgstr "NOVA"
 
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
@@ -4948,7 +4943,7 @@ msgstr "환경"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "친환경 점수"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4956,12 +4951,12 @@ msgstr "낮은 환경 영향(Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "그린스코어는 A+부터 F까지 등급으로 나뉜 환경 점수로, 식품이 환경에 미치는 영향을 쉽게 비교할 수 있도록 해줍니다."
+msgstr "Green-Score는 A+부터 F까지 등급으로 나뉜 Green-Score로, 식품이 환경에 미치는 영향을 쉽게 비교할 수 있도록 해줍니다."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "친환경 점수"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4969,12 +4964,12 @@ msgstr "낮은 환경 영향(Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "그린스코어는 A+부터 F까지 등급으로 나뉜 환경 점수로, 식품이 환경에 미치는 영향을 쉽게 비교할 수 있도록 해줍니다."
+msgstr "Green-Score는 A+부터 F까지 등급으로 나뉜 Green-Score로, 식품이 환경에 미치는 영향을 쉽게 비교할 수 있도록 해줍니다."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "환경 점수 %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5160,22 +5155,22 @@ msgstr "환경적 영향"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "그린스코어 점수"
+msgstr "Green-Score 점수"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "그린스코어 등급"
+msgstr "Green-Score 등급"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "그린스코어 계산 세부 정보"
+msgstr "Green-Score 계산 세부 정보"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "그린스코어에 대한 정보"
+msgstr "Green-Score에 대한 정보"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5212,19 +5207,19 @@ msgstr "준비된 제품의 영양 정보가 누락되었습니다."
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "친환경 점수"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "친환경 점수"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "친환경 점수"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "친환경 점수"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5395,7 +5390,7 @@ msgstr "이 플랫폼은 또한 제품에 대한 심층 분석을 제공합니�
 # It = the platform
 msgctxt "product_edits_by_producers_indicators"
 msgid "It computes indicators such as the Nutri-Score, NOVA, and the Green-Score, and automatically identifies suggestions to improve them (for instance all products that would get a better Nutri-Score grade with a slight composition change)."
-msgstr "이 시스템은 뉴트리스코어, NOVA, 그린스코어와 같은 지표를 계산하고, 이를 개선할 수 있는 방안을 자동으로 제시합니다(예: 성분 구성을 약간만 변경하면 뉴트리스코어 등급이 향상되는 모든 제품)."
+msgstr "이 시스템은 Nutri-Score, NOVA, Green-Score와 같은 지표를 계산하고, 이를 개선할 수 있는 방안을 자동으로 제시합니다(예: 성분 구성을 약간만 변경하면 Nutri-Score 등급이 향상되는 모든 제품)."
 
 msgctxt "attribute_forest_footprint_name"
 msgid "Forest footprint"
@@ -5530,7 +5525,7 @@ msgstr "사용자 정보가 삭제되고 있습니다. 몇 분 정도 소요될 
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "그린스코어는 적용되지 않습니다."
+msgstr "Green-Score는 적용되지 않습니다."
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5547,7 +5542,7 @@ msgstr "Green-Score는 아직 이 범주에 적용할 수 없지만 이에 대�
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "에코 점수가 계산되지 않음"
+msgstr "Green-Score가 계산되지 않음"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5893,7 +5888,7 @@ msgstr "Green-Score 공식은 더 정확하게 만들기 위해 정기적으로 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "그린스코어는 원래 프랑스를 위해 개발되었으며 현재 다른 유럽 국가로 확대 적용되고 있습니다. 그린스코어 공식은 각 국가에 더욱 적합하고 정확도를 높이기 위해 정기적으로 개선되므로 변경될 수 있습니다."
+msgstr "Green-Score는 원래 프랑스를 위해 개발되었으며 현재 다른 유럽 국가로 확대 적용되고 있습니다. Green-Score 공식은 각 국가에 더욱 적합하고 정확도를 높이기 위해 정기적으로 개선되므로 변경될 수 있습니다."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6216,7 +6211,7 @@ msgstr "보너스 및 과오"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "이 제품의 에코 점수"
+msgstr "이 제품의 Green-Score"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -7134,19 +7129,19 @@ msgstr "결석"
 
 msgctxt "nutriscore_is_water"
 msgid "This product is considered to be water for the calculation of the Nutri-Score."
-msgstr "이 제품은 뉴트리스코어 계산 시 물로 간주됩니다."
+msgstr "이 제품은 Nutri-Score 계산 시 물로 간주됩니다."
 
 msgctxt "nutriscore_is_fat_oil_nuts_seeds"
 msgid "This product is considered to be fat, oil, nuts or seeds for the calculation of the Nutri-Score."
-msgstr "이 제품은 뉴트리스코어 계산 시 지방, 기름, 견과류 또는 씨앗류로 간주됩니다."
+msgstr "이 제품은 Nutri-Score 계산 시 지방, 기름, 견과류 또는 씨앗류로 간주됩니다."
 
 msgctxt "nutriscore_is_cheese"
 msgid "This product is considered to be cheese for the calculation of the Nutri-Score."
-msgstr "이 제품은 뉴트리스코어 계산 시 치즈로 간주됩니다."
+msgstr "이 제품은 Nutri-Score 계산 시 치즈로 간주됩니다."
 
 msgctxt "nutriscore_is_red_meat_product"
 msgid "This product is considered to be a red meat product for the calculation of the Nutri-Score."
-msgstr "이 제품은 뉴트리스코어 계산 시 붉은 육류 제품으로 간주됩니다."
+msgstr "이 제품은 Nutri-Score 계산 시 붉은 육류 제품으로 간주됩니다."
 
 msgctxt "nutriscore_count_proteins_reason_beverage"
 msgid "Points for proteins are counted because the product is considered to be a beverage."
@@ -7174,19 +7169,19 @@ msgstr "단백질 점수는 마이너스 점수가 11점 이상이기 때문에 
 
 msgctxt "nutriscore_new_computation_title"
 msgid "Discover the new Nutri-Score!"
-msgstr "새로운 뉴트리스코어를 만나보세요!"
+msgstr "새로운 Nutri-Score를 만나보세요!"
 
 msgctxt "nutriscore_new_computation_description"
 msgid "<p>The computation of the Nutri-Score is evolving to provide better recommendations based on the latest scientific evidence.</p><p>Main improvements:</p><ul><li>Better score for some fatty fish and oils rich in good fats</li><li>Better score for whole products rich in fiber</li><li>Worse score for products containing a lot of salt or sugar</li><li>Worse score for red meat (compared to poultry)</li></ul>"
-msgstr "<p>뉴트리스코어 계산 방식은 최신 과학적 근거를 바탕으로 더 나은 권장 사항을 제공하기 위해 지속적으로 발전하고 있습니다.</p><p>주요 개선 사항:</p><ul><li>지방이 풍부한 생선과 좋은 지방이 풍부한 오일의 점수 향상</li><li>식이섬유가 풍부한 가공식품의 점수 향상</li><li>소금이나 설탕 함량이 높은 제품의 점수 하락</li><li>붉은 육류(가금류 대비)의 점수 하락</li></ul>"
+msgstr "<p>Nutri-Score 계산 방식은 최신 과학적 근거를 바탕으로 더 나은 권장 사항을 제공하기 위해 지속적으로 발전하고 있습니다.</p><p>주요 개선 사항:</p><ul><li>지방이 풍부한 생선과 좋은 지방이 풍부한 오일의 점수 향상</li><li>식이섬유가 풍부한 가공식품의 점수 향상</li><li>소금이나 설탕 함량이 높은 제품의 점수 하락</li><li>붉은 육류(가금류 대비)의 점수 하락</li></ul>"
 
 msgctxt "nutriscore_new_computation_link_text"
 msgid "Discover all the improvements of the new Nutri-Score"
-msgstr "새로운 뉴트리스코어의 모든 개선 사항을 확인해 보세요."
+msgstr "새로운 Nutri-Score의 모든 개선 사항을 확인해 보세요."
 
 msgctxt "nutriscore_explanation_what_it_is"
 msgid "The Nutri-Score is a logo on the overall nutritional quality of products."
-msgstr "뉴트리스코어는 제품의 전반적인 영양 품질을 나타내는 로고입니다."
+msgstr "Nutri-Score는 제품의 전반적인 영양 품질을 나타내는 로고입니다."
 
 msgctxt "nutriscore_explanation_what_it_takes_into_account"
 msgid "The score from A to E is calculated based on nutrients and foods to favor (proteins, fiber, fruits, vegetables and legumes ...) and nutrients to limit (calories, saturated fat, sugars, salt)."
@@ -7202,7 +7197,7 @@ msgstr "이 로고의 표시는 공중 보건 당국에서 권장하는 사항�
 
 msgctxt "nutriscore_explanation_title"
 msgid "What is the Nutri-Score?"
-msgstr "뉴트리스코어란 무엇인가요?"
+msgstr "Nutri-Score란 무엇인가요?"
 
 msgctxt "nutrient_info_energy_risk"
 msgid "Energy intakes above energy requirements are associated with increased risks of weight gain, overweight, obesity, and consequently risk of diet-related chronic diseases."
@@ -7444,11 +7439,11 @@ msgstr "제품 데이터가 포함된 파일을 선택하세요."
 
 msgctxt "number_of_products_without_nutriscore"
 msgid "Number of products without Nutri-Score"
-msgstr "뉴트리스코어가 없는 제품 수"
+msgstr "Nutri-Score가 없는 제품 수"
 
 msgctxt "percent_of_products_with_nutriscore"
 msgid "% of products where Nutri-Score is computed"
-msgstr "뉴트리스코어가 계산되는 제품의 비율"
+msgstr "Nutri-Score가 계산되는 제품의 비율"
 
 msgctxt "products_to_be_exported"
 msgid "Products to be exported"
@@ -7460,7 +7455,7 @@ msgstr "수출 제품"
 
 msgctxt "opportunities_to_improve_nutriscore"
 msgid "Opp. for Nutri-Score improvements"
-msgstr "뉴트리스코어 개선에 반대합니다."
+msgstr "Nutri-Score 개선에 반대합니다."
 
 msgctxt "date_of_last_update"
 msgid "Date of last update"
@@ -7615,7 +7610,7 @@ msgstr "여러 연구에 따르면 초가공식품 섭취량을 줄이는 것이
 
 msgctxt "discover_the_evolution_of_the_nutriscore_grades_of_your_products"
 msgid "Discover the evolution of the Nutri-Score grades of your products"
-msgstr "귀사 제품의 뉴트리스코어 등급 변화 추이를 확인해 보세요."
+msgstr "귀사 제품의 Nutri-Score 등급 변화 추이를 확인해 보세요."
 
 msgctxt "add_products_to_discover_the_evolution_of_their_nutriscore_grades"
 msgid "Add products with a category, ingredients list and nutrition facts to discover the evolution of their Nutri-Score grades."

--- a/po/common/kw.po
+++ b/po/common/kw.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/ky.po
+++ b/po/common/ky.po
@@ -63,7 +63,7 @@ msgstr "жана салым кошуучулар үчүн <a href=\"https://www.
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Ачык сулуулук фактылары продуктуну издөө"
+msgstr "Open Beauty Facts продуктуну издөө"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Жашыл балл – бул азык-түлүк продуктуларынын айлана-чөйрөгө тийгизген таасирин салыштырууну жеңилдетүүчү А+тан Fга чейинки экологиялык балл."
+msgstr "Green-Score – бул азык-түлүк продуктуларынын айлана-чөйрөгө тийгизген таасирин салыштырууну жеңилдетүүчү А+тан Fга чейинки экологиялык балл."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Жашыл балл – бул азык-түлүк продуктуларынын айлана-чөйрөгө тийгизген таасирин салыштырууну жеңилдетүүчү А+тан Fга чейинки экологиялык балл."
+msgstr "Green-Score – бул азык-түлүк продуктуларынын айлана-чөйрөгө тийгизген таасирин салыштырууну жеңилдетүүчү А+тан Fга чейинки экологиялык балл."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Бул продукт үчүн бизде бар категория Жашыл-Упайды эсептөө үчүн жетиштүү так эмес. Сиз дагы так продукт категориясын кошо аласызбы?"
+msgstr "Бул продукт үчүн бизде бар категория Green-Score эсептөө үчүн жетиштүү так эмес. Сиз дагы так продукт категориясын кошо аласызбы?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/la.po
+++ b/po/common/la.po
@@ -63,7 +63,7 @@ msgstr "et grex Facebookianus <a href=\"https://www.facebook.com/groups/OpenBeau
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Aperi inquisitionem productorum Factorum Pulchritudinis"
+msgstr "Aperi inquisitionem productorum Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Viridis Punctus est aestimatio environmentalis ab A+ ad F quae facilem reddit comparationem effectus productorum cibariorum in ambitum."
+msgstr "Green-Score est aestimatio environmentalis ab A+ ad F quae facilem reddit comparationem effectus productorum cibariorum in ambitum."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Viridis Punctus est aestimatio environmentalis ab A+ ad F quae facilem reddit comparationem effectus productorum cibariorum in ambitum."
+msgstr "Green-Score est aestimatio environmentalis ab A+ ad F quae facilem reddit comparationem effectus productorum cibariorum in ambitum."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Categoria quam huic producto habemus non satis accurata est ad Punctum Viride computandum. Potesne categoriam producti accuratiorem addere?"
+msgstr "Categoria quam huic producto habemus non satis accurata est ad Green-Score computandum. Potesne categoriam producti accuratiorem addere?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/lb.po
+++ b/po/common/lb.po
@@ -63,7 +63,7 @@ msgstr "an d'Facebook-Grupp <a href=\"https://www.facebook.com/groups/OpenBeauty
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Produktsich iwwer Beauty Facts opmaachen"
+msgstr "Produktsich iwwer Open Beauty Facts opmaachen"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -448,7 +448,7 @@ msgstr "Barcode Nummer:"
 
 msgctxt "you_can_also_help_us"
 msgid "You can also help to fund the Open Food Facts project"
-msgstr "Dir kënnt och hëllefe den OpenFoodFacts Projet ze ënnerstëtzen "
+msgstr "Dir kënnt och hëllefe den Open Food Facts Projet ze ënnerstëtzen"
 
 msgctxt "producers_administration_manual"
 msgid "Producers Admin manual"
@@ -1758,11 +1758,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language

--- a/po/common/lo.po
+++ b/po/common/lo.po
@@ -63,7 +63,7 @@ msgstr "ແລະ ກຸ່ມເຟສບຸກ <a href=\"https://www.facebook.
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ເປີດການຄົ້ນຫາຜະລິດຕະພັນ Beauty Facts"
+msgstr "ເປີດການຄົ້ນຫາຜະລິດຕະພັນ Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ຄະແນນສີຂຽວແມ່ນຄະແນນດ້ານສິ່ງແວດລ້ອມຕັ້ງແຕ່ A+ ຫາ F ເຊິ່ງເຮັດໃຫ້ງ່າຍຕໍ່ການປຽບທຽບຜົນກະທົບຂອງຜະລິດຕະພັນອາຫານຕໍ່ສິ່ງແວດລ້ອມ."
+msgstr "Green-Scoreແມ່ນຄະແນນດ້ານສິ່ງແວດລ້ອມຕັ້ງແຕ່ A+ ຫາ F ເຊິ່ງເຮັດໃຫ້ງ່າຍຕໍ່ການປຽບທຽບຜົນກະທົບຂອງຜະລິດຕະພັນອາຫານຕໍ່ສິ່ງແວດລ້ອມ."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ຄະແນນສີຂຽວແມ່ນຄະແນນດ້ານສິ່ງແວດລ້ອມຕັ້ງແຕ່ A+ ຫາ F ເຊິ່ງເຮັດໃຫ້ງ່າຍຕໍ່ການປຽບທຽບຜົນກະທົບຂອງຜະລິດຕະພັນອາຫານຕໍ່ສິ່ງແວດລ້ອມ."
+msgstr "Green-Scoreແມ່ນຄະແນນດ້ານສິ່ງແວດລ້ອມຕັ້ງແຕ່ A+ ຫາ F ເຊິ່ງເຮັດໃຫ້ງ່າຍຕໍ່ການປຽບທຽບຜົນກະທົບຂອງຜະລິດຕະພັນອາຫານຕໍ່ສິ່ງແວດລ້ອມ."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"

--- a/po/common/lt.po
+++ b/po/common/lt.po
@@ -63,7 +63,7 @@ msgstr "ir <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">„Faceb
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Atidaryti „Beauty Facts“ produktų paiešką"
+msgstr "Atidaryti „Open Beauty Facts“ produktų paiešką"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1764,11 +1764,6 @@ msgstr "Mitybos pažymiai"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Mitybos klasė"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -5475,7 +5470,7 @@ msgstr "Produktai su geriausiu Nutri-Score"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "Produktai su geriausiu ekologiniu balu"
+msgstr "Produktai su geriausiu Green-Score"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5529,7 +5524,7 @@ msgstr "Vartotojas ištrinamas. Tai gali užtrukti kelias minutes."
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "„Green Score“ netaikomas"
+msgstr "„Green-Score“ netaikomas"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5546,7 +5541,7 @@ msgstr "Green-Score šiai kategorijai dar netaikomas, tačiau stengiamės, kad j
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Ekologinis balas neapskaičiuotas"
+msgstr "Green-Score neapskaičiuotas"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5688,7 +5683,7 @@ msgstr "Miško pėdsakas apskaičiuojamas atsižvelgiant į ingredientus, kurių
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "Ekologinį balą galima apskaičiuoti tik tuo atveju, jei produktas turi pakankamai tikslią kategoriją."
+msgstr "Green-Score galima apskaičiuoti tik tuo atveju, jei produktas turi pakankamai tikslią kategoriją."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5700,7 +5695,7 @@ msgstr "Jei esate šio gaminio gamintojas, galite atsiųsti mums informaciją su
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "Įspėjimas: kai kuri informacija, reikalinga norint tiksliai apskaičiuoti ekologinį balą, nepateikiama (žr. toliau pateiktą skaičiavimo informaciją)."
+msgstr "Įspėjimas: kai kuri informacija, reikalinga norint tiksliai apskaičiuoti Green-Score, nepateikiama (žr. toliau pateiktą skaičiavimo informaciją)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5855,12 +5850,12 @@ msgstr "Informacija apie šios prekės pakuotę nėra pakankamai tiksli (tikslio
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "Norėdami tiksliau apskaičiuoti ekologinį balą, galite pakeisti produkto puslapį ir juos pridėti."
+msgstr "Norėdami tiksliau apskaičiuoti Green-Score, galite pakeisti produkto puslapį ir juos pridėti."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "Norėdami tiksliau apskaičiuoti ekologinį balą, galite redaguoti produkto puslapį ir juos pridėti."
+msgstr "Norėdami tiksliau apskaičiuoti Green-Score, galite redaguoti produkto puslapį ir juos pridėti."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -6215,7 +6210,7 @@ msgstr "Premijos ir trūkumai"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Šio produkto ekologinis balas"
+msgstr "Šio produkto Green-Score"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"

--- a/po/common/lv.po
+++ b/po/common/lv.po
@@ -21,7 +21,7 @@ msgstr "Sadarbības, bezmaksas un atvērta datubāze ar sastāvdaļām, uzturvē
 
 msgctxt "tagline_off"
 msgid "Open Food Facts gathers information and data on food products from around the world."
-msgstr "Atvērtie pārtikas fakti apkopo informāciju un datus par pārtikas produktiem no visas pasaules."
+msgstr "Open Food Facts apkopo informāciju un datus par pārtikas produktiem no visas pasaules."
 
 msgctxt "footer_tagline_off"
 msgid "A collaborative, free and open database of food products from around the world."
@@ -63,7 +63,7 @@ msgstr "un <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">Facebook
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Atvērt Beauty Facts produktu meklēšanu"
+msgstr "Atvērt Open Beauty Facts produktu meklēšanu"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -166,7 +166,7 @@ msgstr "Sastāvdaļas, alergēni, piedevas, uzturvērtības fakti, etiķetes, sa
 
 msgctxt "search_description_opensearch_opff"
 msgid "Open Pet Food Facts product search"
-msgstr "Atvērt mājdzīvnieku barības faktu produktu meklēšanu"
+msgstr "Atvērt Open Pet Food Facts produktu meklēšanu"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1065,7 +1065,7 @@ msgstr "https://wiki.openfoodfacts.org"
 # Do not translate Open Beauty Facts but do translate Cosmetics
 msgctxt "footer_obf"
 msgid "Open Beauty Facts - Cosmetics"
-msgstr "Atklāti skaistumkopšanas fakti - kosmētika"
+msgstr "Atklāti Open Open Beauty Facts - kosmētika"
 
 msgctxt "footer_obf_link"
 msgid "https://world.openbeautyfacts.org"
@@ -1073,7 +1073,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "Atklāti pārtikas fakti ražotājiem"
+msgstr "Open Food Facts ražotājiem"
 
 msgctxt "for"
 msgid "for"
@@ -1762,11 +1762,6 @@ msgstr "Uztura pakāpes"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Uztura pakāpe"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4945,7 +4940,7 @@ msgstr "Vide"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "Zaļais rādītājs"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4958,7 +4953,7 @@ msgstr "Green-Score ir vides vērtējums no A+ līdz F, kas ļauj viegli salīdz
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "Zaļais rādītājs"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4971,7 +4966,7 @@ msgstr "Green-Score ir vides vērtējums no A+ līdz F, kas ļauj viegli salīdz
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Zaļais rādītājs %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5157,7 +5152,7 @@ msgstr "Ietekme uz vidi"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "Zaļā vērtējuma rādītājs"
+msgstr "Green-Score rādītājs"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
@@ -5167,12 +5162,12 @@ msgstr "Green-Score vērtējums"
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "Zaļā rādītāja aprēķināšanas detaļas"
+msgstr "Green-Score aprēķināšanas detaļas"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "Informācija par Zaļo punktu skaitu"
+msgstr "Informācija par Green-Score"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5209,19 +5204,19 @@ msgstr "Trūkstoša uzturvērtības informācija pagatavotajam produktam"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "Zaļais rādītājs"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "Zaļais rādītājs"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "Zaļais rādītājs"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "Zaļais rādītājs"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5473,7 +5468,7 @@ msgstr "Produkti ar labāko Nutri-Score vērtējumu"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "Produkti ar vislabāko zaļo vērtējumu"
+msgstr "Produkti ar vislabāko Green-Score"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5527,7 +5522,7 @@ msgstr "Lietotājs tiek dzēsts. Tas var aizņemt dažas minūtes."
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "Zaļais rādītājs nav piemērojams"
+msgstr "Green-Score nav piemērojams"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5540,11 +5535,11 @@ msgstr "Vēl nav piemērojams kategorijai: {category}"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "Zaļais rādītājs šajā kategorijā vēl nav piemērojams, taču mēs strādājam pie atbalsta pievienošanas."
+msgstr "Green-Score šajā kategorijā vēl nav piemērojams, taču mēs strādājam pie atbalsta pievienošanas."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Zaļais rādītājs nav aprēķināts"
+msgstr "Green-Score nav aprēķināts"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5556,7 +5551,7 @@ msgstr "Trūkst precīzas kategorijas"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "Mēs nevarējām aprēķināt šī produkta zaļo vērtējumu, jo trūkst dažu datu. Vai jūs varētu palīdzēt to papildināt?"
+msgstr "Mēs nevarējām aprēķināt šī produkta Green-Score, jo trūkst dažu datu. Vai jūs varētu palīdzēt to papildināt?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5686,7 +5681,7 @@ msgstr "Meža pēdas nospiedumu aprēķina, ņemot vērā sastāvdaļas, kuru ra
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "Zaļo vērtējumu var aprēķināt tikai tad, ja produktam ir pietiekami precīza kategorija."
+msgstr "Green-Score var aprēķināt tikai tad, ja produktam ir pietiekami precīza kategorija."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5698,7 +5693,7 @@ msgstr "Ja esat šī produkta ražotājs, varat nosūtīt mums informāciju, izm
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "Brīdinājums: daļa informācijas, kas nepieciešama, lai precīzi aprēķinātu Zaļo punktu skaitu, nav sniegta (sīkāku informāciju par aprēķinu skatiet tālāk)."
+msgstr "Brīdinājums: daļa informācijas, kas nepieciešama, lai precīzi aprēķinātu Green-Score, nav sniegta (sīkāku informāciju par aprēķinu skatiet tālāk)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5853,12 +5848,12 @@ msgstr "Informācija par šī produkta iepakojumu nav pietiekami precīza (prec�
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "Lai precīzāk aprēķinātu Zaļo rādītāju, varat modificēt produkta lapu un pievienot tos."
+msgstr "Lai precīzāk aprēķinātu Green-Score, varat modificēt produkta lapu un pievienot tos."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "Lai precīzāk aprēķinātu Zaļo vērtējumu, varat rediģēt produkta lapu un pievienot tos."
+msgstr "Lai precīzāk aprēķinātu Green-Score, varat rediģēt produkta lapu un pievienot tos."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5880,17 +5875,17 @@ msgstr "Ja esat šī produkta ražotājs, varat nosūtīt mums informāciju, izm
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "Zaļais rādītājs <a href=\"/green-score\"></a> ir eksperimentāls rādītājs, kas apkopo pārtikas produktu ietekmi uz vidi."
+msgstr "Green-Score <a href=\"/green-score\"></a> ir eksperimentāls rādītājs, kas apkopo pārtikas produktu ietekmi uz vidi."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
 msgid "The Green-Score formula is subject to change as it is regularly improved to make it more precise."
-msgstr "Zaļā rādītāja formula var tikt mainīta, jo tā tiek regulāri uzlabota, lai padarītu to precīzāku."
+msgstr "Green-Score formula var tikt mainīta, jo tā tiek regulāri uzlabota, lai padarītu to precīzāku."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Zaļais rādītājs sākotnēji tika izstrādāts Francijai, un tas tiek paplašināts uz citām Eiropas valstīm. Zaļā rādītāja formula var tikt mainīta, jo tā tiek regulāri uzlabota, lai padarītu to precīzāku un labāk piemērotu katrai valstij."
+msgstr "Green-Score sākotnēji tika izstrādāts Francijai, un tas tiek paplašināts uz citām Eiropas valstīm. Green-Score formula var tikt mainīta, jo tā tiek regulāri uzlabota, lai padarītu to precīzāku un labāk piemērotu katrai valstij."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6213,7 +6208,7 @@ msgstr "Bonusi un zaudējumi"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Zaļais vērtējums šim produktam"
+msgstr "Green-Score šim produktam"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6488,11 +6483,11 @@ msgstr "Noņemt attēla atlasi"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Paldies"
+msgstr "Uzziniet vairāk par Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "Uzziniet vairāk par Zaļo rādītāju"
+msgstr "Uzziniet vairāk par Green-Score"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6542,11 +6537,11 @@ msgstr "Vai varētu pievienot informāciju, kas nepieciešama, lai aprēķinātu
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Vai varētu pievienot precīzu produktu kategoriju, lai mēs varētu aprēķināt Zaļo vērtējumu?"
+msgstr "Vai varētu pievienot precīzu produktu kategoriju, lai mēs varētu aprēķināt Green-Score?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Šī produkta kategorija, kas mums ir, nav pietiekami precīza, lai aprēķinātu zaļo punktu skaitu. Vai varētu pievienot precīzāku produkta kategoriju?"
+msgstr "Šī produkta kategorija, kas mums ir, nav pietiekami precīza, lai aprēķinātu Green-Score. Vai varētu pievienot precīzāku produkta kategoriju?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/mg.po
+++ b/po/common/mg.po
@@ -1759,11 +1759,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/mi.po
+++ b/po/common/mi.po
@@ -63,7 +63,7 @@ msgstr "me te rōpū Pukamata <a href=\"https://www.facebook.com/groups/OpenBeau
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Rapu hua mō ngā Mea Ataahua Tuwhera"
+msgstr "Rapu hua mō Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Ko te Kaute-Kakariki he kaute taiao mai i te A+ ki te F, e māmā ai te whakatairite i te pānga o ngā kai ki te taiao."
+msgstr "Ko te Green-Score he kaute taiao mai i te A+ ki te F, e māmā ai te whakatairite i te pānga o ngā kai ki te taiao."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Ko te Kaute-Kakariki he kaute taiao mai i te A+ ki te F, e māmā ai te whakatairite i te pānga o ngā kai ki te taiao."
+msgstr "Ko te Green-Score he kaute taiao mai i te A+ ki te F, e māmā ai te whakatairite i te pānga o ngā kai ki te taiao."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Ko te waahanga kei a maatau mo tenei hua kaore i te tino tika ki te tatau i te Tohu-Kakariki. Ka taea e koe te taapiri i tetahi waahanga hua tino tika?"
+msgstr "Ko te waahanga kei a maatau mo tenei hua kaore i te tino tika ki te tatau i te Green-Score. Ka taea e koe te taapiri i tetahi waahanga hua tino tika?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/ml.po
+++ b/po/common/ml.po
@@ -42,7 +42,7 @@ msgstr "ലോകമെമ്പാടുമുള്ള സൗന്ദര്�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ലോകമെമ്പാടുമുള്ള സൗന്ദര്യവർദ്ധക ഉൽപ്പന്നങ്ങളെക്കുറിച്ചുള്ള വിവരങ്ങളും ഡാറ്റയും ഓപ്പൺ ബ്യൂട്ടി ഫാക്‌ട്‌സ് ശേഖരിക്കുന്നു."
+msgstr "ലോകമെമ്പാടുമുള്ള സൗന്ദര്യവർദ്ധക ഉൽപ്പന്നങ്ങളെക്കുറിച്ചുള്ള വിവരങ്ങളും ഡാറ്റയും Open Beauty Facts ശേഖരിക്കുന്നു."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "കൂടാതെ <a href=\"https://www.facebook.com/groups/OpenBeautyF
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ബ്യൂട്ടി ഫാക്‌ട്‌സ് ഉൽപ്പന്ന തിരയൽ തുറക്കുക"
+msgstr "Open Beauty Facts ഉൽപ്പന്ന തിരയൽ തുറക്കുക"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ഈ ഉൽപ്പന്ന പേജ് പൂർണ്ണമല്ല. ഇത് എഡിറ്റ് ചെയ്‌ത് ഞങ്ങളുടെ കൈവശമുള്ള ഫോട്ടോകളിൽ നിന്ന് കൂടുതൽ ഡാറ്റ ചേർത്തോ, അല്ലെങ്കിൽ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> അല്ലെങ്കിൽ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>എന്നിവയ്‌ക്കായുള്ള യൂണിവേഴ്‌സൽ ഓപ്പൺ ഫുഡ് ഫാക്‌ട്‌സ് ആപ്പ് ഉപയോഗിച്ച് കൂടുതൽ ഫോട്ടോകൾ എടുത്തോ നിങ്ങൾക്ക് ഇത് പൂർത്തിയാക്കാൻ സഹായിക്കാനാകും. നന്ദി!"
+msgstr "ഈ ഉൽപ്പന്ന പേജ് പൂർണ്ണമല്ല. ഇത് എഡിറ്റ് ചെയ്‌ത് ഞങ്ങളുടെ കൈവശമുള്ള ഫോട്ടോകളിൽ നിന്ന് കൂടുതൽ ഡാറ്റ ചേർത്തോ, അല്ലെങ്കിൽ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> അല്ലെങ്കിൽ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>എന്നിവയ്‌ക്കായുള്ള യൂണിവേഴ്‌സൽ Open Food Facts ആപ്പ് ഉപയോഗിച്ച് കൂടുതൽ ഫോട്ടോകൾ എടുത്തോ നിങ്ങൾക്ക് ഇത് പൂർത്തിയാക്കാൻ സഹായിക്കാനാകും. നന്ദി!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ഈ ഉൽപ്പന്ന പേജ് പൂർണ്ണമല്ല. ഇത് എഡിറ്റ് ചെയ്‌ത് ഞങ്ങളുടെ കൈവശമുള്ള ഫോട്ടോകളിൽ നിന്ന് കൂടുതൽ ഡാറ്റ ചേർത്തോ, അല്ലെങ്കിൽ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> അല്ലെങ്കിൽ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>എന്നിവയ്‌ക്കായുള്ള യൂണിവേഴ്‌സൽ ഓപ്പൺ ഫുഡ് ഫാക്‌ട്‌സ് ആപ്പ് ഉപയോഗിച്ച് കൂടുതൽ ഫോട്ടോകൾ എടുത്തോ നിങ്ങൾക്ക് ഇത് പൂർത്തിയാക്കാൻ സഹായിക്കാനാകും. നന്ദി!"
+msgstr "ഈ ഉൽപ്പന്ന പേജ് പൂർണ്ണമല്ല. ഇത് എഡിറ്റ് ചെയ്‌ത് ഞങ്ങളുടെ കൈവശമുള്ള ഫോട്ടോകളിൽ നിന്ന് കൂടുതൽ ഡാറ്റ ചേർത്തോ, അല്ലെങ്കിൽ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> അല്ലെങ്കിൽ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>എന്നിവയ്‌ക്കായുള്ള യൂണിവേഴ്‌സൽ Open Food Facts ആപ്പ് ഉപയോഗിച്ച് കൂടുതൽ ഫോട്ടോകൾ എടുത്തോ നിങ്ങൾക്ക് ഇത് പൂർത്തിയാക്കാൻ സഹായിക്കാനാകും. നന്ദി!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "ന്യൂട്രി-സ്കോർ ബാധകമല്ല"
+msgstr "Nutri-Score ബാധകമല്ല"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "A+ മുതൽ F വരെയുള്ള പാരിസ്ഥിതിക സ്‌കോറാണ് ഗ്രീൻ-സ്‌കോർ, ഇത് ഭക്ഷ്യ ഉൽപ്പന്നങ്ങൾ പരിസ്ഥിതിയിൽ ചെലുത്തുന്ന സ്വാധീനം താരതമ്യം ചെയ്യുന്നത് എളുപ്പമാക്കുന്നു."
+msgstr "A+ മുതൽ F വരെയുള്ള പാരിസ്ഥിതിക സ്‌കോറാണ് Green-Score, ഇത് ഭക്ഷ്യ ഉൽപ്പന്നങ്ങൾ പരിസ്ഥിതിയിൽ ചെലുത്തുന്ന സ്വാധീനം താരതമ്യം ചെയ്യുന്നത് എളുപ്പമാക്കുന്നു."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "A+ മുതൽ F വരെയുള്ള പാരിസ്ഥിതിക സ്‌കോറാണ് ഗ്രീൻ-സ്‌കോർ, ഇത് ഭക്ഷ്യ ഉൽപ്പന്നങ്ങൾ പരിസ്ഥിതിയിൽ ചെലുത്തുന്ന സ്വാധീനം താരതമ്യം ചെയ്യുന്നത് എളുപ്പമാക്കുന്നു."
+msgstr "A+ മുതൽ F വരെയുള്ള പാരിസ്ഥിതിക സ്‌കോറാണ് Green-Score, ഇത് ഭക്ഷ്യ ഉൽപ്പന്നങ്ങൾ പരിസ്ഥിതിയിൽ ചെലുത്തുന്ന സ്വാധീനം താരതമ്യം ചെയ്യുന്നത് എളുപ്പമാക്കുന്നു."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ഗ്രീൻ-സ്കോർ തുടക്കത്തിൽ ഫ്രാൻസിനായി വികസിപ്പിച്ചെടുത്തതാണ്, പിന്നീട് ഇത് മറ്റ് യൂറോപ്യൻ രാജ്യങ്ങളിലേക്കും വ്യാപിപ്പിക്കുകയാണ്. ഗ്രീൻ-സ്കോർ ഫോർമുല കൂടുതൽ കൃത്യവും ഓരോ രാജ്യത്തിനും അനുയോജ്യവുമാക്കുന്നതിന് പതിവായി മെച്ചപ്പെടുത്തുന്നതിനാൽ അത് മാറ്റത്തിന് വിധേയമാണ്."
+msgstr "Green-Score തുടക്കത്തിൽ ഫ്രാൻസിനായി വികസിപ്പിച്ചെടുത്തതാണ്, പിന്നീട് ഇത് മറ്റ് യൂറോപ്യൻ രാജ്യങ്ങളിലേക്കും വ്യാപിപ്പിക്കുകയാണ്. Green-Score ഫോർമുല കൂടുതൽ കൃത്യവും ഓരോ രാജ്യത്തിനും അനുയോജ്യവുമാക്കുന്നതിന് പതിവായി മെച്ചപ്പെടുത്തുന്നതിനാൽ അത് മാറ്റത്തിന് വിധേയമാണ്."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ഈ ഉൽപ്പന്നത്തിന് ഞങ്ങൾ നൽകുന്ന വിഭാഗം ഗ്രീൻ-സ്കോർ കണക്കാക്കാൻ പര്യാപ്തമല്ല. കൂടുതൽ കൃത്യമായ ഒരു ഉൽപ്പന്ന വിഭാഗം ചേർക്കാമോ?"
+msgstr "ഈ ഉൽപ്പന്നത്തിന് ഞങ്ങൾ നൽകുന്ന വിഭാഗം Green-Score കണക്കാക്കാൻ പര്യാപ്തമല്ല. കൂടുതൽ കൃത്യമായ ഒരു ഉൽപ്പന്ന വിഭാഗം ചേർക്കാമോ?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,7 +7665,7 @@ msgstr "ഈ ചിത്രം ഞങ്ങളുടെ മോഡറേറ്റ
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "ന്യൂട്രി-സ്കോർ കണക്കാക്കുന്നതിനുള്ള സെർവിംഗ് സൈസ് മൂല്യവും/അല്ലെങ്കിൽ യൂണിറ്റും ഞങ്ങൾക്ക് നഷ്ടമായി."
+msgstr "Nutri-Score കണക്കാക്കുന്നതിനുള്ള സെർവിംഗ് സൈസ് മൂല്യവും/അല്ലെങ്കിൽ യൂണിറ്റും ഞങ്ങൾക്ക് നഷ്ടമായി."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
@@ -7686,7 +7681,7 @@ msgstr "ലിലോ സെർച്ച് എഞ്ചിൻ"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "റോബോട്ടുകളുടെ കടുത്ത ദുരുപയോഗം കാരണം, തിരിച്ചറിയാത്ത ഉപയോക്താക്കൾക്ക് ഈ പേജ് നൽകാൻ ഞങ്ങൾക്ക് കഴിയില്ല. എല്ലാ ഓപ്പൺ ഫുഡ് ഫാക്റ്റുകളും ആക്‌സസ് ചെയ്യുന്നതിന് ദയവായി ഒരു സൗജന്യ ഓപ്പൺ ഫുഡ് ഫാക്റ്റ്സ് അക്കൗണ്ട് സൃഷ്ടിക്കുക."
+msgstr "റോബോട്ടുകളുടെ കടുത്ത ദുരുപയോഗം കാരണം, തിരിച്ചറിയാത്ത ഉപയോക്താക്കൾക്ക് ഈ പേജ് നൽകാൻ ഞങ്ങൾക്ക് കഴിയില്ല. എല്ലാ ഓപ്പൺ ഫുഡ് ഫാക്റ്റുകളും ആക്‌സസ് ചെയ്യുന്നതിന് ദയവായി ഒരു സൗജന്യ Open Food Facts അക്കൗണ്ട് സൃഷ്ടിക്കുക."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "ആവശ്യമില്ലാത്ത ചേരുവകൾ"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "ഓപ്പൺ ഫുഡ് ഫാക്റ്റ്സിന്റെ ചേരുവകളുടെ പട്ടികയെക്കുറിച്ചുള്ള ധാരണയെ അടിസ്ഥാനമാക്കിയുള്ളതാണ് ഈ മുൻഗണന, ഇത് കൃത്യമായിരിക്കില്ല, എല്ലായ്പ്പോഴും ഉൽപ്പന്നം സ്വയം പരിശോധിക്കുക."
+msgstr "Open Food Facts ചേരുവകളുടെ പട്ടികയെക്കുറിച്ചുള്ള ധാരണയെ അടിസ്ഥാനമാക്കിയുള്ളതാണ് ഈ മുൻഗണന, ഇത് കൃത്യമായിരിക്കില്ല, എല്ലായ്പ്പോഴും ഉൽപ്പന്നം സ്വയം പരിശോധിക്കുക."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "ഞങ്ങൾക്ക് ഇത് കണ്ടെത്താൻ ക
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "ആ മുൻഗണനകൾ ഓപ്പൺ ഫുഡ് ഫാക്റ്റ്സിന്റെ ചേരുവകളുടെ പട്ടികയെക്കുറിച്ചുള്ള ധാരണയെ അടിസ്ഥാനമാക്കിയുള്ളതാണ്, അത് കൃത്യമോ പൂർണ്ണമോ ആകണമെന്നില്ല എന്നതിന് എപ്പോഴും സാധ്യതയുണ്ട്, എല്ലായ്പ്പോഴും ഉൽപ്പന്നം സ്വയം പരിശോധിക്കുക."
+msgstr "ആ മുൻഗണനകൾ Open Food Facts ചേരുവകളുടെ പട്ടികയെക്കുറിച്ചുള്ള ധാരണയെ അടിസ്ഥാനമാക്കിയുള്ളതാണ്, അത് കൃത്യമോ പൂർണ്ണമോ ആകണമെന്നില്ല എന്നതിന് എപ്പോഴും സാധ്യതയുണ്ട്, എല്ലായ്പ്പോഴും ഉൽപ്പന്നം സ്വയം പരിശോധിക്കുക."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/mn.po
+++ b/po/common/mn.po
@@ -63,7 +63,7 @@ msgstr "болон хувь нэмэр оруулагчдад зориулсан
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Нээлттэй Гоо сайхны баримтууд бүтээгдэхүүний хайлт"
+msgstr "Open Beauty Facts бүтээгдэхүүний хайлт"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Ногоон оноо нь А+-аас F хүртэлх байгаль орчны оноо бөгөөд хүнсний бүтээгдэхүүний хүрээлэн буй орчинд үзүүлэх нөлөөллийг харьцуулахад хялбар болгодог."
+msgstr "Green-Score нь А+-аас F хүртэлх байгаль орчны оноо бөгөөд хүнсний бүтээгдэхүүний хүрээлэн буй орчинд үзүүлэх нөлөөллийг харьцуулахад хялбар болгодог."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Ногоон оноо нь А+-аас F хүртэлх байгаль орчны оноо бөгөөд хүнсний бүтээгдэхүүний хүрээлэн буй орчинд үзүүлэх нөлөөллийг харьцуулахад хялбар болгодог."
+msgstr "Green-Score нь А+-аас F хүртэлх байгаль орчны оноо бөгөөд хүнсний бүтээгдэхүүний хүрээлэн буй орчинд үзүүлэх нөлөөллийг харьцуулахад хялбар болгодог."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Ногоон оноог анх Францад зориулж боловсруулсан бөгөөд Европын бусад орнуудад өргөжүүлж байна. Ногоон онооны томъёог илүү нарийвчлалтай, улс орон бүрт илүү тохиромжтой болгохын тулд тогтмол сайжруулж байдаг тул өөрчлөгдөж болно."
+msgstr "Green-Score анх Францад зориулж боловсруулсан бөгөөд Европын бусад орнуудад өргөжүүлж байна. Green-Score томъёог илүү нарийвчлалтай, улс орон бүрт илүү тохиромжтой болгохын тулд тогтмол сайжруулж байдаг тул өөрчлөгдөж болно."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Энэ бүтээгдэхүүний ангилал нь Ногоон оноог тооцоолоход хангалтгүй байна. Та илүү нарийн бүтээгдэхүүний ангилал нэмж болох уу?"
+msgstr "Энэ бүтээгдэхүүний ангилал нь Green-Score тооцоолоход хангалтгүй байна. Та илүү нарийн бүтээгдэхүүний ангилал нэмж болох уу?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7686,7 +7681,7 @@ msgstr "Lilo хайлтын систем"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Роботуудын хүчирхийллийн улмаас бид энэ хуудсыг үл мэдэгдэх хэрэглэгчдэд үзүүлэх боломжгүй. Бүх Нээлттэй Хүнсний Баримтуудад хандахын тулд үнэгүй Нээлттэй Хүнсний Баримтуудын бүртгэл үүсгэнэ үү."
+msgstr "Роботуудын хүчирхийллийн улмаас бид энэ хуудсыг үл мэдэгдэх хэрэглэгчдэд үзүүлэх боломжгүй. Бүх Open Food Facts хандахын тулд үнэгүй Open Food Facts бүртгэл үүсгэнэ үү."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"

--- a/po/common/mr.po
+++ b/po/common/mr.po
@@ -42,7 +42,7 @@ msgstr "जगभरातील सौंदर्यप्रसाधना�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ओपन ब्यूटी फॅक्ट्स जगभरातील सौंदर्य प्रसाधनांविषयी माहिती आणि डेटा गोळा करते."
+msgstr "Open Beauty Facts जगभरातील सौंदर्य प्रसाधनांविषयी माहिती आणि डेटा गोळा करते."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "आणि योगदानकर्त्यांसाठी अस�
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ओपन ब्यूटी फॅक्ट्स उत्पादन शोध"
+msgstr "Open Beauty Facts उत्पादन शोध"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "हे उत्पादन पृष्ठ पूर्ण नाही. तुम्ही ते संपादित करून आणि आमच्याकडे असलेल्या फोटोंमधून अधिक डेटा जोडून किंवा <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> किंवा <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>साठी युनिव्हर्सल ओपन फूड फॅक्ट्स अॅप वापरून अधिक फोटो काढून ते पूर्ण करण्यास मदत करू शकता. धन्यवाद!"
+msgstr "हे उत्पादन पृष्ठ पूर्ण नाही. तुम्ही ते संपादित करून आणि आमच्याकडे असलेल्या फोटोंमधून अधिक डेटा जोडून किंवा <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> किंवा <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>साठी युनिव्हर्सल Open Food Facts अॅप वापरून अधिक फोटो काढून ते पूर्ण करण्यास मदत करू शकता. धन्यवाद!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "हे उत्पादन पृष्ठ पूर्ण नाही. तुम्ही ते संपादित करून आणि आमच्याकडे असलेल्या फोटोंमधून अधिक डेटा जोडून किंवा <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> किंवा <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>साठी युनिव्हर्सल ओपन फूड फॅक्ट्स अॅप वापरून अधिक फोटो काढून ते पूर्ण करण्यास मदत करू शकता. धन्यवाद!"
+msgstr "हे उत्पादन पृष्ठ पूर्ण नाही. तुम्ही ते संपादित करून आणि आमच्याकडे असलेल्या फोटोंमधून अधिक डेटा जोडून किंवा <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> किंवा <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>साठी युनिव्हर्सल Open Food Facts अॅप वापरून अधिक फोटो काढून ते पूर्ण करण्यास मदत करू शकता. धन्यवाद!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "न्यूट्री-स्कोअर लागू नाही"
+msgstr "Nutri-Score लागू नाही"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ग्रीन-स्कोअर हा A+ ते F पर्यंतचा पर्यावरणीय स्कोअर आहे जो अन्न उत्पादनांचा पर्यावरणावर होणाऱ्या परिणामाची तुलना करणे सोपे करतो."
+msgstr "Green-Score हा A+ ते F पर्यंतचा पर्यावरणीय स्कोअर आहे जो अन्न उत्पादनांचा पर्यावरणावर होणाऱ्या परिणामाची तुलना करणे सोपे करतो."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ग्रीन-स्कोअर हा A+ ते F पर्यंतचा पर्यावरणीय स्कोअर आहे जो अन्न उत्पादनांचा पर्यावरणावर होणाऱ्या परिणामाची तुलना करणे सोपे करतो."
+msgstr "Green-Score हा A+ ते F पर्यंतचा पर्यावरणीय स्कोअर आहे जो अन्न उत्पादनांचा पर्यावरणावर होणाऱ्या परिणामाची तुलना करणे सोपे करतो."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ग्रीन-स्कोअर सुरुवातीला फ्रान्ससाठी विकसित करण्यात आला होता आणि तो इतर युरोपीय देशांमध्ये विस्तारित केला जात आहे. ग्रीन-स्कोअर सूत्र बदलू शकते कारण ते नियमितपणे सुधारले जात आहे जेणेकरून ते अधिक अचूक आणि प्रत्येक देशासाठी अधिक योग्य असेल."
+msgstr "Green-Score सुरुवातीला फ्रान्ससाठी विकसित करण्यात आला होता आणि तो इतर युरोपीय देशांमध्ये विस्तारित केला जात आहे. Green-Score सूत्र बदलू शकते कारण ते नियमितपणे सुधारले जात आहे जेणेकरून ते अधिक अचूक आणि प्रत्येक देशासाठी अधिक योग्य असेल."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "या उत्पादनासाठी आमच्याकडे असलेली श्रेणी ग्रीन-स्कोअर मोजण्यासाठी पुरेशी अचूक नाही. तुम्ही अधिक अचूक उत्पादन श्रेणी जोडू शकाल का?"
+msgstr "या उत्पादनासाठी आमच्याकडे असलेली श्रेणी Green-Score मोजण्यासाठी पुरेशी अचूक नाही. तुम्ही अधिक अचूक उत्पादन श्रेणी जोडू शकाल का?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,15 +7665,15 @@ msgstr "ही प्रतिमा आमच्या मॉडरेटरन
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "न्यूट्री-स्कोअरची गणना करण्यासाठी आमच्याकडे सर्व्हिंग साईज व्हॅल्यू आणि/किंवा युनिट गहाळ आहे."
+msgstr "Nutri-Scoreची गणना करण्यासाठी आमच्याकडे सर्व्हिंग साईज व्हॅल्यू आणि/किंवा युनिट गहाळ आहे."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> हे उद्योगापासून स्वतंत्र असलेल्या एका ना-नफा संस्थेने बनवले आहे. ते सर्वांसाठी बनवले आहे, सर्वांनी बनवले आहे आणि त्याला सर्वांकडून निधी दिला जातो. तुम्ही ओपन फूड फॅक्ट्सला देणगी देऊन आमच्या कामाला पाठिंबा देऊ शकता.<br/><b>धन्यवाद!</b>"
+msgstr "<<site_name>> हे उद्योगापासून स्वतंत्र असलेल्या एका ना-नफा संस्थेने बनवले आहे. ते सर्वांसाठी बनवले आहे, सर्वांनी बनवले आहे आणि त्याला सर्वांकडून निधी दिला जातो. तुम्ही Open Food Factsला देणगी देऊन आमच्या कामाला पाठिंबा देऊ शकता.<br/><b>धन्यवाद!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> हे उद्योगापासून स्वतंत्र असलेल्या एका ना-नफा संस्थेने बनवले आहे. ते सर्वांसाठी बनवले आहे, सर्वांनी बनवले आहे आणि त्याला सर्वांकडून निधी दिला जातो. तुम्ही ओपन फूड फॅक्ट्सना देणगी देऊन आणि लिलो सर्च इंजिन वापरून आमच्या कामाला पाठिंबा देऊ शकता.<br/><b>धन्यवाद!</b>"
+msgstr "<<site_name>> हे उद्योगापासून स्वतंत्र असलेल्या एका ना-नफा संस्थेने बनवले आहे. ते सर्वांसाठी बनवले आहे, सर्वांनी बनवले आहे आणि त्याला सर्वांकडून निधी दिला जातो. तुम्ही Open Food Factsना देणगी देऊन आणि लिलो सर्च इंजिन वापरून आमच्या कामाला पाठिंबा देऊ शकता.<br/><b>धन्यवाद!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7686,7 +7681,7 @@ msgstr "लिलो सर्च इंजिन"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "रोबोट्सकडून मोठ्या प्रमाणात गैरवापर होत असल्याने, आम्ही हे पेज अज्ञात वापरकर्त्यांना देऊ शकत नाही. सर्व ओपन फूड फॅक्ट्स अॅक्सेस करण्यासाठी कृपया एक मोफत ओपन फूड फॅक्ट्स खाते तयार करा."
+msgstr "रोबोट्सकडून मोठ्या प्रमाणात गैरवापर होत असल्याने, आम्ही हे पेज अज्ञात वापरकर्त्यांना देऊ शकत नाही. सर्व Open Food Facts अॅक्सेस करण्यासाठी कृपया एक मोफत Open Food Facts खाते तयार करा."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "नको असलेले घटक"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "ही पसंती ओपन फूड फॅक्ट्सच्या घटक यादीच्या आकलनावर आधारित आहे आणि ती अचूक असू शकत नाही, नेहमी उत्पादन स्वतः तपासा."
+msgstr "ही पसंती Open Food Factsच्या घटक यादीच्या आकलनावर आधारित आहे आणि ती अचूक असू शकत नाही, नेहमी उत्पादन स्वतः तपासा."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "आम्हाला आढळले नाही: {unwanted_ingredient
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "त्या पसंती ओपन फूड फॅक्ट्सच्या घटक यादीच्या आकलनावर आधारित आहेत आणि ती अचूक किंवा पूर्ण नसण्याची शक्यता नेहमीच असते, नेहमी उत्पादन स्वतः तपासा."
+msgstr "त्या पसंती Open Food Factsच्या घटक यादीच्या आकलनावर आधारित आहेत आणि ती अचूक किंवा पूर्ण नसण्याची शक्यता नेहमीच असते, नेहमी उत्पादन स्वतः तपासा."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/ms.po
+++ b/po/common/ms.po
@@ -63,7 +63,7 @@ msgstr "dan kumpulan Facebook <a href=\"https://www.facebook.com/groups/OpenBeau
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Carian produk Fakta Kecantikan Terbuka"
+msgstr "Carian produk Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "Halaman produk ini belum lengkap. Anda boleh membantu melengkapkannya dengan mengeditnya dan menambah lebih banyak data daripada foto yang kami ada, atau dengan mengambil lebih banyak foto menggunakan aplikasi Fakta Makanan Terbuka universal untuk <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> atau <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Terima kasih!"
+msgstr "Halaman produk ini belum lengkap. Anda boleh membantu melengkapkannya dengan mengeditnya dan menambah lebih banyak data daripada foto yang kami ada, atau dengan mengambil lebih banyak foto menggunakan aplikasi Open Food Facts universal untuk <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> atau <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Terima kasih!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "Halaman produk ini belum lengkap. Anda boleh membantu melengkapkannya dengan mengeditnya dan menambah lebih banyak data daripada foto yang kami ada, atau dengan mengambil lebih banyak foto menggunakan aplikasi Fakta Makanan Terbuka universal untuk <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> atau <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Terima kasih!"
+msgstr "Halaman produk ini belum lengkap. Anda boleh membantu melengkapkannya dengan mengeditnya dan menambah lebih banyak data daripada foto yang kami ada, atau dengan mengambil lebih banyak foto menggunakan aplikasi Open Food Facts universal untuk <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> atau <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Terima kasih!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1766,11 +1766,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Gred pemakanan"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -2902,7 +2897,7 @@ msgstr "Penterjemah kami"
 
 msgctxt "translators_lead"
 msgid "We would like to say THANK YOU to the awesome translators that make it possible to present Open Food Facts, Open Beauty Facts, and Open Pet Food Facts to you in all these different languages! <a href=\"https://translate.openfoodfacts.org/\">You can join us in this global effort: it doesn't require any technical knowledge.</a>"
-msgstr "Kami ingin mengucapkan TERIMA KASIH kepada penterjemah hebat yang memungkinkan untuk membentangkan Fakta Makanan Terbuka, Fakta Kecantikan Terbuka, dan Fakta Makanan Binatang Terbuka kepada anda dalam semua bahasa yang berbeza ini! <a href=\"https://translate.openfoodfacts.org/\">Anda boleh menyertai kami dalam usaha global ini: ia tidak memerlukan pengetahuan teknikal.</a>"
+msgstr "Kami ingin mengucapkan TERIMA KASIH kepada penterjemah hebat yang memungkinkan untuk membentangkan Open Food Facts, Open Beauty Facts, dan Open Pet Food Facts kepada anda dalam semua bahasa yang berbeza ini! <a href=\"https://translate.openfoodfacts.org/\">Anda boleh menyertai kami dalam usaha global ini: ia tidak memerlukan pengetahuan teknikal.</a>"
 
 msgctxt "translators_renewal_notice"
 msgid "Please note that this table is refreshed nightly and might be out of date."
@@ -4956,7 +4951,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Skor Hijau ialah skor alam sekitar dari A+ hingga F yang memudahkan perbandingan impak produk makanan terhadap alam sekitar."
+msgstr "Green-Score ialah skor alam sekitar dari A+ hingga F yang memudahkan perbandingan impak produk makanan terhadap alam sekitar."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4969,7 +4964,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Skor Hijau ialah skor alam sekitar dari A+ hingga F yang memudahkan perbandingan impak produk makanan terhadap alam sekitar."
+msgstr "Green-Score ialah skor alam sekitar dari A+ hingga F yang memudahkan perbandingan impak produk makanan terhadap alam sekitar."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5689,7 +5684,7 @@ msgstr "Jejak hutan dikira dengan mengambil kira ramuan yang penghasilannya meme
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "Skor Eko hanya dapat dikira jika produk mempunyai kategori tepat yang mencukupi."
+msgstr "Green-Score hanya dapat dikira jika produk mempunyai kategori tepat yang mencukupi."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5701,7 +5696,7 @@ msgstr "Sekiranya anda pengilang produk ini, anda boleh menghantar kepada kami m
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "Amaran: sesetengah maklumat yang diperlukan untuk mengira Skor Eko dengan tepat tidak diberikan (lihat perincian pengiraan di bawah)."
+msgstr "Amaran: sesetengah maklumat yang diperlukan untuk mengira Green-Score dengan tepat tidak diberikan (lihat perincian pengiraan di bawah)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5861,7 +5856,7 @@ msgstr ""
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "Untuk pengiraan Skor Eko yang lebih tepat, anda boleh menyunting halaman produk dan menambahkannya."
+msgstr "Untuk pengiraan Green-Score yang lebih tepat, anda boleh menyunting halaman produk dan menambahkannya."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5883,17 +5878,17 @@ msgstr "Sekiranya anda pengilang produk ini, anda boleh menghantar kepada kami m
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "<a href=\"/green-score\">Skor Eko</a> adalah skor eksperimental yang mengikhtisarkan kesan persekitaran produk makanan."
+msgstr "<a href=\"/green-score\">Green-Score</a> adalah skor eksperimental yang mengikhtisarkan kesan persekitaran produk makanan."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
 msgid "The Green-Score formula is subject to change as it is regularly improved to make it more precise."
-msgstr "Formula Skor Eko adalah tertakluk kepada perubahan kerana ia ditambah baik secara berkala untuk menjadikannya lebih tepat."
+msgstr "Formula Green-Score adalah tertakluk kepada perubahan kerana ia ditambah baik secara berkala untuk menjadikannya lebih tepat."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Skor Hijau pada mulanya dibangunkan untuk Perancis dan ia sedang diperluaskan ke negara-negara Eropah yang lain. Formula Skor Hijau tertakluk kepada perubahan kerana ia sentiasa diperbaiki untuk menjadikannya lebih tepat dan lebih sesuai untuk setiap negara."
+msgstr "Green-Score pada mulanya dibangunkan untuk Perancis dan ia sedang diperluaskan ke negara-negara Eropah yang lain. Formula Green-Score tertakluk kepada perubahan kerana ia sentiasa diperbaiki untuk menjadikannya lebih tepat dan lebih sesuai untuk setiap negara."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6549,7 +6544,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Kategori yang kami ada untuk produk ini tidak cukup tepat untuk mengira Skor Hijau. Bolehkah anda menambah kategori produk yang lebih tepat?"
+msgstr "Kategori yang kami ada untuk produk ini tidak cukup tepat untuk mengira Green-Score. Bolehkah anda menambah kategori produk yang lebih tepat?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7688,7 +7683,7 @@ msgstr "Laporkan imej ini kepada moderator kami"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Kami kehilangan nilai saiz hidangan dan/atau unit untuk mengira Skor Nutri"
+msgstr "Kami kehilangan nilai saiz hidangan dan/atau unit untuk mengira Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/mt.po
+++ b/po/common/mt.po
@@ -63,7 +63,7 @@ msgstr "u l-grupp ta' Facebook <a href=\"https://www.facebook.com/groups/OpenBea
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Tiftix miftuħ tal-prodott Beauty Facts"
+msgstr "Tiftix miftuħ tal-prodott Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language

--- a/po/common/my.po
+++ b/po/common/my.po
@@ -63,7 +63,7 @@ msgstr "နှင့် ပံ့ပိုးကူညီသူများအ�
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Beauty Facts ထုတ်ကုန်ရှာဖွေမှုကို ဖွင့်ပါ"
+msgstr "Open Beauty Facts ထုတ်ကုန်ရှာဖွေမှုကို ဖွင့်ပါ"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ဤထုတ်ကုန်အတွက် ကျွန်ုပ်တို့တွင်ရှိသော အမျိုးအစားသည် အစိမ်းရောင်ရမှတ်ကို တွက်ချက်ရန် မလုံလောက်ပါ။ ပိုမိုတိကျသော ထုတ်ကုန်အမျိုးအစားကို ထည့်နိုင်ပါသလား။"
+msgstr "ဤထုတ်ကုန်အတွက် ကျွန်ုပ်တို့တွင်ရှိသော အမျိုးအစားသည် Green-Scoreကို တွက်ချက်ရန် မလုံလောက်ပါ။ ပိုမိုတိကျသော ထုတ်ကုန်အမျိုးအစားကို ထည့်နိုင်ပါသလား။"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/nb.po
+++ b/po/common/nb.po
@@ -63,7 +63,7 @@ msgstr "og Facebook-gruppen <a href=\"https://www.facebook.com/groups/OpenBeauty
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Åpne produktsøket for skjønnhetsfakta"
+msgstr "Åpne produktsøket for Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1763,11 +1763,6 @@ msgstr ""
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4720,7 +4715,7 @@ msgstr "Mangler data for å beregne Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Ernæringsvidde ikke relevant"
+msgstr "Nutri-Score ikke relevant"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -6489,7 +6484,7 @@ msgstr ""
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Tusen takk"
+msgstr "Lær mer om Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
@@ -7132,7 +7127,7 @@ msgstr "Fravær"
 
 msgctxt "nutriscore_is_water"
 msgid "This product is considered to be water for the calculation of the Nutri-Score."
-msgstr "Dette produktet anses for å være vann ved beregningen av Nutri-score."
+msgstr "Dette produktet anses for å være vann ved beregningen av Nutri-Score."
 
 msgctxt "nutriscore_is_fat_oil_nuts_seeds"
 msgid "This product is considered to be fat, oil, nuts or seeds for the calculation of the Nutri-Score."

--- a/po/common/ne.po
+++ b/po/common/ne.po
@@ -42,7 +42,7 @@ msgstr "विश्वभरका कस्मेटिक उत्पाद�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ओपन ब्यूटी फ्याक्ट्सले विश्वभरका कस्मेटिक उत्पादनहरूको जानकारी र तथ्याङ्क सङ्कलन गर्दछ।"
+msgstr "Open Beauty Factsले विश्वभरका कस्मेटिक उत्पादनहरूको जानकारी र तथ्याङ्क सङ्कलन गर्दछ।"
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "र <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">यो�
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "सौन्दर्य तथ्य उत्पादन खोज खोल्नुहोस्"
+msgstr "Open Beauty Facts उत्पादन खोज खोल्नुहोस्"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "यो उत्पादन पृष्ठ पूरा छैन। तपाईं यसलाई सम्पादन गरेर र हामीसँग भएका तस्बिरहरूबाट थप डेटा थपेर, वा <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> वा <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>को लागि विश्वव्यापी ओपन फूड फ्याक्ट्स एप प्रयोग गरेर थप तस्बिरहरू खिचेर यसलाई पूरा गर्न मद्दत गर्न सक्नुहुन्छ। धन्यवाद!"
+msgstr "यो उत्पादन पृष्ठ पूरा छैन। तपाईं यसलाई सम्पादन गरेर र हामीसँग भएका तस्बिरहरूबाट थप डेटा थपेर, वा <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> वा <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>को लागि विश्वव्यापी Open Food Facts एप प्रयोग गरेर थप तस्बिरहरू खिचेर यसलाई पूरा गर्न मद्दत गर्न सक्नुहुन्छ। धन्यवाद!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "यो उत्पादन पृष्ठ पूरा छैन। तपाईं यसलाई सम्पादन गरेर र हामीसँग भएका तस्बिरहरूबाट थप डेटा थपेर, वा <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> वा <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>को लागि विश्वव्यापी ओपन फूड फ्याक्ट्स एप प्रयोग गरेर थप तस्बिरहरू खिचेर यसलाई पूरा गर्न मद्दत गर्न सक्नुहुन्छ। धन्यवाद!"
+msgstr "यो उत्पादन पृष्ठ पूरा छैन। तपाईं यसलाई सम्पादन गरेर र हामीसँग भएका तस्बिरहरूबाट थप डेटा थपेर, वा <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> वा <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>को लागि विश्वव्यापी Open Food Facts एप प्रयोग गरेर थप तस्बिरहरू खिचेर यसलाई पूरा गर्न मद्दत गर्न सक्नुहुन्छ। धन्यवाद!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "न्यूट्री-स्कोर लागू हुँदैन"
+msgstr "Nutri-Score लागू हुँदैन"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ग्रिन-स्कोर भनेको A+ देखि F सम्मको वातावरणीय स्कोर हो जसले वातावरणमा खाद्य उत्पादनहरूको प्रभावको तुलना गर्न सजिलो बनाउँछ।"
+msgstr "Green-Score भनेको A+ देखि F सम्मको वातावरणीय स्कोर हो जसले वातावरणमा खाद्य उत्पादनहरूको प्रभावको तुलना गर्न सजिलो बनाउँछ।"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ग्रिन-स्कोर भनेको A+ देखि F सम्मको वातावरणीय स्कोर हो जसले वातावरणमा खाद्य उत्पादनहरूको प्रभावको तुलना गर्न सजिलो बनाउँछ।"
+msgstr "Green-Score भनेको A+ देखि F सम्मको वातावरणीय स्कोर हो जसले वातावरणमा खाद्य उत्पादनहरूको प्रभावको तुलना गर्न सजिलो बनाउँछ।"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ग्रीन-स्कोर सुरुमा फ्रान्सको लागि विकसित गरिएको थियो र यसलाई अन्य युरोपेली देशहरूमा विस्तार गरिँदैछ। ग्रीन-स्कोर सूत्र परिवर्तनको विषय हो किनकि यसलाई नियमित रूपमा सुधार गरिन्छ ताकि यसलाई प्रत्येक देशको लागि अझ सटीक र राम्रोसँग उपयुक्त बनाइयोस्।"
+msgstr "Green-Score सुरुमा फ्रान्सको लागि विकसित गरिएको थियो र यसलाई अन्य युरोपेली देशहरूमा विस्तार गरिँदैछ। Green-Score सूत्र परिवर्तनको विषय हो किनकि यसलाई नियमित रूपमा सुधार गरिन्छ ताकि यसलाई प्रत्येक देशको लागि अझ सटीक र राम्रोसँग उपयुक्त बनाइयोस्।"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "यस उत्पादनको लागि हामीसँग भएको श्रेणी ग्रीन-स्कोर गणना गर्न पर्याप्त सटीक छैन। के तपाईं अझ सटीक उत्पादन श्रेणी थप्न सक्नुहुन्छ?"
+msgstr "यस उत्पादनको लागि हामीसँग भएको श्रेणी Green-Score गणना गर्न पर्याप्त सटीक छैन। के तपाईं अझ सटीक उत्पादन श्रेणी थप्न सक्नुहुन्छ?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,15 +7665,15 @@ msgstr "यो तस्बिर हाम्रा मोडरेटरहर
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "हामीसँग न्यूट्री-स्कोर गणना गर्न सर्भिङ साइज मान र/वा एकाइ छुटेको छ।"
+msgstr "हामीसँग Nutri-Score गणना गर्न सर्भिङ साइज मान र/वा एकाइ छुटेको छ।"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> उद्योगबाट स्वतन्त्र, गैर-नाफामुखी संस्थाद्वारा बनाइएको हो। यो सबैका लागि बनाइएको हो, सबैद्वारा, र यो सबैद्वारा वित्त पोषित छ। तपाईं ओपन फूड फ्याक्ट्समा दान गरेर हाम्रो कामलाई समर्थन गर्न सक्नुहुन्छ।<br/><b>धन्यवाद!</b>"
+msgstr "<<site_name>> उद्योगबाट स्वतन्त्र, गैर-नाफामुखी संस्थाद्वारा बनाइएको हो। यो सबैका लागि बनाइएको हो, सबैद्वारा, र यो सबैद्वारा वित्त पोषित छ। तपाईं Open Food Factsमा दान गरेर हाम्रो कामलाई समर्थन गर्न सक्नुहुन्छ।<br/><b>धन्यवाद!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> उद्योगबाट स्वतन्त्र, गैर-नाफामुखी संस्थाद्वारा बनाइएको हो। यो सबैका लागि बनाइएको हो, सबैद्वारा, र यो सबैद्वारा वित्त पोषित छ। तपाईं ओपन फूड फ्याक्ट्समा दान गरेर र लिलो खोज इन्जिन प्रयोग गरेर हाम्रो कामलाई समर्थन गर्न सक्नुहुन्छ।<br/><b>धन्यवाद!</b>"
+msgstr "<<site_name>> उद्योगबाट स्वतन्त्र, गैर-नाफामुखी संस्थाद्वारा बनाइएको हो। यो सबैका लागि बनाइएको हो, सबैद्वारा, र यो सबैद्वारा वित्त पोषित छ। तपाईं Open Food Factsमा दान गरेर र लिलो खोज इन्जिन प्रयोग गरेर हाम्रो कामलाई समर्थन गर्न सक्नुहुन्छ।<br/><b>धन्यवाद!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7686,7 +7681,7 @@ msgstr "लिलो खोज इन्जिन"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "रोबोटहरूबाट हुने अत्यधिक दुरुपयोगका कारण, हामी यो पृष्ठ अज्ञात प्रयोगकर्ताहरूलाई सेवा दिन असमर्थ छौं। सबै ओपन फूड फ्याक्ट्स पहुँच गर्न कृपया नि:शुल्क ओपन फूड फ्याक्ट्स खाता सिर्जना गर्नुहोस्।"
+msgstr "रोबोटहरूबाट हुने अत्यधिक दुरुपयोगका कारण, हामी यो पृष्ठ अज्ञात प्रयोगकर्ताहरूलाई सेवा दिन असमर्थ छौं। सबै Open Food Facts पहुँच गर्न कृपया नि:शुल्क Open Food Facts खाता सिर्जना गर्नुहोस्।"
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "नचाहिने सामग्रीहरू"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "यो प्राथमिकता ओपन फूड फ्याक्ट्सको सामग्री सूचीको बुझाइमा आधारित छ र यो सही नहुन सक्छ, सधैं उत्पादन आफैं जाँच गर्नुहोस्।"
+msgstr "यो प्राथमिकता Open Food Factsको सामग्री सूचीको बुझाइमा आधारित छ र यो सही नहुन सक्छ, सधैं उत्पादन आफैं जाँच गर्नुहोस्।"
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "हामीले पत्ता लगाएनौं: {unwanted_ingr
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "ती प्राथमिकताहरू ओपन फूड फ्याक्ट्सको सामग्री सूचीको बुझाइमा आधारित हुन्छन् र यो सही वा पूर्ण नहुन सक्ने सम्भावना सधैं रहन्छ, सधैं उत्पादन आफैं जाँच गर्नुहोस्।"
+msgstr "ती प्राथमिकताहरू Open Food Factsको सामग्री सूचीको बुझाइमा आधारित हुन्छन् र यो सही वा पूर्ण नहुन सक्ने सम्भावना सधैं रहन्छ, सधैं उत्पादन आफैं जाँच गर्नुहोस्।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/nl.po
+++ b/po/common/nl.po
@@ -1667,11 +1667,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Voedingsgraad"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/nl_BE.po
+++ b/po/common/nl_BE.po
@@ -1765,11 +1765,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Voedingswaarde"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/nl_NL.po
+++ b/po/common/nl_NL.po
@@ -1765,11 +1765,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Voedingsgraad"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/nn.po
+++ b/po/common/nn.po
@@ -63,7 +63,7 @@ msgstr "og Facebook-gruppen <a href=\"https://www.facebook.com/groups/OpenBeauty
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Åpne produktsøket for skjønnhetsfakta"
+msgstr "Åpne produktsøket for Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4705,7 +4700,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Næringsscore ikke aktuelt"
+msgstr "Nutri-Score ikke aktuelt"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -7671,7 +7666,7 @@ msgstr "Rapporter dette bildet til moderatorene våre"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Vi mangler verdien og/eller enheten for å beregne næringspoengsummen."
+msgstr "Vi mangler verdien og/eller enheten for å beregne Nutri-Score."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/no.po
+++ b/po/common/no.po
@@ -63,7 +63,7 @@ msgstr "og Facebook-gruppen <a href=\"https://www.facebook.com/groups/OpenBeauty
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Åpne produktsøket for skjønnhetsfakta"
+msgstr "Åpne produktsøket for Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4705,7 +4700,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Næringsscore ikke aktuelt"
+msgstr "Nutri-Score ikke aktuelt"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -7671,7 +7666,7 @@ msgstr "Rapporter dette bildet til moderatorene våre"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Vi mangler verdien og/eller enheten for å beregne næringspoengsummen."
+msgstr "Vi mangler verdien og/eller enheten for å beregne Nutri-Score."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/nr.po
+++ b/po/common/nr.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/oc.po
+++ b/po/common/oc.po
@@ -63,7 +63,7 @@ msgstr "e lo grop <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">p
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Dobrir la recèrca de produchs Beauty Facts"
+msgstr "Dobrir la recèrca de produchs Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Lo Verd-Score es una nòta environamentala de A+ a F que facilita la comparason de l'impacte dels produches alimentaris sus l'environament."
+msgstr "Green-Score es una nòta environamentala de A+ a F que facilita la comparason de l'impacte dels produches alimentaris sus l'environament."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Lo Verd-Score es una nòta environamentala de A+ a F que facilita la comparason de l'impacte dels produches alimentaris sus l'environament."
+msgstr "Green-Score es una nòta environamentala de A+ a F que facilita la comparason de l'impacte dels produches alimentaris sus l'environament."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"

--- a/po/common/or.po
+++ b/po/common/or.po
@@ -42,7 +42,7 @@ msgstr "ସାରା ବିଶ୍ୱର ପ୍ରସାଧନ ଉତ୍ପାଦ
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ଓପନ୍ ବ୍ୟୁଟି ଫ୍ୟାକ୍ଟସ୍ ସାରା ବିଶ୍ୱରୁ କସମେଟିକ୍ ଉତ୍ପାଦ ବିଷୟରେ ସୂଚନା ଏବଂ ତଥ୍ୟ ସଂଗ୍ରହ କରେ।"
+msgstr "Open Beauty Facts ସାରା ବିଶ୍ୱରୁ କସମେଟିକ୍ ଉତ୍ପାଦ ବିଷୟରେ ସୂଚନା ଏବଂ ତଥ୍ୟ ସଂଗ୍ରହ କରେ।"
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "ଏବଂ ଅବଦାନକାରୀଙ୍କ ପାଇଁ <a href=\"ht
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ସୌନ୍ଦର୍ଯ୍ୟ ତଥ୍ୟ ଉତ୍ପାଦ ସନ୍ଧାନ ଖୋଲନ୍ତୁ"
+msgstr "Open Beauty Facts ଉତ୍ପାଦ ସନ୍ଧାନ ଖୋଲନ୍ତୁ"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ଏହି ଉତ୍ପାଦ ପୃଷ୍ଠାଟି ସମ୍ପୂର୍ଣ୍ଣ ନୁହେଁ। ଆପଣ ଏହାକୁ ସମ୍ପାଦନ କରି ଏବଂ ଆମ ପାଖରେ ଥିବା ଫଟୋଗୁଡ଼ିକରୁ ଅଧିକ ତଥ୍ୟ ଯୋଡି ଏହାକୁ ସମ୍ପୂର୍ଣ୍ଣ କରିବାରେ ସାହାଯ୍ୟ କରିପାରିବେ, କିମ୍ବା <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> କିମ୍ବା <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>ପାଇଁ ୟୁନିଭର୍ସାଲ୍ ଓପନ ଫୁଡ୍ ଫ୍ୟାକ୍ଟସ୍ ଆପ୍ ବ୍ୟବହାର କରି ଅଧିକ ଫଟୋ ଉଠାଇପାରିବେ। ଧନ୍ୟବାଦ!"
+msgstr "ଏହି ଉତ୍ପାଦ ପୃଷ୍ଠାଟି ସମ୍ପୂର୍ଣ୍ଣ ନୁହେଁ। ଆପଣ ଏହାକୁ ସମ୍ପାଦନ କରି ଏବଂ ଆମ ପାଖରେ ଥିବା ଫଟୋଗୁଡ଼ିକରୁ ଅଧିକ ତଥ୍ୟ ଯୋଡି ଏହାକୁ ସମ୍ପୂର୍ଣ୍ଣ କରିବାରେ ସାହାଯ୍ୟ କରିପାରିବେ, କିମ୍ବା <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> କିମ୍ବା <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>ପାଇଁ ୟୁନିଭର୍ସାଲ୍ Open Food Facts ଆପ୍ ବ୍ୟବହାର କରି ଅଧିକ ଫଟୋ ଉଠାଇପାରିବେ। ଧନ୍ୟବାଦ!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ଏହି ଉତ୍ପାଦ ପୃଷ୍ଠାଟି ସମ୍ପୂର୍ଣ୍ଣ ନୁହେଁ। ଆପଣ ଏହାକୁ ସମ୍ପାଦନ କରି ଏବଂ ଆମ ପାଖରେ ଥିବା ଫଟୋଗୁଡ଼ିକରୁ ଅଧିକ ତଥ୍ୟ ଯୋଡି ଏହାକୁ ସମ୍ପୂର୍ଣ୍ଣ କରିବାରେ ସାହାଯ୍ୟ କରିପାରିବେ, କିମ୍ବା <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> କିମ୍ବା <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>ପାଇଁ ୟୁନିଭର୍ସାଲ୍ ଓପନ ଫୁଡ୍ ଫ୍ୟାକ୍ଟସ୍ ଆପ୍ ବ୍ୟବହାର କରି ଅଧିକ ଫଟୋ ଉଠାଇପାରିବେ। ଧନ୍ୟବାଦ!"
+msgstr "ଏହି ଉତ୍ପାଦ ପୃଷ୍ଠାଟି ସମ୍ପୂର୍ଣ୍ଣ ନୁହେଁ। ଆପଣ ଏହାକୁ ସମ୍ପାଦନ କରି ଏବଂ ଆମ ପାଖରେ ଥିବା ଫଟୋଗୁଡ଼ିକରୁ ଅଧିକ ତଥ୍ୟ ଯୋଡି ଏହାକୁ ସମ୍ପୂର୍ଣ୍ଣ କରିବାରେ ସାହାଯ୍ୟ କରିପାରିବେ, କିମ୍ବା <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> କିମ୍ବା <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>ପାଇଁ ୟୁନିଭର୍ସାଲ୍ Open Food Facts ଆପ୍ ବ୍ୟବହାର କରି ଅଧିକ ଫଟୋ ଉଠାଇପାରିବେ। ଧନ୍ୟବାଦ!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "ନ୍ୟୁଟ୍ରି-ସ୍କୋର୍ ପ୍ରଯୁଜ୍ୟ ନୁହେଁ"
+msgstr "Nutri-Score ପ୍ରଯୁଜ୍ୟ ନୁହେଁ"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ଗ୍ରୀନ୍-ସ୍କୋର୍ ହେଉଛି A+ ରୁ F ପର୍ଯ୍ୟନ୍ତ ଏକ ପରିବେଶଗତ ସ୍କୋର ଯାହା ପରିବେଶ ଉପରେ ଖାଦ୍ୟ ଉତ୍ପାଦର ପ୍ରଭାବକୁ ତୁଳନା କରିବା ସହଜ କରିଥାଏ।"
+msgstr "Green-Score ହେଉଛି A+ ରୁ F ପର୍ଯ୍ୟନ୍ତ ଏକ ପରିବେଶଗତ ସ୍କୋର ଯାହା ପରିବେଶ ଉପରେ ଖାଦ୍ୟ ଉତ୍ପାଦର ପ୍ରଭାବକୁ ତୁଳନା କରିବା ସହଜ କରିଥାଏ।"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ଗ୍ରୀନ୍-ସ୍କୋର୍ ହେଉଛି A+ ରୁ F ପର୍ଯ୍ୟନ୍ତ ଏକ ପରିବେଶଗତ ସ୍କୋର ଯାହା ପରିବେଶ ଉପରେ ଖାଦ୍ୟ ଉତ୍ପାଦର ପ୍ରଭାବକୁ ତୁଳନା କରିବା ସହଜ କରିଥାଏ।"
+msgstr "Green-Score ହେଉଛି A+ ରୁ F ପର୍ଯ୍ୟନ୍ତ ଏକ ପରିବେଶଗତ ସ୍କୋର ଯାହା ପରିବେଶ ଉପରେ ଖାଦ୍ୟ ଉତ୍ପାଦର ପ୍ରଭାବକୁ ତୁଳନା କରିବା ସହଜ କରିଥାଏ।"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ଗ୍ରୀନ୍-ସ୍କୋର୍ ପ୍ରାରମ୍ଭରେ ଫ୍ରାନ୍ସ ପାଇଁ ବିକଶିତ ହୋଇଥିଲା ଏବଂ ଏହାକୁ ଅନ୍ୟ ୟୁରୋପୀୟ ଦେଶଗୁଡ଼ିକୁ ବିସ୍ତାର କରାଯାଉଛି। ଗ୍ରୀନ୍-ସ୍କୋର୍ ସୂତ୍ରକୁ ପରିବର୍ତ୍ତନ କରାଯାଇପାରିବ କାରଣ ଏହାକୁ ନିୟମିତ ଭାବରେ ଉନ୍ନତ କରାଯାଉଛି ଯାହା ଦ୍ୱାରା ଏହାକୁ ପ୍ରତ୍ୟେକ ଦେଶ ପାଇଁ ଅଧିକ ସଠିକ୍ ଏବଂ ଉପଯୁକ୍ତ କରାଯାଇପାରିବ।"
+msgstr "Green-Score ପ୍ରାରମ୍ଭରେ ଫ୍ରାନ୍ସ ପାଇଁ ବିକଶିତ ହୋଇଥିଲା ଏବଂ ଏହାକୁ ଅନ୍ୟ ୟୁରୋପୀୟ ଦେଶଗୁଡ଼ିକୁ ବିସ୍ତାର କରାଯାଉଛି। Green-Score ସୂତ୍ରକୁ ପରିବର୍ତ୍ତନ କରାଯାଇପାରିବ କାରଣ ଏହାକୁ ନିୟମିତ ଭାବରେ ଉନ୍ନତ କରାଯାଉଛି ଯାହା ଦ୍ୱାରା ଏହାକୁ ପ୍ରତ୍ୟେକ ଦେଶ ପାଇଁ ଅଧିକ ସଠିକ୍ ଏବଂ ଉପଯୁକ୍ତ କରାଯାଇପାରିବ।"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ଏହି ଉତ୍ପାଦ ପାଇଁ ଆମେ ଯେଉଁ ବର୍ଗରେ ଅଛୁ ତାହା ସବୁଜ-ସ୍କୋର ଗଣନା କରିବା ପାଇଁ ଯଥେଷ୍ଟ ସଠିକ୍ ନୁହେଁ। ଆପଣ କ’ଣ ଅଧିକ ସଠିକ୍ ଉତ୍ପାଦ ବର୍ଗ ଯୋଡିପାରିବେ?"
+msgstr "ଏହି ଉତ୍ପାଦ ପାଇଁ ଆମେ ଯେଉଁ ବର୍ଗରେ ଅଛୁ ତାହା Green-Score ଗଣନା କରିବା ପାଇଁ ଯଥେଷ୍ଟ ସଠିକ୍ ନୁହେଁ। ଆପଣ କ’ଣ ଅଧିକ ସଠିକ୍ ଉତ୍ପାଦ ବର୍ଗ ଯୋଡିପାରିବେ?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,7 +7665,7 @@ msgstr "ଏହି ପ୍ରତିଛବିଟି ଆମର ମୋଡରେଟର
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "ନ୍ୟୁଟ୍ରି-ସ୍କୋର ଗଣନା କରିବା ପାଇଁ ଆମେ ସର୍ଭିଂ ଆକାର ମୂଲ୍ୟ ଏବଂ/କିମ୍ବା ୟୁନିଟ୍ ହରାଇଛୁ।"
+msgstr "Nutri-Score ଗଣନା କରିବା ପାଇଁ ଆମେ ସର୍ଭିଂ ଆକାର ମୂଲ୍ୟ ଏବଂ/କିମ୍ବା ୟୁନିଟ୍ ହରାଇଛୁ।"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
@@ -7772,7 +7767,7 @@ msgstr "ଅନାବଶ୍ୟକ ଉପାଦାନଗୁଡ଼ିକ"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "ଏହି ପସନ୍ଦ ଓପନ ଫୁଡ୍ ଫ୍ୟାକ୍ଟସର ଉପାଦାନ ତାଲିକାର ବୁଝାମଣା ଉପରେ ଆଧାରିତ ଏବଂ ଏହା ସଠିକ୍ ନ ହୋଇପାରେ, ସର୍ବଦା ନିଜେ ଉତ୍ପାଦଟି ଯାଞ୍ଚ କରନ୍ତୁ।"
+msgstr "ଏହି ପସନ୍ଦ Open Food Facts ଉପାଦାନ ତାଲିକାର ବୁଝାମଣା ଉପରେ ଆଧାରିତ ଏବଂ ଏହା ସଠିକ୍ ନ ହୋଇପାରେ, ସର୍ବଦା ନିଜେ ଉତ୍ପାଦଟି ଯାଞ୍ଚ କରନ୍ତୁ।"
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "ଆମେ ଚିହ୍ନଟ କରିପାରିଲୁ ନାହିଁ
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "ସେହି ପସନ୍ଦଗୁଡ଼ିକ ଓପନ ଫୁଡ୍ ଫ୍ୟାକ୍ଟସର ଉପାଦାନ ତାଲିକାର ବୁଝାମଣା ଉପରେ ଆଧାରିତ ଏବଂ ସର୍ବଦା ଏକ ସମ୍ଭାବନା ରହିଥାଏ ଯେ ଏହା ସଠିକ୍ କିମ୍ବା ସମ୍ପୂର୍ଣ୍ଣ ନ ହୋଇପାରେ, ସର୍ବଦା ନିଜେ ଉତ୍ପାଦଟି ଯାଞ୍ଚ କରନ୍ତୁ।"
+msgstr "ସେହି ପସନ୍ଦଗୁଡ଼ିକ Open Food Facts ଉପାଦାନ ତାଲିକାର ବୁଝାମଣା ଉପରେ ଆଧାରିତ ଏବଂ ସର୍ବଦା ଏକ ସମ୍ଭାବନା ରହିଥାଏ ଯେ ଏହା ସଠିକ୍ କିମ୍ବା ସମ୍ପୂର୍ଣ୍ଣ ନ ହୋଇପାରେ, ସର୍ବଦା ନିଜେ ଉତ୍ପାଦଟି ଯାଞ୍ଚ କରନ୍ତୁ।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/pa.po
+++ b/po/common/pa.po
@@ -42,7 +42,7 @@ msgstr "ਦੁਨੀਆ ਭਰ ਦੇ ਕਾਸਮੈਟਿਕ ਉਤਪਾਦ�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ਓਪਨ ਬਿਊਟੀ ਫੈਕਟਸ ਦੁਨੀਆ ਭਰ ਦੇ ਕਾਸਮੈਟਿਕ ਉਤਪਾਦਾਂ ਬਾਰੇ ਜਾਣਕਾਰੀ ਅਤੇ ਡੇਟਾ ਇਕੱਠਾ ਕਰਦਾ ਹੈ।"
+msgstr "Open Beauty Facts ਦੁਨੀਆ ਭਰ ਦੇ ਕਾਸਮੈਟਿਕ ਉਤਪਾਦਾਂ ਬਾਰੇ ਜਾਣਕਾਰੀ ਅਤੇ ਡੇਟਾ ਇਕੱਠਾ ਕਰਦਾ ਹੈ।"
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "ਅਤੇ ਯੋਗਦਾਨ ਪਾਉਣ ਵਾਲਿਆਂ ਲਈ <a h
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ਸੁੰਦਰਤਾ ਤੱਥ ਉਤਪਾਦ ਖੋਜ ਖੋਲ੍ਹੋ"
+msgstr "Open Beauty Facts ਉਤਪਾਦ ਖੋਜ ਖੋਲ੍ਹੋ"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ਇਹ ਉਤਪਾਦ ਪੰਨਾ ਪੂਰਾ ਨਹੀਂ ਹੈ। ਤੁਸੀਂ ਇਸਨੂੰ ਸੰਪਾਦਿਤ ਕਰਕੇ ਅਤੇ ਸਾਡੇ ਕੋਲ ਮੌਜੂਦ ਫੋਟੋਆਂ ਤੋਂ ਹੋਰ ਡੇਟਾ ਜੋੜ ਕੇ, ਜਾਂ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ਐਂਡਰਾਇਡ</a> ਜਾਂ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">ਆਈਫੋਨ/ਆਈਪੈਡ</a>ਲਈ ਯੂਨੀਵਰਸਲ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਐਪ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਹੋਰ ਫੋਟੋਆਂ ਖਿੱਚ ਕੇ ਇਸਨੂੰ ਪੂਰਾ ਕਰਨ ਵਿੱਚ ਮਦਦ ਕਰ ਸਕਦੇ ਹੋ। ਧੰਨਵਾਦ!"
+msgstr "ਇਹ ਉਤਪਾਦ ਪੰਨਾ ਪੂਰਾ ਨਹੀਂ ਹੈ। ਤੁਸੀਂ ਇਸਨੂੰ ਸੰਪਾਦਿਤ ਕਰਕੇ ਅਤੇ ਸਾਡੇ ਕੋਲ ਮੌਜੂਦ ਫੋਟੋਆਂ ਤੋਂ ਹੋਰ ਡੇਟਾ ਜੋੜ ਕੇ, ਜਾਂ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ਐਂਡਰਾਇਡ</a> ਜਾਂ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">ਆਈਫੋਨ/ਆਈਪੈਡ</a>ਲਈ ਯੂਨੀਵਰਸਲ Open Food Facts ਐਪ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਹੋਰ ਫੋਟੋਆਂ ਖਿੱਚ ਕੇ ਇਸਨੂੰ ਪੂਰਾ ਕਰਨ ਵਿੱਚ ਮਦਦ ਕਰ ਸਕਦੇ ਹੋ। ਧੰਨਵਾਦ!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ਇਹ ਉਤਪਾਦ ਪੰਨਾ ਪੂਰਾ ਨਹੀਂ ਹੈ। ਤੁਸੀਂ ਇਸਨੂੰ ਸੰਪਾਦਿਤ ਕਰਕੇ ਅਤੇ ਸਾਡੇ ਕੋਲ ਮੌਜੂਦ ਫੋਟੋਆਂ ਤੋਂ ਹੋਰ ਡੇਟਾ ਜੋੜ ਕੇ, ਜਾਂ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ਐਂਡਰਾਇਡ</a> ਜਾਂ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">ਆਈਫੋਨ/ਆਈਪੈਡ</a>ਲਈ ਯੂਨੀਵਰਸਲ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਐਪ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਹੋਰ ਫੋਟੋਆਂ ਖਿੱਚ ਕੇ ਇਸਨੂੰ ਪੂਰਾ ਕਰਨ ਵਿੱਚ ਮਦਦ ਕਰ ਸਕਦੇ ਹੋ। ਧੰਨਵਾਦ!"
+msgstr "ਇਹ ਉਤਪਾਦ ਪੰਨਾ ਪੂਰਾ ਨਹੀਂ ਹੈ। ਤੁਸੀਂ ਇਸਨੂੰ ਸੰਪਾਦਿਤ ਕਰਕੇ ਅਤੇ ਸਾਡੇ ਕੋਲ ਮੌਜੂਦ ਫੋਟੋਆਂ ਤੋਂ ਹੋਰ ਡੇਟਾ ਜੋੜ ਕੇ, ਜਾਂ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ਐਂਡਰਾਇਡ</a> ਜਾਂ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">ਆਈਫੋਨ/ਆਈਪੈਡ</a>ਲਈ ਯੂਨੀਵਰਸਲ Open Food Facts ਐਪ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਹੋਰ ਫੋਟੋਆਂ ਖਿੱਚ ਕੇ ਇਸਨੂੰ ਪੂਰਾ ਕਰਨ ਵਿੱਚ ਮਦਦ ਕਰ ਸਕਦੇ ਹੋ। ਧੰਨਵਾਦ!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "ਨਿਊਟ੍ਰੀ-ਸਕੋਰ ਲਾਗੂ ਨਹੀਂ ਹੈ"
+msgstr "Nutri-Score ਲਾਗੂ ਨਹੀਂ ਹੈ"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ਗ੍ਰੀਨ-ਸਕੋਰ A+ ਤੋਂ F ਤੱਕ ਦਾ ਇੱਕ ਵਾਤਾਵਰਣ ਸਕੋਰ ਹੈ ਜੋ ਵਾਤਾਵਰਣ 'ਤੇ ਭੋਜਨ ਉਤਪਾਦਾਂ ਦੇ ਪ੍ਰਭਾਵ ਦੀ ਤੁਲਨਾ ਕਰਨਾ ਆਸਾਨ ਬਣਾਉਂਦਾ ਹੈ।"
+msgstr "Green-Score A+ ਤੋਂ F ਤੱਕ ਦਾ ਇੱਕ ਵਾਤਾਵਰਣ ਸਕੋਰ ਹੈ ਜੋ ਵਾਤਾਵਰਣ 'ਤੇ ਭੋਜਨ ਉਤਪਾਦਾਂ ਦੇ ਪ੍ਰਭਾਵ ਦੀ ਤੁਲਨਾ ਕਰਨਾ ਆਸਾਨ ਬਣਾਉਂਦਾ ਹੈ।"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ਗ੍ਰੀਨ-ਸਕੋਰ A+ ਤੋਂ F ਤੱਕ ਦਾ ਇੱਕ ਵਾਤਾਵਰਣ ਸਕੋਰ ਹੈ ਜੋ ਵਾਤਾਵਰਣ 'ਤੇ ਭੋਜਨ ਉਤਪਾਦਾਂ ਦੇ ਪ੍ਰਭਾਵ ਦੀ ਤੁਲਨਾ ਕਰਨਾ ਆਸਾਨ ਬਣਾਉਂਦਾ ਹੈ।"
+msgstr "Green-Score A+ ਤੋਂ F ਤੱਕ ਦਾ ਇੱਕ ਵਾਤਾਵਰਣ ਸਕੋਰ ਹੈ ਜੋ ਵਾਤਾਵਰਣ 'ਤੇ ਭੋਜਨ ਉਤਪਾਦਾਂ ਦੇ ਪ੍ਰਭਾਵ ਦੀ ਤੁਲਨਾ ਕਰਨਾ ਆਸਾਨ ਬਣਾਉਂਦਾ ਹੈ।"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ਗ੍ਰੀਨ-ਸਕੋਰ ਸ਼ੁਰੂ ਵਿੱਚ ਫਰਾਂਸ ਲਈ ਵਿਕਸਤ ਕੀਤਾ ਗਿਆ ਸੀ ਅਤੇ ਇਸਨੂੰ ਹੋਰ ਯੂਰਪੀਅਨ ਦੇਸ਼ਾਂ ਵਿੱਚ ਵਧਾਇਆ ਜਾ ਰਿਹਾ ਹੈ। ਗ੍ਰੀਨ-ਸਕੋਰ ਫਾਰਮੂਲਾ ਬਦਲ ਸਕਦਾ ਹੈ ਕਿਉਂਕਿ ਇਸਨੂੰ ਨਿਯਮਿਤ ਤੌਰ 'ਤੇ ਸੁਧਾਰਿਆ ਜਾਂਦਾ ਹੈ ਤਾਂ ਜੋ ਇਸਨੂੰ ਹਰੇਕ ਦੇਸ਼ ਲਈ ਵਧੇਰੇ ਸਟੀਕ ਅਤੇ ਬਿਹਤਰ ਢੰਗ ਨਾਲ ਅਨੁਕੂਲ ਬਣਾਇਆ ਜਾ ਸਕੇ।"
+msgstr "Green-Score ਸ਼ੁਰੂ ਵਿੱਚ ਫਰਾਂਸ ਲਈ ਵਿਕਸਤ ਕੀਤਾ ਗਿਆ ਸੀ ਅਤੇ ਇਸਨੂੰ ਹੋਰ ਯੂਰਪੀਅਨ ਦੇਸ਼ਾਂ ਵਿੱਚ ਵਧਾਇਆ ਜਾ ਰਿਹਾ ਹੈ। Green-Score ਫਾਰਮੂਲਾ ਬਦਲ ਸਕਦਾ ਹੈ ਕਿਉਂਕਿ ਇਸਨੂੰ ਨਿਯਮਿਤ ਤੌਰ 'ਤੇ ਸੁਧਾਰਿਆ ਜਾਂਦਾ ਹੈ ਤਾਂ ਜੋ ਇਸਨੂੰ ਹਰੇਕ ਦੇਸ਼ ਲਈ ਵਧੇਰੇ ਸਟੀਕ ਅਤੇ ਬਿਹਤਰ ਢੰਗ ਨਾਲ ਅਨੁਕੂਲ ਬਣਾਇਆ ਜਾ ਸਕੇ।"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ਇਸ ਉਤਪਾਦ ਲਈ ਸਾਡੇ ਕੋਲ ਜੋ ਸ਼੍ਰੇਣੀ ਹੈ ਉਹ ਗ੍ਰੀਨ-ਸਕੋਰ ਦੀ ਗਣਨਾ ਕਰਨ ਲਈ ਕਾਫ਼ੀ ਸਟੀਕ ਨਹੀਂ ਹੈ। ਕੀ ਤੁਸੀਂ ਇੱਕ ਹੋਰ ਸਟੀਕ ਉਤਪਾਦ ਸ਼੍ਰੇਣੀ ਜੋੜ ਸਕਦੇ ਹੋ?"
+msgstr "ਇਸ ਉਤਪਾਦ ਲਈ ਸਾਡੇ ਕੋਲ ਜੋ ਸ਼੍ਰੇਣੀ ਹੈ ਉਹ Green-Score ਦੀ ਗਣਨਾ ਕਰਨ ਲਈ ਕਾਫ਼ੀ ਸਟੀਕ ਨਹੀਂ ਹੈ। ਕੀ ਤੁਸੀਂ ਇੱਕ ਹੋਰ ਸਟੀਕ ਉਤਪਾਦ ਸ਼੍ਰੇਣੀ ਜੋੜ ਸਕਦੇ ਹੋ?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,15 +7665,15 @@ msgstr "ਇਸ ਤਸਵੀਰ ਦੀ ਰਿਪੋਰਟ ਸਾਡੇ ਮਾਡ�
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "ਸਾਡੇ ਕੋਲ ਨਿਊਟ੍ਰੀ-ਸਕੋਰ ਦੀ ਗਣਨਾ ਕਰਨ ਲਈ ਸਰਵਿੰਗ ਸਾਈਜ਼ ਵੈਲਯੂ ਅਤੇ/ਜਾਂ ਯੂਨਿਟ ਦੀ ਘਾਟ ਹੈ।"
+msgstr "ਸਾਡੇ ਕੋਲ Nutri-Score ਦੀ ਗਣਨਾ ਕਰਨ ਲਈ ਸਰਵਿੰਗ ਸਾਈਜ਼ ਵੈਲਯੂ ਅਤੇ/ਜਾਂ ਯੂਨਿਟ ਦੀ ਘਾਟ ਹੈ।"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> ਇੱਕ ਗੈਰ-ਮੁਨਾਫ਼ਾ ਸੰਗਠਨ ਦੁਆਰਾ ਬਣਾਇਆ ਗਿਆ ਹੈ, ਜੋ ਕਿ ਉਦਯੋਗ ਤੋਂ ਸੁਤੰਤਰ ਹੈ। ਇਹ ਸਾਰਿਆਂ ਲਈ ਬਣਾਇਆ ਗਿਆ ਹੈ, ਸਾਰਿਆਂ ਦੁਆਰਾ, ਅਤੇ ਇਸਨੂੰ ਸਾਰਿਆਂ ਦੁਆਰਾ ਫੰਡ ਦਿੱਤਾ ਜਾਂਦਾ ਹੈ। ਤੁਸੀਂ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਨੂੰ ਦਾਨ ਕਰਕੇ ਸਾਡੇ ਕੰਮ ਦਾ ਸਮਰਥਨ ਕਰ ਸਕਦੇ ਹੋ।<br/><b>ਧੰਨਵਾਦ!</b>"
+msgstr "<<site_name>> ਇੱਕ ਗੈਰ-ਮੁਨਾਫ਼ਾ ਸੰਗਠਨ ਦੁਆਰਾ ਬਣਾਇਆ ਗਿਆ ਹੈ, ਜੋ ਕਿ ਉਦਯੋਗ ਤੋਂ ਸੁਤੰਤਰ ਹੈ। ਇਹ ਸਾਰਿਆਂ ਲਈ ਬਣਾਇਆ ਗਿਆ ਹੈ, ਸਾਰਿਆਂ ਦੁਆਰਾ, ਅਤੇ ਇਸਨੂੰ ਸਾਰਿਆਂ ਦੁਆਰਾ ਫੰਡ ਦਿੱਤਾ ਜਾਂਦਾ ਹੈ। ਤੁਸੀਂ Open Food Facts ਨੂੰ ਦਾਨ ਕਰਕੇ ਸਾਡੇ ਕੰਮ ਦਾ ਸਮਰਥਨ ਕਰ ਸਕਦੇ ਹੋ।<br/><b>ਧੰਨਵਾਦ!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> ਇੱਕ ਗੈਰ-ਮੁਨਾਫ਼ਾ ਸੰਗਠਨ ਦੁਆਰਾ ਬਣਾਇਆ ਗਿਆ ਹੈ, ਜੋ ਕਿ ਉਦਯੋਗ ਤੋਂ ਸੁਤੰਤਰ ਹੈ। ਇਹ ਸਾਰਿਆਂ ਲਈ ਬਣਾਇਆ ਗਿਆ ਹੈ, ਸਾਰਿਆਂ ਦੁਆਰਾ, ਅਤੇ ਇਸਨੂੰ ਸਾਰਿਆਂ ਦੁਆਰਾ ਫੰਡ ਦਿੱਤਾ ਜਾਂਦਾ ਹੈ। ਤੁਸੀਂ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਨੂੰ ਦਾਨ ਕਰਕੇ ਅਤੇ ਲੀਲੋ ਸਰਚ ਇੰਜਣ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਸਾਡੇ ਕੰਮ ਦਾ ਸਮਰਥਨ ਕਰ ਸਕਦੇ ਹੋ।<br/><b>ਧੰਨਵਾਦ!</b>"
+msgstr "<<site_name>> ਇੱਕ ਗੈਰ-ਮੁਨਾਫ਼ਾ ਸੰਗਠਨ ਦੁਆਰਾ ਬਣਾਇਆ ਗਿਆ ਹੈ, ਜੋ ਕਿ ਉਦਯੋਗ ਤੋਂ ਸੁਤੰਤਰ ਹੈ। ਇਹ ਸਾਰਿਆਂ ਲਈ ਬਣਾਇਆ ਗਿਆ ਹੈ, ਸਾਰਿਆਂ ਦੁਆਰਾ, ਅਤੇ ਇਸਨੂੰ ਸਾਰਿਆਂ ਦੁਆਰਾ ਫੰਡ ਦਿੱਤਾ ਜਾਂਦਾ ਹੈ। ਤੁਸੀਂ Open Food Facts ਨੂੰ ਦਾਨ ਕਰਕੇ ਅਤੇ ਲੀਲੋ ਸਰਚ ਇੰਜਣ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਸਾਡੇ ਕੰਮ ਦਾ ਸਮਰਥਨ ਕਰ ਸਕਦੇ ਹੋ।<br/><b>ਧੰਨਵਾਦ!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7686,7 +7681,7 @@ msgstr "ਲੀਲੋ ਸਰਚ ਇੰਜਣ"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "ਰੋਬੋਟਾਂ ਵੱਲੋਂ ਭਾਰੀ ਦੁਰਵਰਤੋਂ ਦੇ ਕਾਰਨ, ਅਸੀਂ ਇਸ ਪੰਨੇ ਨੂੰ ਅਣਪਛਾਤੇ ਉਪਭੋਗਤਾਵਾਂ ਨੂੰ ਨਹੀਂ ਦੇ ਸਕਦੇ। ਕਿਰਪਾ ਕਰਕੇ ਸਾਰੇ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਤੱਕ ਪਹੁੰਚ ਕਰਨ ਲਈ ਇੱਕ ਮੁਫ਼ਤ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਖਾਤਾ ਬਣਾਓ।"
+msgstr "ਰੋਬੋਟਾਂ ਵੱਲੋਂ ਭਾਰੀ ਦੁਰਵਰਤੋਂ ਦੇ ਕਾਰਨ, ਅਸੀਂ ਇਸ ਪੰਨੇ ਨੂੰ ਅਣਪਛਾਤੇ ਉਪਭੋਗਤਾਵਾਂ ਨੂੰ ਨਹੀਂ ਦੇ ਸਕਦੇ। ਕਿਰਪਾ ਕਰਕੇ ਸਾਰੇ Open Food Facts ਤੱਕ ਪਹੁੰਚ ਕਰਨ ਲਈ ਇੱਕ ਮੁਫ਼ਤ Open Food Facts ਖਾਤਾ ਬਣਾਓ।"
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "ਅਣਚਾਹੇ ਤੱਤ"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "ਇਹ ਤਰਜੀਹ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਦੀ ਸਮੱਗਰੀ ਸੂਚੀ ਦੀ ਸਮਝ 'ਤੇ ਅਧਾਰਤ ਹੈ ਅਤੇ ਹੋ ਸਕਦਾ ਹੈ ਕਿ ਇਹ ਸਹੀ ਨਾ ਹੋਵੇ, ਹਮੇਸ਼ਾ ਉਤਪਾਦ ਦੀ ਖੁਦ ਜਾਂਚ ਕਰੋ।"
+msgstr "ਇਹ ਤਰਜੀਹ Open Food Facts ਦੀ ਸਮੱਗਰੀ ਸੂਚੀ ਦੀ ਸਮਝ 'ਤੇ ਅਧਾਰਤ ਹੈ ਅਤੇ ਹੋ ਸਕਦਾ ਹੈ ਕਿ ਇਹ ਸਹੀ ਨਾ ਹੋਵੇ, ਹਮੇਸ਼ਾ ਉਤਪਾਦ ਦੀ ਖੁਦ ਜਾਂਚ ਕਰੋ।"
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "ਸਾਨੂੰ ਇਹ ਪਤਾ ਨਹੀਂ ਲੱਗਿਆ: {unwanted
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "ਉਹ ਤਰਜੀਹਾਂ ਓਪਨ ਫੂਡ ਫੈਕਟਸ ਦੀ ਸਮੱਗਰੀ ਸੂਚੀ ਦੀ ਸਮਝ 'ਤੇ ਅਧਾਰਤ ਹਨ ਅਤੇ ਹਮੇਸ਼ਾ ਇਹ ਸੰਭਾਵਨਾ ਰਹਿੰਦੀ ਹੈ ਕਿ ਇਹ ਸਹੀ ਜਾਂ ਸੰਪੂਰਨ ਨਾ ਹੋਵੇ, ਹਮੇਸ਼ਾ ਉਤਪਾਦ ਦੀ ਖੁਦ ਜਾਂਚ ਕਰੋ।"
+msgstr "ਉਹ ਤਰਜੀਹਾਂ Open Food Facts ਦੀ ਸਮੱਗਰੀ ਸੂਚੀ ਦੀ ਸਮਝ 'ਤੇ ਅਧਾਰਤ ਹਨ ਅਤੇ ਹਮੇਸ਼ਾ ਇਹ ਸੰਭਾਵਨਾ ਰਹਿੰਦੀ ਹੈ ਕਿ ਇਹ ਸਹੀ ਜਾਂ ਸੰਪੂਰਨ ਨਾ ਹੋਵੇ, ਹਮੇਸ਼ਾ ਉਤਪਾਦ ਦੀ ਖੁਦ ਜਾਂਚ ਕਰੋ।"
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/pl.po
+++ b/po/common/pl.po
@@ -1766,11 +1766,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Stopień odżywienia"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/pt.po
+++ b/po/common/pt.po
@@ -1667,11 +1667,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Classificação nutricional"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/pt_BR.po
+++ b/po/common/pt_BR.po
@@ -1765,11 +1765,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Classificação nutricional"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4709,7 +4704,7 @@ msgstr "O Nutri-Score é calculado e pode ser tido em conta para todos os produt
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "Nutri-Pontos %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
@@ -4973,7 +4968,7 @@ msgstr "O Green-Score é uma classificação ambiental de A+ a F que facilita a 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Eco-Pontuação %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -6532,7 +6527,7 @@ msgstr "Use as preferências padrão"
 
 msgctxt "reset_preferences_details"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "Score nutricional. score ecológico e nível de processamento de alimento (NOVA)"
+msgstr "Nutri-Score. Green-Score e nível de processamento de alimento (NOVA)"
 
 msgctxt "actions_add_ingredients"
 msgid "Could you add the ingredients list?"
@@ -6540,11 +6535,11 @@ msgstr "Você pode adicionar a lista de ingredientes?"
 
 msgctxt "actions_to_compute_nutriscore"
 msgid "Could you add the information needed to compute the Nutri-Score?"
-msgstr "Você pode adicionar as informações necessárias para computar o score nutricional?"
+msgstr "Você pode adicionar as informações necessárias para computar o Nutri-Score?"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Você pode adicionar uma categoria precisa de produto para que possamos computar o score ecológico?"
+msgstr "Você pode adicionar uma categoria precisa de produto para que possamos computar o Green-Score?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
@@ -7443,11 +7438,11 @@ msgstr "Selecione um arquivo com dados do produto"
 
 msgctxt "number_of_products_without_nutriscore"
 msgid "Number of products without Nutri-Score"
-msgstr "Quantidade de produtos sem Pontuação Nutricional"
+msgstr "Quantidade de produtos sem Nutri-Score"
 
 msgctxt "percent_of_products_with_nutriscore"
 msgid "% of products where Nutri-Score is computed"
-msgstr "% de produtos onde a Pontuação Nutricional é calculada"
+msgstr "% de produtos onde a Nutri-Score é calculada"
 
 msgctxt "products_to_be_exported"
 msgid "Products to be exported"
@@ -7459,7 +7454,7 @@ msgstr "Produtos exportados"
 
 msgctxt "opportunities_to_improve_nutriscore"
 msgid "Opp. for Nutri-Score improvements"
-msgstr "Oportunidade para melhorias na Pontuação Nutricional"
+msgstr "Oportunidade para melhorias na Nutri-Score"
 
 msgctxt "date_of_last_update"
 msgid "Date of last update"
@@ -7614,11 +7609,11 @@ msgstr "Diversos estudos determinaram que o consumo reduzido de alimentos ultrap
 
 msgctxt "discover_the_evolution_of_the_nutriscore_grades_of_your_products"
 msgid "Discover the evolution of the Nutri-Score grades of your products"
-msgstr "Descubra a evolução da Nutri-Pontuação de seus produtos"
+msgstr "Descubra a evolução da Nutri-Score de seus produtos"
 
 msgctxt "add_products_to_discover_the_evolution_of_their_nutriscore_grades"
 msgid "Add products with a category, ingredients list and nutrition facts to discover the evolution of their Nutri-Score grades."
-msgstr "Adicione produtos com uma categoria, lista de ingredientes e fatores nutricionais para descobrir a evolução da Nutri-Pontuação deles."
+msgstr "Adicione produtos com uma categoria, lista de ingredientes e fatores nutricionais para descobrir a evolução da Nutri-Score deles."
 
 msgctxt "in_contact_with_food"
 msgid "In contact with food"
@@ -7671,7 +7666,7 @@ msgstr "Agricultura orgânica e comércio justo"
 
 msgctxt "reset_preferences_details_food"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "Score nutricional. score ecológico e nível de processamento de alimento (NOVA)"
+msgstr "Nutri-Score. Green-Score e nível de processamento de alimento (NOVA)"
 
 msgctxt "reset_preferences_details_product"
 msgid "Good repairability"

--- a/po/common/pt_PT.po
+++ b/po/common/pt_PT.po
@@ -1765,11 +1765,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Classificação nutricional"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/qu.po
+++ b/po/common/qu.po
@@ -63,7 +63,7 @@ msgstr "chaymanta <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">F
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Kichasqa Sumaq kay Chiqap ruru maskay"
+msgstr "Open Beauty Facts ruru maskay"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Verde-Puntuación nisqa pachamamamanta A+ nisqamanta F nisqakamam chaymi mana sasachu tupachiyta mikhuy rurukuna pachamamapi imayna kasqanmanta."
+msgstr "Green-Score nisqa pachamamamanta A+ nisqamanta F nisqakamam chaymi mana sasachu tupachiyta mikhuy rurukuna pachamamapi imayna kasqanmanta."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Verde-Puntuación nisqa pachamamamanta A+ nisqamanta F nisqakamam chaymi mana sasachu tupachiyta mikhuy rurukuna pachamamapi imayna kasqanmanta."
+msgstr "Green-Score nisqa pachamamamanta A+ nisqamanta F nisqakamam chaymi mana sasachu tupachiyta mikhuy rurukuna pachamamapi imayna kasqanmanta."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Kay rurupaq categoría kaqniykuqa mana allinchu Verde-Puntuación yupaypaq. ¿Aswan chiqan rurukuna categoría yapayta atiwaqchu?"
+msgstr "Kay rurupaq categoría kaqniykuqa mana allinchu Green-Score yupaypaq. ¿Aswan chiqan rurukuna categoría yapayta atiwaqchu?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7686,7 +7681,7 @@ msgstr "Lilo maskaq"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Robotkunamanta llumpay abusorayku, mana kay p'anqata mana riqsisqa llamk'aqkunaman sirwiyta atiykuchu. Ama hina kaspa, huk mana qullqiyuq Kichasqa Mikhuy Chiqap yupayta ruway llapa Kichasqa Mikhuy Chiqap kaqman yaykunapaq."
+msgstr "Robotkunamanta llumpay abusorayku, mana kay p'anqata mana riqsisqa llamk'aqkunaman sirwiyta atiykuchu. Ama hina kaspa, huk mana qullqiyuq Open Food Facts yupayta ruway llapa Open Food Facts kaqman yaykunapaq."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"

--- a/po/common/rm.po
+++ b/po/common/rm.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/ro.po
+++ b/po/common/ro.po
@@ -166,7 +166,7 @@ msgstr "Ingrediente, alergeni, aditivi, valori nutriționale, etichete, originea
 
 msgctxt "search_description_opensearch_opff"
 msgid "Open Pet Food Facts product search"
-msgstr "Deschideți căutarea produselor Pet Food Facts"
+msgstr "Deschideți căutarea produselor Open Pet Food Facts"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1073,7 +1073,7 @@ msgstr "https://ro.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "Informații despre alimente deschise pentru producători"
+msgstr "Open Food Facts pentru producători"
 
 msgctxt "for"
 msgid "for"
@@ -1762,11 +1762,6 @@ msgstr "Scoruri nutrițional"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Scor nutrițional"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4709,11 +4704,11 @@ msgstr "Nutri-Score-ul este calculat și poate fi luat în considerare pentru to
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "Nutri-Scor %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
-msgstr "Nutri-Scor necunoscut"
+msgstr "Nutri-Score necunoscut"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
 msgid "Missing data to compute the Nutri-Score"
@@ -4721,7 +4716,7 @@ msgstr "Lipsesc date pentru a calcula Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Scorul Nutri nu este aplicabil"
+msgstr "Nutri-Scoree nu este aplicabil"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5558,7 +5553,7 @@ msgstr "Lipsește o categorie precisă"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "Nu am putut calcula Scorul Eco al acestui produs, deoarece îi lipsesc unele date, ați putea ajuta la completarea acestora?"
+msgstr "Nu am putut calcula Green-Score al acestui produs, deoarece îi lipsesc unele date, ați putea ajuta la completarea acestora?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5666,7 +5661,7 @@ msgstr "Unele dintre datele pentru produsele lui %s provin din %s."
 
 msgctxt "data_source_database_note_about_the_producers_platform"
 msgid "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_url>\">free plaform for producers</a> to access and complete this data, and to obtain reports, analysis and product improvements opportunities (e.g. better Nutri-Score)."
-msgstr "Producătorii pot folosi <a href=\"<producers_platform_url>\">pentru producătorii</a> pentru a accesa și completa aceste date și pentru a obține rapoarte, analize și oportunități de îmbunătățire a produselor (de ex. Nutri-Score mai bun)."
+msgstr "Producătorii pot folosi platforma gratuită Open Food Facts <a href=\"<producers_platform_url>\">pentru producătorii</a> pentru a accesa și completa aceste date și pentru a obține rapoarte, analize și oportunități de îmbunătățire a produselor (de ex. Nutri-Score mai bun)."
 
 # variable names between { } must not be translated
 msgctxt "f_data_source_database_provider"
@@ -5892,7 +5887,7 @@ msgstr "Formula Green-Score este supusă modificării, deoarece este îmbunătă
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Scorul Verde a fost inițial dezvoltat pentru Franța și este extins în alte țări europene. Formula Scorului Verde este supusă modificărilor, deoarece este îmbunătățită periodic pentru a fi mai precisă și mai potrivită fiecărei țări."
+msgstr "Green-Score a fost inițial dezvoltat pentru Franța și este extins în alte țări europene. Formula Scorului Verde este supusă modificărilor, deoarece este îmbunătățită periodic pentru a fi mai precisă și mai potrivită fiecărei țări."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6490,7 +6485,7 @@ msgstr "Deselectați imaginea"
 
 msgctxt "nutriscore_learn_more"
 msgid "Learn more about the Nutri-Score"
-msgstr "Vă mulţumim"
+msgstr "Aflați mai multe despre Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
@@ -6544,7 +6539,7 @@ msgstr "Ați putea adăuga informațiile necesare pentru a calcula Nutri-Score?"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Ați putea adăuga o categorie de produse precisă, astfel încât să putem calcula Scorul Eco?"
+msgstr "Ați putea adăuga o categorie de produse precisă, astfel încât să putem calcula Green-Score?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"

--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -1065,7 +1065,7 @@ msgstr "https://wiki.openfoodfacts.org"
 # Do not translate Open Beauty Facts but do translate Cosmetics
 msgctxt "footer_obf"
 msgid "Open Beauty Facts - Cosmetics"
-msgstr "Косметика"
+msgstr "Open Beauty Facts — Open Beauty Facts"
 
 msgctxt "footer_obf_link"
 msgid "https://world.openbeautyfacts.org"
@@ -1765,11 +1765,6 @@ msgstr "Уровни питательных веществ"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Уровень питательных веществ"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -2904,7 +2899,7 @@ msgstr "Переводчики"
 
 msgctxt "translators_lead"
 msgid "We would like to say THANK YOU to the awesome translators that make it possible to present Open Food Facts, Open Beauty Facts, and Open Pet Food Facts to you in all these different languages! <a href=\"https://translate.openfoodfacts.org/\">You can join us in this global effort: it doesn't require any technical knowledge.</a>"
-msgstr "Мы хотим сказать СПАСИБО прекрасным переводчикам, благодаря которым люди со всех стран могут пользоваться Open Food Facts, Open Beauty Facts и Open Pet Facts. <a href=\"https://translate.openfoodfacts.org/\"> Вы можете присоединиться к нам в этом глобальном усилии: для этого не требуется никаких технических навыков. </a>"
+msgstr "Мы хотим сказать СПАСИБО прекрасным переводчикам, благодаря которым люди со всех стран могут пользоваться Open Food Facts, Open Beauty Facts и Open Pet Food Facts. <a href=\"https://translate.openfoodfacts.org/\"> Вы можете присоединиться к нам в этом глобальном усилии: для этого не требуется никаких технических навыков. </a>"
 
 msgctxt "translators_renewal_notice"
 msgid "Please note that this table is refreshed nightly and might be out of date."
@@ -2985,7 +2980,7 @@ msgstr "Группы NOVA"
 # Title for the link to the explanation of what a NOVA Group is
 msgctxt "nova_groups_info"
 msgid "NOVA groups for food processing"
-msgstr "Группы Nova для классификации полуфабрикатов"
+msgstr "Группы NOVA для классификации полуфабрикатов"
 
 msgctxt "footer_partners"
 msgid "Partners"
@@ -4070,7 +4065,7 @@ msgstr "Файл получен"
 
 msgctxt "nutriscore_calculation_details"
 msgid "Details of the calculation of the Nutri-Score"
-msgstr "Детали расчета Nutri-core"
+msgstr "Детали расчета Nutri-Score"
 
 msgctxt "nutriscore_is_beverage"
 msgid "This product is considered a beverage for the calculation of the Nutri-Score."
@@ -4958,7 +4953,7 @@ msgstr "Низкая экологическая нагрузка (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "«Зеленый рейтинг» — это экологическая оценка от A+ до F, которая позволяет легко сравнивать воздействие пищевых продуктов на окружающую среду."
+msgstr "«Green-Score» — это экологическая оценка от A+ до F, которая позволяет легко сравнивать воздействие пищевых продуктов на окружающую среду."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4971,7 +4966,7 @@ msgstr "Низкая экологическая нагрузка (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "«Зеленый рейтинг» — это экологическая оценка от A+ до F, которая позволяет легко сравнивать воздействие пищевых продуктов на окружающую среду."
+msgstr "«Green-Score» — это экологическая оценка от A+ до F, которая позволяет легко сравнивать воздействие пищевых продуктов на окружающую среду."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5895,7 +5890,7 @@ msgstr "Формула Green-Score может изменяться, поскол
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Индекс «Зеленый рейтинг» был первоначально разработан для Франции, и в настоящее время его применение распространяется и на другие европейские страны. Формула расчета индекса «Зеленый рейтинг» может изменяться, поскольку регулярно совершенствуется для повышения точности и адаптации к особенностям каждой страны."
+msgstr "Индекс «Green-Score» был первоначально разработан для Франции, и в настоящее время его применение распространяется и на другие европейские страны. Формула расчета индекса «Green-Score» может изменяться, поскольку регулярно совершенствуется для повышения точности и адаптации к особенностям каждой страны."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."

--- a/po/common/sa.po
+++ b/po/common/sa.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ग्रीन-स्कोरः A+ तः F पर्यन्तं पर्यावरणीयः स्कोरः अस्ति यत् खाद्यपदार्थानाम् पर्यावरणस्य उपरि प्रभावस्य तुलनां कर्तुं सुलभं करोति।"
+msgstr "Green-Score A+ तः F पर्यन्तं पर्यावरणीयः स्कोरः अस्ति यत् खाद्यपदार्थानाम् पर्यावरणस्य उपरि प्रभावस्य तुलनां कर्तुं सुलभं करोति।"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ग्रीन-स्कोरः A+ तः F पर्यन्तं पर्यावरणीयः स्कोरः अस्ति यत् खाद्यपदार्थानाम् पर्यावरणस्य उपरि प्रभावस्य तुलनां कर्तुं सुलभं करोति।"
+msgstr "Green-Score A+ तः F पर्यन्तं पर्यावरणीयः स्कोरः अस्ति यत् खाद्यपदार्थानाम् पर्यावरणस्य उपरि प्रभावस्य तुलनां कर्तुं सुलभं करोति।"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ग्रीन-स्कोर् प्रारम्भे फ्रान्सदेशस्य कृते विकसितः आसीत्, अन्येषु यूरोपीयदेशेषु अपि तस्य विस्तारः क्रियते । ग्रीन-स्कोर-सूत्रं परिवर्तनीयं भवति यतः नियमितरूपेण तस्य सुधारः भवति यत् एतत् अधिकं सटीकं भवति, प्रत्येकस्य देशस्य कृते अधिकं उपयुक्तं च भवति ।"
+msgstr "Green-Score प्रारम्भे फ्रान्सदेशस्य कृते विकसितः आसीत्, अन्येषु यूरोपीयदेशेषु अपि तस्य विस्तारः क्रियते । Green-Score-सूत्रं परिवर्तनीयं भवति यतः नियमितरूपेण तस्य सुधारः भवति यत् एतत् अधिकं सटीकं भवति, प्रत्येकस्य देशस्य कृते अधिकं उपयुक्तं च भवति ।"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."

--- a/po/common/sat.po
+++ b/po/common/sat.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/sc.po
+++ b/po/common/sc.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/sco.po
+++ b/po/common/sco.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/sd.po
+++ b/po/common/sd.po
@@ -42,7 +42,7 @@ msgstr "دنيا جي چوڌاري سينگار جي شين جي اجزاء ۽ �
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "اوپن بيوٽي فيڪٽس دنيا جي چوڌاري سينگار جي شين بابت معلومات ۽ ڊيٽا گڏ ڪري ٿو."
+msgstr "Open Beauty Facts دنيا جي چوڌاري سينگار جي شين بابت معلومات ۽ ڊيٽا گڏ ڪري ٿو."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "۽ <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">حصو �
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "خوبصورتي حقيقتن جي پراڊڪٽ جي ڳولا کوليو"
+msgstr "Open Beauty Facts جي پراڊڪٽ جي ڳولا کوليو"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "هي پراڊڪٽ صفحو مڪمل نه آهي. توهان ان کي ايڊٽ ڪري ۽ اسان وٽ موجود تصويرن مان وڌيڪ ڊيٽا شامل ڪري، يا <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> يا <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>لاءِ يونيورسل اوپن فوڊ فيڪٽس ايپ استعمال ڪندي وڌيڪ تصويرون ڪڍي ان کي مڪمل ڪرڻ ۾ مدد ڪري سگهو ٿا. مهرباني!"
+msgstr "هي پراڊڪٽ صفحو مڪمل نه آهي. توهان ان کي ايڊٽ ڪري ۽ اسان وٽ موجود تصويرن مان وڌيڪ ڊيٽا شامل ڪري، يا <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> يا <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>لاءِ يونيورسل Open Food Facts ايپ استعمال ڪندي وڌيڪ تصويرون ڪڍي ان کي مڪمل ڪرڻ ۾ مدد ڪري سگهو ٿا. مهرباني!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "هي پراڊڪٽ صفحو مڪمل نه آهي. توهان ان کي ايڊٽ ڪري ۽ اسان وٽ موجود تصويرن مان وڌيڪ ڊيٽا شامل ڪري، يا <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> يا <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>لاءِ يونيورسل اوپن فوڊ فيڪٽس ايپ استعمال ڪندي وڌيڪ تصويرون ڪڍي ان کي مڪمل ڪرڻ ۾ مدد ڪري سگهو ٿا. مهرباني!"
+msgstr "هي پراڊڪٽ صفحو مڪمل نه آهي. توهان ان کي ايڊٽ ڪري ۽ اسان وٽ موجود تصويرن مان وڌيڪ ڊيٽا شامل ڪري، يا <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> يا <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>لاءِ يونيورسل Open Food Facts ايپ استعمال ڪندي وڌيڪ تصويرون ڪڍي ان کي مڪمل ڪرڻ ۾ مدد ڪري سگهو ٿا. مهرباني!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "غذائي اسڪور لاڳو ناهي"
+msgstr "Nutri-Score لاڳو ناهي"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "گرين اسڪور A+ کان F تائين هڪ ماحولياتي اسڪور آهي جيڪو ماحول تي کاڌي جي شين جي اثر جو مقابلو ڪرڻ آسان بڻائي ٿو."
+msgstr "Green-Score A+ کان F تائين هڪ ماحولياتي اسڪور آهي جيڪو ماحول تي کاڌي جي شين جي اثر جو مقابلو ڪرڻ آسان بڻائي ٿو."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "گرين اسڪور A+ کان F تائين هڪ ماحولياتي اسڪور آهي جيڪو ماحول تي کاڌي جي شين جي اثر جو مقابلو ڪرڻ آسان بڻائي ٿو."
+msgstr "Green-Score A+ کان F تائين هڪ ماحولياتي اسڪور آهي جيڪو ماحول تي کاڌي جي شين جي اثر جو مقابلو ڪرڻ آسان بڻائي ٿو."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "گرين اسڪور شروعاتي طور تي فرانس لاءِ تيار ڪيو ويو هو ۽ ان کي ٻين يورپي ملڪن تائين وڌايو پيو وڃي. گرين اسڪور فارمولا تبديل ٿيڻ جي تابع آهي ڇاڪاڻ ته ان کي باقاعدي طور تي بهتر بڻايو ويندو آهي ته جيئن ان کي هر ملڪ لاءِ وڌيڪ صحيح ۽ بهتر طور تي مناسب بڻائي سگهجي."
+msgstr "Green-Score شروعاتي طور تي فرانس لاءِ تيار ڪيو ويو هو ۽ ان کي ٻين يورپي ملڪن تائين وڌايو پيو وڃي. Green-Score فارمولا تبديل ٿيڻ جي تابع آهي ڇاڪاڻ ته ان کي باقاعدي طور تي بهتر بڻايو ويندو آهي ته جيئن ان کي هر ملڪ لاءِ وڌيڪ صحيح ۽ بهتر طور تي مناسب بڻائي سگهجي."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "هن پراڊڪٽ لاءِ اسان وٽ جيڪا ڪيٽيگري آهي اها گرين اسڪور کي ڳڻڻ لاءِ ڪافي صحيح ناهي. ڇا توهان وڌيڪ صحيح پراڊڪٽ ڪيٽيگري شامل ڪري سگهو ٿا؟"
+msgstr "هن پراڊڪٽ لاءِ اسان وٽ جيڪا ڪيٽيگري آهي اها Green-Score کي ڳڻڻ لاءِ ڪافي صحيح ناهي. ڇا توهان وڌيڪ صحيح پراڊڪٽ ڪيٽيگري شامل ڪري سگهو ٿا؟"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7674,11 +7669,11 @@ msgstr "اسان وٽ Nutri-Score جي حساب لاءِ سرونگ سائيز �
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> هڪ غير منافع بخش تنظيم پاران ٺاهيو ويو آهي، جيڪو صنعت کان آزاد آهي. اهو سڀني لاءِ ٺاهيو ويو آهي، سڀني طرفان، ۽ ان کي سڀني طرفان فنڊ ڪيو ويندو آهي. توهان اوپن فوڊ فيڪٽس کي عطيو ڪري اسان جي ڪم جي حمايت ڪري سگهو ٿا.<br/><b>مهرباني!</b>"
+msgstr "<<site_name>> هڪ غير منافع بخش تنظيم پاران ٺاهيو ويو آهي، جيڪو صنعت کان آزاد آهي. اهو سڀني لاءِ ٺاهيو ويو آهي، سڀني طرفان، ۽ ان کي سڀني طرفان فنڊ ڪيو ويندو آهي. توهان Open Food Facts کي عطيو ڪري اسان جي ڪم جي حمايت ڪري سگهو ٿا.<br/><b>مهرباني!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> هڪ غير منافع بخش تنظيم پاران ٺاهيو ويو آهي، جيڪو صنعت کان آزاد آهي. اهو سڀني لاءِ ٺاهيو ويو آهي، سڀني طرفان، ۽ ان کي سڀني طرفان فنڊ ڪيو ويندو آهي. توهان اوپن فوڊ فيڪٽس کي عطيو ڏئي ۽ ليلو سرچ انجن استعمال ڪندي اسان جي ڪم جي حمايت ڪري سگهو ٿا.<br/><b>مهرباني!</b>"
+msgstr "<<site_name>> هڪ غير منافع بخش تنظيم پاران ٺاهيو ويو آهي، جيڪو صنعت کان آزاد آهي. اهو سڀني لاءِ ٺاهيو ويو آهي، سڀني طرفان، ۽ ان کي سڀني طرفان فنڊ ڪيو ويندو آهي. توهان Open Food Facts کي عطيو ڏئي ۽ ليلو سرچ انجن استعمال ڪندي اسان جي ڪم جي حمايت ڪري سگهو ٿا.<br/><b>مهرباني!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7686,7 +7681,7 @@ msgstr "ليلو سرچ انجن"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "روبوٽس جي وڏي غلط استعمال جي ڪري، اسان هي صفحو نامعلوم استعمال ڪندڙن کي پيش ڪرڻ جي قابل نه آهيون. مهرباني ڪري سڀني اوپن فوڊ فيڪٽس تائين رسائي حاصل ڪرڻ لاءِ هڪ مفت اوپن فوڊ فيڪٽس اڪائونٽ ٺاهيو."
+msgstr "روبوٽس جي وڏي غلط استعمال جي ڪري، اسان هي صفحو نامعلوم استعمال ڪندڙن کي پيش ڪرڻ جي قابل نه آهيون. مهرباني ڪري سڀني Open Food Facts تائين رسائي حاصل ڪرڻ لاءِ هڪ مفت Open Food Facts اڪائونٽ ٺاهيو."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "ناپسنديده اجزا"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "هي ترجيح اوپن فوڊ فيڪٽس جي اجزاء جي فهرست جي سمجھ تي ٻڌل آهي ۽ شايد صحيح نه هجي، هميشه پراڊڪٽ کي پاڻ چيڪ ڪريو."
+msgstr "هي ترجيح Open Food Facts جي اجزاء جي فهرست جي سمجھ تي ٻڌل آهي ۽ شايد صحيح نه هجي، هميشه پراڊڪٽ کي پاڻ چيڪ ڪريو."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "اسان کي خبر نه پئي: {unwanted_ingredients}. اسان شا�
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "اهي ترجيحون اوپن فوڊ فيڪٽس جي اجزاء جي فهرست جي سمجھ تي ٻڌل آهن ۽ هميشه اهو امڪان آهي ته اهو صحيح يا مڪمل نه هجي، هميشه پاڻ پراڊڪٽ چيڪ ڪريو."
+msgstr "اهي ترجيحون Open Food Facts جي اجزاء جي فهرست جي سمجھ تي ٻڌل آهن ۽ هميشه اهو امڪان آهي ته اهو صحيح يا مڪمل نه هجي، هميشه پاڻ پراڊڪٽ چيڪ ڪريو."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/sg.po
+++ b/po/common/sg.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/si.po
+++ b/po/common/si.po
@@ -63,7 +63,7 @@ msgstr "සහ <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">ද�
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "රූපලාවන්‍ය කරුණු නිෂ්පාදන සෙවීම විවෘත කරන්න"
+msgstr "Open Beauty Facts නිෂ්පාදන සෙවීම විවෘත කරන්න"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "මෙම නිෂ්පාදන පිටුව සම්පූර්ණ නැත. එය සංස්කරණය කිරීමෙන් සහ අප සතුව ඇති ඡායාරූප වලින් තවත් දත්ත එකතු කිරීමෙන් හෝ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> හෝ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>සඳහා විශ්වීය විවෘත ආහාර කරුණු යෙදුම භාවිතයෙන් තවත් ඡායාරූප ගැනීමෙන් ඔබට එය සම්පූර්ණ කිරීමට උදව් කළ හැකිය. ස්තූතියි!"
+msgstr "මෙම නිෂ්පාදන පිටුව සම්පූර්ණ නැත. එය සංස්කරණය කිරීමෙන් සහ අප සතුව ඇති ඡායාරූප වලින් තවත් දත්ත එකතු කිරීමෙන් හෝ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> හෝ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>සඳහා විශ්වීය Open Food Facts යෙදුම භාවිතයෙන් තවත් ඡායාරූප ගැනීමෙන් ඔබට එය සම්පූර්ණ කිරීමට උදව් කළ හැකිය. ස්තූතියි!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "මෙම නිෂ්පාදන පිටුව සම්පූර්ණ නැත. එය සංස්කරණය කිරීමෙන් සහ අප සතුව ඇති ඡායාරූප වලින් තවත් දත්ත එකතු කිරීමෙන් හෝ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> හෝ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>සඳහා විශ්වීය විවෘත ආහාර කරුණු යෙදුම භාවිතයෙන් තවත් ඡායාරූප ගැනීමෙන් ඔබට එය සම්පූර්ණ කිරීමට උදව් කළ හැකිය. ස්තූතියි!"
+msgstr "මෙම නිෂ්පාදන පිටුව සම්පූර්ණ නැත. එය සංස්කරණය කිරීමෙන් සහ අප සතුව ඇති ඡායාරූප වලින් තවත් දත්ත එකතු කිරීමෙන් හෝ <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> හෝ <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>සඳහා විශ්වීය Open Food Facts යෙදුම භාවිතයෙන් තවත් ඡායාරූප ගැනීමෙන් ඔබට එය සම්පූර්ණ කිරීමට උදව් කළ හැකිය. ස්තූතියි!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "හරිත-ලකුණ යනු A+ සිට F දක්වා පාරිසරික ලකුණු වන අතර එමඟින් ආහාර නිෂ්පාදන පරිසරයට ඇති බලපෑම සංසන්දනය කිරීම පහසු කරයි."
+msgstr "Green-Score යනු A+ සිට F දක්වා පාරිසරික ලකුණු වන අතර එමඟින් ආහාර නිෂ්පාදන පරිසරයට ඇති බලපෑම සංසන්දනය කිරීම පහසු කරයි."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "හරිත-ලකුණ යනු A+ සිට F දක්වා පාරිසරික ලකුණු වන අතර එමඟින් ආහාර නිෂ්පාදන පරිසරයට ඇති බලපෑම සංසන්දනය කිරීම පහසු කරයි."
+msgstr "Green-Score යනු A+ සිට F දක්වා පාරිසරික ලකුණු වන අතර එමඟින් ආහාර නිෂ්පාදන පරිසරයට ඇති බලපෑම සංසන්දනය කිරීම පහසු කරයි."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "හරිත ලකුණු සූත්‍රය මුලින් ප්‍රංශය සඳහා සංවර්ධනය කරන ලද අතර එය අනෙකුත් යුරෝපීය රටවලට ද ව්‍යාප්ත වෙමින් පවතී. හරිත ලකුණු සූත්‍රය වෙනස් වීමට යටත් වේ, මන්ද එය සෑම රටකටම වඩාත් නිවැරදි හා වඩාත් සුදුසු වන පරිදි නිතිපතා වැඩිදියුණු කරනු ලැබේ."
+msgstr "Green-Score සූත්‍රය මුලින් ප්‍රංශය සඳහා සංවර්ධනය කරන ලද අතර එය අනෙකුත් යුරෝපීය රටවලට ද ව්‍යාප්ත වෙමින් පවතී. Green-Score සූත්‍රය වෙනස් වීමට යටත් වේ, මන්ද එය සෑම රටකටම වඩාත් නිවැරදි හා වඩාත් සුදුසු වන පරිදි නිතිපතා වැඩිදියුණු කරනු ලැබේ."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "මෙම නිෂ්පාදනය සඳහා අප සතුව ඇති කාණ්ඩය හරිත-ලකුණු ගණනය කිරීමට ප්‍රමාණවත් තරම් නිවැරදි නොවේ. ඔබට වඩාත් නිවැරදි නිෂ්පාදන කාණ්ඩයක් එක් කළ හැකිද?"
+msgstr "මෙම නිෂ්පාදනය සඳහා අප සතුව ඇති කාණ්ඩය Green-Score ගණනය කිරීමට ප්‍රමාණවත් තරම් නිවැරදි නොවේ. ඔබට වඩාත් නිවැරදි නිෂ්පාදන කාණ්ඩයක් එක් කළ හැකිද?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/sk.po
+++ b/po/common/sk.po
@@ -63,7 +63,7 @@ msgstr "a skupina na Facebooku <a href=\"https://www.facebook.com/groups/OpenBea
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Otvorte vyhľadávanie produktov Beauty Facts"
+msgstr "Otvorte vyhľadávanie produktov Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -154,7 +154,7 @@ msgstr "Spoločná, bezplatná a otvorená databáza ingrediencií, výživovýc
 
 msgctxt "tagline_opff"
 msgid "Open Pet Food Facts gathers information and data on pet food products from around the world."
-msgstr "Open Food Facts zhromažďuje informácie a údaje o produktoch krmiva pre zvieratá z celého sveta."
+msgstr "Open Open Pet Food Facts zhromažďuje informácie a údaje o produktoch krmiva pre zvieratá z celého sveta."
 
 msgctxt "footer_tagline_opff"
 msgid "A collaborative, free and open database of pet food products from around the world."
@@ -166,7 +166,7 @@ msgstr "Zloženie, alergény, aditíva, nutričné údaje, etikety, pôvod zlož
 
 msgctxt "search_description_opensearch_opff"
 msgid "Open Pet Food Facts product search"
-msgstr "Otvorte vyhľadávanie produktov Pet Food Facts"
+msgstr "Otvorte vyhľadávanie produktov Open Pet Food Facts"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1763,11 +1763,6 @@ msgstr "Stupeň výživnosti"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Stupeň výživnosti"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4948,7 +4943,7 @@ msgstr "Životné prostredie"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "Eko-skóre"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4961,7 +4956,7 @@ msgstr "Green-Score je environmentálne skóre od A+ do F, ktoré umožňuje jed
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "Eko-skóre"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -5212,19 +5207,19 @@ msgstr "Chýbajúce nutričné hodnoty pre pripravený výrobok"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "Eko-skóre"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "Eko-skóre"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "Eko-skóre"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "Eko-skóre"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"

--- a/po/common/sl.po
+++ b/po/common/sl.po
@@ -1763,11 +1763,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Prehranska stopnja"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -5473,7 +5468,7 @@ msgstr "Izdelki z najboljšim Nutri-Score"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "Izdelki z najboljšo ekološko oceno"
+msgstr "Izdelki z najboljšo Green-Score"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5544,7 +5539,7 @@ msgstr "Green-Score še ne velja za to kategorijo, izdelava je še v teku."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Eko-ocena ni izračunana"
+msgstr "Green-Score ni izračunana"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5556,7 +5551,7 @@ msgstr "Manjka natančna kategorija"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "Eko-Skore tega izdelka ni mogoče izračunati saj manjkajo določeni podatki. Lahko pomagate pri dokončanju?"
+msgstr "Green-Score tega izdelka ni mogoče izračunati saj manjkajo določeni podatki. Lahko pomagate pri dokončanju?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5890,7 +5885,7 @@ msgstr "Formula Green-Score se lahko spreminja, saj se redno izboljšuje, da pos
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Zelena lestvica je bila prvotno razvita za Francijo in se razširja tudi na druge evropske države. Formula za zeleno lestvico se lahko spremeni, saj se redno izboljšuje, da bi bila natančnejša in bolj primerna za posamezno državo."
+msgstr "Green-Score je bila prvotno razvita za Francijo in se razširja tudi na druge evropske države. Formula za Green-Score se lahko spremeni, saj se redno izboljšuje, da bi bila natančnejša in bolj primerna za posamezno državo."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6213,7 +6208,7 @@ msgstr "Bonusi in malusi"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Eko-Score ocena za ta izdelek"
+msgstr "Green-Score ocena za ta izdelek"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"

--- a/po/common/sma.po
+++ b/po/common/sma.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/sn.po
+++ b/po/common/sn.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -7674,11 +7669,11 @@ msgstr "Isu tiri kurasikirwa nehukuru hwekushumira uye / kana yuniti yekuverenga
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> inogadzirwa nesangano risingabatsiri, rakazvimiririra kubva kuindasitiri. Yakagadzirirwa vose, nevose, uye inotsigirwa nevose. Unogona kutsigira basa redu nekupa kuVhura Chikafu Chokwadi.<br/><b>Ndatenda!</b>"
+msgstr "<<site_name>> inogadzirwa nesangano risingabatsiri, rakazvimiririra kubva kuindasitiri. Yakagadzirirwa vose, nevose, uye inotsigirwa nevose. Unogona kutsigira basa redu nekupa kuOpen Food Facts.<br/><b>Ndatenda!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> inogadzirwa nesangano risingabatsiri, rakazvimiririra kubva kuindasitiri. Yakagadzirirwa vose, nevose, uye inotsigirwa nevose. Unogona kutsigira basa redu nekupa Vhura Chikafu Chokwadi uye zvakare nekushandisa Lilo yekutsvaga injini.<br/><b>Ndatenda!</b>"
+msgstr "<<site_name>> inogadzirwa nesangano risingabatsiri, rakazvimiririra kubva kuindasitiri. Yakagadzirirwa vose, nevose, uye inotsigirwa nevose. Unogona kutsigira basa redu nekupa Open Food Facts uye zvakare nekushandisa Lilo yekutsvaga injini.<br/><b>Ndatenda!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7686,7 +7681,7 @@ msgstr "Lilo search engine"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Nekuda kwekushungurudzwa kwakanyanya kubva kumarobhoti, hatikwanise kushandira peji rino kune vashandisi vasingazivikanwe. Ndokumbirawo ugadzire account yemahara yakavhurika yeChikafu Chokwadi kuti uwane ese akavhurika Chikafu Chokwadi."
+msgstr "Nekuda kwekushungurudzwa kwakanyanya kubva kumarobhoti, hatikwanise kushandira peji rino kune vashandisi vasingazivikanwe. Ndokumbirawo ugadzire account yemahara yakavhurika yeOpen Food Facts kuti uwane ese akavhurika Open Food Facts."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "Zvisikwa zvisingadiwi"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "Sarudzo iyi yakavakirwa paOpen Food Chokwadi 'kunzwisisa kweiyo emukati rondedzero uye inogona kunge isiri iyo chaiyo, gara uchitarisa chigadzirwa iwe pachako."
+msgstr "Sarudzo iyi yakavakirwa paOpen Food Factskunzwisisa kweiyo emukati rondedzero uye inogona kunge isiri iyo chaiyo, gara uchitarisa chigadzirwa iwe pachako."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "Hatina kuona: {unwanted_ingredients}. Tinogona kunge takapotsa zvimwe zv
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "Izvo zvaunofarira zvakavakirwa paOpen Food Chokwadi 'kunzwisisa kweiyo inongedzo rondedzero uye pane nguva dzose mukana wekuti inogona kunge isiri iyo chaiyo kana yakakwana, gara uchitarisa chigadzirwa iwe pachako."
+msgstr "Izvo zvaunofarira zvakavakirwa paOpen Food Factskunzwisisa kweiyo inongedzo rondedzero uye pane nguva dzose mukana wekuti inogona kunge isiri iyo chaiyo kana yakakwana, gara uchitarisa chigadzirwa iwe pachako."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/so.po
+++ b/po/common/so.po
@@ -42,7 +42,7 @@ msgstr "Kaydka xogta oo wada shaqeyn, bilaash ah oo furan oo ah maaddooyinka, iy
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "Furan Quruxda Xaqiiqooyinka waxay ururisaa macluumaad iyo xog ku saabsan alaabada qurxinta ee ka kala yimid daafaha dunida."
+msgstr "Open Beauty Facts waxay ururisaa macluumaad iyo xog ku saabsan alaabada qurxinta ee ka kala yimid daafaha dunida."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "iyo kooxda Facebook ee <a href=\"https://www.facebook.com/groups/OpenBea
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Raadinta badeecada Xaqiiqooyinka Quruxda Furan"
+msgstr "Raadinta badeecada Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "Boggan badeecada ma dhammaystirna. Waxaad ku caawin kartaa dhammaystirkiisa adigoo tafatiraya oo ku daraya xog dheeraad ah sawirada aan hayno, ama adigoo sawirro badan ka qaadaya abka Xaqiiqooyinka Cuntada Furan ee caalamiga ah ee <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> ama <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Mahadsanid!"
+msgstr "Boggan badeecada ma dhammaystirna. Waxaad ku caawin kartaa dhammaystirkiisa adigoo tafatiraya oo ku daraya xog dheeraad ah sawirada aan hayno, ama adigoo sawirro badan ka qaadaya abka Open Food Facts ee caalamiga ah ee <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> ama <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Mahadsanid!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "Boggan badeecada ma dhammaystirna. Waxaad ku caawin kartaa dhammaystirkiisa adigoo tafatiraya oo ku daraya xog dheeraad ah sawirada aan hayno, ama adigoo sawirro badan ka qaadaya abka Xaqiiqooyinka Cuntada Furan ee caalamiga ah ee <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> ama <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Mahadsanid!"
+msgstr "Boggan badeecada ma dhammaystirna. Waxaad ku caawin kartaa dhammaystirkiisa adigoo tafatiraya oo ku daraya xog dheeraad ah sawirada aan hayno, ama adigoo sawirro badan ka qaadaya abka Open Food Facts ee caalamiga ah ee <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> ama <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Mahadsanid!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Dhibcaha Cagaaran waa dhibco deegaan oo laga bilaabo A+ ilaa F taasoo sahlaysa in la isbarbardhigo saameynta cuntooyinka ay ku leeyihiin deegaanka."
+msgstr "Green-Score waa dhibco deegaan oo laga bilaabo A+ ilaa F taasoo sahlaysa in la isbarbardhigo saameynta cuntooyinka ay ku leeyihiin deegaanka."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Dhibcaha Cagaaran waa dhibco deegaan oo laga bilaabo A+ ilaa F taasoo sahlaysa in la isbarbardhigo saameynta cuntooyinka ay ku leeyihiin deegaanka."
+msgstr "Green-Score waa dhibco deegaan oo laga bilaabo A+ ilaa F taasoo sahlaysa in la isbarbardhigo saameynta cuntooyinka ay ku leeyihiin deegaanka."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Dhibcaha Cagaaran waxaa markii hore loo sameeyay Faransiiska waxaana loo fidinayaa dalalka kale ee Yurub. Qaaciddada Dhibcaha Cagaaran way isbeddeli kartaa maadaama si joogto ah loo hagaajiyo si looga dhigo mid sax ah oo ku habboon waddan kasta."
+msgstr "Green-Score waxaa markii hore loo sameeyay Faransiiska waxaana loo fidinayaa dalalka kale ee Yurub. Qaaciddada Green-Score way isbeddeli kartaa maadaama si joogto ah loo hagaajiyo si looga dhigo mid sax ah oo ku habboon waddan kasta."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Qaybta aan u hayno alaabtan maaha mid sax ah oo ku filan si loo xisaabiyo Dhibcaha Cagaaran. Ma ku dari kartaa qayb badeecada oo sax ah?"
+msgstr "Qaybta aan u hayno alaabtan maaha mid sax ah oo ku filan si loo xisaabiyo Green-Score. Ma ku dari kartaa qayb badeecada oo sax ah?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7674,11 +7669,11 @@ msgstr "Waxaa naga maqan qiimaha adeega iyo/ama cutubka si loo xisaabiyo Dhibcah
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> waxaa sameeyay urur aan faa'iido doon ahayn, oo ka madax bannaan warshadaha. Waxaa loo sameeyay dhammaan, dhammaan, waxaana maalgeliyay dhammaan. Waxaad ku taageeri kartaa shaqadayada adiga oo ku deeqaya Xaqiiqda Cuntada Furan.<br/><b>Mahadsanid!</b>"
+msgstr "<<site_name>> waxaa sameeyay urur aan faa'iido doon ahayn, oo ka madax bannaan warshadaha. Waxaa loo sameeyay dhammaan, dhammaan, waxaana maalgeliyay dhammaan. Waxaad ku taageeri kartaa shaqadayada adiga oo ku deeqaya Open Food Facts.<br/><b>Mahadsanid!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> waxaa sameeyay urur aan faa'iido doon ahayn, oo ka madax bannaan warshadaha. Waxaa loo sameeyay dhammaan, dhammaan, waxaana maalgeliyay dhammaan. Waxaad ku taageeri kartaa shaqadeena adiga oo ku deeqaya Xaqiiqda Cuntada Furan iyo sidoo kale adiga oo isticmaalaya mashiinka raadinta Lilo.<br/><b>Mahadsanid!</b>"
+msgstr "<<site_name>> waxaa sameeyay urur aan faa'iido doon ahayn, oo ka madax bannaan warshadaha. Waxaa loo sameeyay dhammaan, dhammaan, waxaana maalgeliyay dhammaan. Waxaad ku taageeri kartaa shaqadeena adiga oo ku deeqaya Open Food Facts iyo sidoo kale adiga oo isticmaalaya mashiinka raadinta Lilo.<br/><b>Mahadsanid!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7686,7 +7681,7 @@ msgstr "Isticmaal mashiinka raadinta"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Xadgudubka culus ee ka imaanaya robots-ka awgeed, ma awoodno inaan boggan ugu adeegno isticmaalayaasha aan la aqoonsan. Fadlan samee akoon Furan oo Xaqiiqda Cuntada ah si aad u gasho dhammaan Xaqiiqooyinka Cuntada Furan."
+msgstr "Xadgudubka culus ee ka imaanaya robots-ka awgeed, ma awoodno inaan boggan ugu adeegno isticmaalayaasha aan la aqoonsan. Fadlan samee akoon Furan oo Xaqiiqda Cuntada ah si aad u gasho dhammaan Open Food Facts."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "Walxaha aan la rabin"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "Doorashadani waxay ku salaysan tahay Xaqiiqooyinka Cuntada Furan ee fahamka liiska maaddooyinka waxaana laga yaabaa inaanay sax ahayn, had iyo jeer iska hubi badeecada."
+msgstr "Doorashadani waxay ku salaysan tahay Open Food Facts ee fahamka liiska maaddooyinka waxaana laga yaabaa inaanay sax ahayn, had iyo jeer iska hubi badeecada."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "Ma aanan ogaanin: {unwanted_ingredients}. Waxa laga yaabaa in aanu seegn
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "Dookhyadaas waxay ku saleysan yihiin Xaqiiqooyinka Cuntada Furan ee fahamka liiska walxaha waxaana mar walba jirta suurtagalnimada inaysan sax ahayn ama aysan dhammaystirnayn, had iyo jeer iska hubi badeecada."
+msgstr "Dookhyadaas waxay ku saleysan yihiin Open Food Facts ee fahamka liiska walxaha waxaana mar walba jirta suurtagalnimada inaysan sax ahayn ama aysan dhammaystirnayn, had iyo jeer iska hubi badeecada."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/son.po
+++ b/po/common/son.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/sq.po
+++ b/po/common/sq.po
@@ -63,7 +63,7 @@ msgstr "dhe grupi <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">n
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Hap kërkimin e produkteve \"Fakte Bukurie\""
+msgstr "Hap kërkimin e produkteve \"Open Beauty Facts\""
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Rezultati i Gjelbër është një rezultat mjedisor nga A+ në F që e bën të lehtë krahasimin e ndikimit të produkteve ushqimore në mjedis."
+msgstr "Green-Score është një rezultat mjedisor nga A+ në F që e bën të lehtë krahasimin e ndikimit të produkteve ushqimore në mjedis."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Rezultati i Gjelbër është një rezultat mjedisor nga A+ në F që e bën të lehtë krahasimin e ndikimit të produkteve ushqimore në mjedis."
+msgstr "Green-Score është një rezultat mjedisor nga A+ në F që e bën të lehtë krahasimin e ndikimit të produkteve ushqimore në mjedis."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"

--- a/po/common/sr.po
+++ b/po/common/sr.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/sr_CS.po
+++ b/po/common/sr_CS.po
@@ -63,7 +63,7 @@ msgstr "и Фејсбук група <a href=\"https://www.facebook.com/groups/O
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Отворите претрагу производа Beauty Facts"
+msgstr "Отворите претрагу производа Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4705,7 +4700,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Нутри-скор се не примењује"
+msgstr "Nutri-Score се не примењује"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4939,7 +4934,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Зелени резултат је еколошка оцена од А+ до Ф која олакшава упоређивање утицаја прехрамбених производа на животну средину."
+msgstr "Green-Score је еколошка оцена од А+ до Ф која олакшава упоређивање утицаја прехрамбених производа на животну средину."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4952,7 +4947,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Зелени резултат је еколошка оцена од А+ до Ф која олакшава упоређивање утицаја прехрамбених производа на животну средину."
+msgstr "Green-Score је еколошка оцена од А+ до Ф која олакшава упоређивање утицаја прехрамбених производа на животну средину."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5876,7 +5871,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Зелени резултат је првобитно развијен за Француску и проширује се на друге европске земље. Формула Зеленог резултата подложна је променама јер се редовно побољшава како би била прецизнија и боље прилагођена свакој земљи."
+msgstr "Green-Score је првобитно развијен за Француску и проширује се на друге европске земље. Формула Green-Score подложна је променама јер се редовно побољшава како би била прецизнија и боље прилагођена свакој земљи."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -7671,7 +7666,7 @@ msgstr "Пријавите ову слику нашим модераторима
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Недостаје нам вредност величине порције и/или јединица за израчунавање Нутри-скора"
+msgstr "Недостаје нам вредност величине порције и/или јединица за израчунавање Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/sr_RS.po
+++ b/po/common/sr_RS.po
@@ -63,7 +63,7 @@ msgstr "и Фејсбук група <a href=\"https://www.facebook.com/groups/O
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Отворите претрагу производа Beauty Facts"
+msgstr "Отворите претрагу производа Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Нутри-скор се не примењује"
+msgstr "Nutri-Score се не примењује"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Зелени резултат је еколошка оцена од А+ до Ф која олакшава упоређивање утицаја прехрамбених производа на животну средину."
+msgstr "Green-Score је еколошка оцена од А+ до Ф која олакшава упоређивање утицаја прехрамбених производа на животну средину."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Зелени резултат је еколошка оцена од А+ до Ф која олакшава упоређивање утицаја прехрамбених производа на животну средину."
+msgstr "Green-Score је еколошка оцена од А+ до Ф која олакшава упоређивање утицаја прехрамбених производа на животну средину."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Зелени резултат је првобитно развијен за Француску и проширује се на друге европске земље. Формула Зеленог резултата подложна је променама јер се редовно побољшава како би била прецизнија и боље прилагођена свакој земљи."
+msgstr "Green-Score је првобитно развијен за Француску и проширује се на друге европске земље. Формула Green-Score подложна је променама јер се редовно побољшава како би била прецизнија и боље прилагођена свакој земљи."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -7670,7 +7665,7 @@ msgstr "Пријавите ову слику нашим модераторима
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Недостаје нам вредност величине порције и/или јединица за израчунавање Нутри-скора"
+msgstr "Недостаје нам вредност величине порције и/или јединица за израчунавање Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/ss.po
+++ b/po/common/ss.po
@@ -63,7 +63,7 @@ msgstr ""
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Vula lusesho lwemkhicito we-Beauty Facts"
+msgstr "Vula lusesho lwemkhicito we-Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "Lelikhasi lemkhicito alikapheleli. Ungasita ekuyicedzeni ngekuyihlela bese wengeta imininingwane leminyenti kuletitfombe lesinato, noma ngekutsatsa titfombe letinyenti usebentisa luhlelo lokusebenta lwemhlaba wonkhe lwe- <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> noma <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Ngiyabonga!"
+msgstr "Lelikhasi lemkhicito alikapheleli. Ungasita ekuyicedzeni ngekuyihlela bese wengeta imininingwane leminyenti kuletitfombe lesinato, noma ngekutsatsa titfombe letinyenti usebentisa luhlelo lokusebenta lwemhlaba wonkhe lwe-Open Food Facts <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> noma <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Ngiyabonga!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "Lelikhasi lemkhicito alikapheleli. Ungasita ekuyicedzeni ngekuyihlela bese wengeta imininingwane leminyenti kuletitfombe lesinato, noma ngekutsatsa titfombe letinyenti usebentisa luhlelo lokusebenta lwemhlaba wonkhe lwe- <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> noma <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Ngiyabonga!"
+msgstr "Lelikhasi lemkhicito alikapheleli. Ungasita ekuyicedzeni ngekuyihlela bese wengeta imininingwane leminyenti kuletitfombe lesinato, noma ngekutsatsa titfombe letinyenti usebentisa luhlelo lokusebenta lwemhlaba wonkhe lwe-Open Food Facts <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> noma <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Ngiyabonga!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Emaphuzu e-Nutri akasebenti"
+msgstr "Nutri-Score akasebenti"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -7686,7 +7681,7 @@ msgstr "Lilo injini yekuphenya"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Ngenca yekuhlukunyetwa lokukhulu ngemarobhothi, asikhoni kuniketa lelikhasi kubasebentisi labangakatiwa. Sicela wente i-akhawunti yamahhala yeMaciniso Ekudla Lokuvulekile kute ufinyelele kuwo onkhe Emaciniso Ekudla Lokuvulekile."
+msgstr "Ngenca yekuhlukunyetwa lokukhulu ngemarobhothi, asikhoni kuniketa lelikhasi kubasebentisi labangakatiwa. Sicela wente i-akhawunti yamahhala yeOpen Food Facts kute ufinyelele kuwo onkhe Open Food Facts."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"

--- a/po/common/st.po
+++ b/po/common/st.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -7674,7 +7669,7 @@ msgstr "Ha re na boleng ba boholo ba tšebeletso le/kapa yuniti ho bala Nutri-Sc
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> e entsoe ke mokhatlo o sa etseng phaello, o ikemetseng ho tsoa indastering. E etselitsoe bohle, ke bohle, 'me e tšehetsoa ke bohle. U ka tšehetsa mosebetsi oa rona ka ho fana ka lintlha tsa Open Food.<br/><b>Kea leboha!</b>"
+msgstr "<<site_name>> e entsoe ke mokhatlo o sa etseng phaello, o ikemetseng ho tsoa indastering. E etselitsoe bohle, ke bohle, 'me e tšehetsoa ke bohle. U ka tšehetsa mosebetsi oa rona ka ho fana ka lintlha tsa Open Food Facts.<br/><b>Kea leboha!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"

--- a/po/common/sv.po
+++ b/po/common/sv.po
@@ -63,7 +63,7 @@ msgstr "och <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">Faceboo
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Öppna skönhetsfakta produktsökning"
+msgstr "Öppna Open Beauty Facts produktsökning"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1766,11 +1766,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Näringsbetyg"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -2976,7 +2971,7 @@ msgstr "Enhet"
 
 msgctxt "nova_groups_s"
 msgid "NOVA group"
-msgstr "Nova grupp"
+msgstr "NOVA grupp"
 
 msgctxt "nova_groups_p"
 msgid "NOVA groups"
@@ -4763,7 +4758,7 @@ msgstr "Livsmedelsbearbetning"
 
 msgctxt "attribute_nova_name"
 msgid "NOVA group"
-msgstr "Nova grupp"
+msgstr "NOVA grupp"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
@@ -4825,7 +4820,7 @@ msgstr "Frågefilter"
 
 msgctxt "nova_group_producer"
 msgid "NOVA group"
-msgstr "Nova grupp"
+msgstr "NOVA grupp"
 
 msgctxt "error_unknown_org"
 msgid "Unknown organization."
@@ -4950,7 +4945,7 @@ msgstr "Miljö"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "Grön poäng"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4963,7 +4958,7 @@ msgstr "Green-Score är ett miljöbetyg från A+ till F som gör det enkelt att 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "Grön poäng"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4976,7 +4971,7 @@ msgstr "Green-Score är ett miljöbetyg från A+ till F som gör det enkelt att 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Grön-poäng %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5177,7 +5172,7 @@ msgstr "Detaljer om beräkningen av Green-Score"
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "Information om Green Score"
+msgstr "Information om Green-Score"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5214,19 +5209,19 @@ msgstr "Saknar näringsinformation för färdig produkt"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "Grön poäng"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "Grön poäng"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "Grön poäng"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "Grön poäng"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5549,7 +5544,7 @@ msgstr "Green-Score är ännu inte tillämpligt för den här kategorin, men vi 
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Eco-score ej beräknad"
+msgstr "Green-Score ej beräknad"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5981,7 +5976,7 @@ msgstr "medium"
 
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
-msgstr "Obs: Näringsvärdet för teer och örtteer motsvarar produkten tillagad med endast vatten, utan socker eller mjölk."
+msgstr "Obs: Nutri-Score för teer och örtteer motsvarar produkten tillagad med endast vatten, utan socker eller mjölk."
 
 msgctxt "g_per_100g"
 msgid "%s g / 100 g"
@@ -6497,7 +6492,7 @@ msgstr "Läs mer om Nutri-Score"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "Läs mer om Green Score"
+msgstr "Läs mer om Green-Score"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -7690,7 +7685,7 @@ msgstr "Rapportera den här bilden till våra moderatorer"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Vi saknar portionsstorleksvärdet och/eller enheten för att beräkna näringspoängen."
+msgstr "Vi saknar portionsstorleksvärdet och/eller enheten för att beräkna Nutri-Score."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/sw.po
+++ b/po/common/sw.po
@@ -63,7 +63,7 @@ msgstr "na kikundi cha Facebook cha <a href=\"https://www.facebook.com/groups/Op
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Utafutaji wa bidhaa za Urembo wa Open"
+msgstr "Utafutaji wa bidhaa za Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4705,7 +4700,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Nutri-Alama haitumiki"
+msgstr "Nutri-Score haitumiki"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4939,7 +4934,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Kipimo cha Kijani ni alama ya kimazingira kuanzia A+ hadi F ambayo hurahisisha kulinganisha athari za bidhaa za chakula kwenye mazingira."
+msgstr "Green-Score ni alama ya kimazingira kuanzia A+ hadi F ambayo hurahisisha kulinganisha athari za bidhaa za chakula kwenye mazingira."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4952,7 +4947,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Kipimo cha Kijani ni alama ya kimazingira kuanzia A+ hadi F ambayo hurahisisha kulinganisha athari za bidhaa za chakula kwenye mazingira."
+msgstr "Green-Score ni alama ya kimazingira kuanzia A+ hadi F ambayo hurahisisha kulinganisha athari za bidhaa za chakula kwenye mazingira."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5876,7 +5871,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Kiwango cha Kijani kilianzishwa awali kwa ajili ya Ufaransa na kinapanuliwa hadi nchi zingine za Ulaya. Fomula ya Kiwango cha Kijani inaweza kubadilika kwani inaboreshwa mara kwa mara ili kuifanya iwe sahihi zaidi na inayofaa zaidi kwa kila nchi."
+msgstr "Green-Score kilianzishwa awali kwa ajili ya Ufaransa na kinapanuliwa hadi nchi zingine za Ulaya. Fomula ya Green-Score inaweza kubadilika kwani inaboreshwa mara kwa mara ili kuifanya iwe sahihi zaidi na inayofaa zaidi kwa kila nchi."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6532,7 +6527,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Kitengo tulicho nacho cha bidhaa hii si sahihi vya kutosha kukokotoa Alama ya Kijani. Je, unaweza kuongeza aina sahihi zaidi ya bidhaa?"
+msgstr "Kitengo tulicho nacho cha bidhaa hii si sahihi vya kutosha kukokotoa Green-Score. Je, unaweza kuongeza aina sahihi zaidi ya bidhaa?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7675,7 +7670,7 @@ msgstr "Tunakosa thamani ya saizi ya kuhudumia na/au kitengo cha kukokotoa Nutri
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> imeundwa na shirika lisilo la faida, lisilo na tasnia. Imeundwa kwa wote, na wote, na inafadhiliwa na wote. Unaweza kusaidia kazi yetu kwa kuchangia Ukweli wa Chakula cha Open.<br/><b>Asante!</b>"
+msgstr "<<site_name>> imeundwa na shirika lisilo la faida, lisilo na tasnia. Imeundwa kwa wote, na wote, na inafadhiliwa na wote. Unaweza kusaidia kazi yetu kwa kuchangia Open Food Facts.<br/><b>Asante!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"

--- a/po/common/ta.po
+++ b/po/common/ta.po
@@ -42,7 +42,7 @@ msgstr "உலகெங்கிலும் உள்ள அழகுசாத�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ஓப்பன் பியூட்டி ஃபேக்ட்ஸ், உலகம் முழுவதிலுமிருந்து அழகுசாதனப் பொருட்கள் குறித்த தகவல்களையும் தரவுகளையும் சேகரிக்கிறது."
+msgstr "Open Beauty Facts, உலகம் முழுவதிலுமிருந்து அழகுசாதனப் பொருட்கள் குறித்த தகவல்களையும் தரவுகளையும் சேகரிக்கிறது."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "மற்றும் பங்களிப்பாளர்களு�
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "அழகுத் தகவல்கள் தயாரிப்புத் தேடலைத் திறக்கவும்"
+msgstr "Open Beauty Facts தயாரிப்புத் தேடலைத் திறக்கவும்"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -154,7 +154,7 @@ msgstr "உலகெங்கிலும் உள்ள பொருட்க�
 
 msgctxt "tagline_opff"
 msgid "Open Pet Food Facts gathers information and data on pet food products from around the world."
-msgstr "திறந்த தயாரிப்பு உண்மைகள் உலகெங்கிலும் உள்ள பல்வேறு வகையான தயாரிப்புகள்பற்றிய தகவல்களையும் தரவையும் சேகரிக்கிறது."
+msgstr "Open Pet Food Facts உலகெங்கிலும் உள்ள பல்வேறு வகையான தயாரிப்புகள்பற்றிய தகவல்களையும் தரவையும் சேகரிக்கிறது."
 
 msgctxt "footer_tagline_opff"
 msgid "A collaborative, free and open database of pet food products from around the world."
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "நியூட்ரி-ஸ்கோர் பொருந்தாது"
+msgstr "Nutri-Score பொருந்தாது"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4934,11 +4929,11 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "குறைந்த சுற்றுச்சூழல் பாதிப்பு (பச்சை ஸ்கோர்)"
+msgstr "குறைந்த சுற்றுச்சூழல் பாதிப்பு (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "பசுமை மதிப்பெண் என்பது A+ முதல் F வரையிலான சுற்றுச்சூழல் மதிப்பெண் ஆகும், இது உணவுப் பொருட்களின் சுற்றுச்சூழலின் தாக்கத்தை ஒப்பிடுவதை எளிதாக்குகிறது."
+msgstr "Green-Score என்பது A+ முதல் F வரையிலான சுற்றுச்சூழல் மதிப்பெண் ஆகும், இது உணவுப் பொருட்களின் சுற்றுச்சூழலின் தாக்கத்தை ஒப்பிடுவதை எளிதாக்குகிறது."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4947,16 +4942,16 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "குறைந்த சுற்றுச்சூழல் பாதிப்பு (பச்சை ஸ்கோர்)"
+msgstr "குறைந்த சுற்றுச்சூழல் பாதிப்பு (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "பசுமை மதிப்பெண் என்பது A+ முதல் F வரையிலான சுற்றுச்சூழல் மதிப்பெண் ஆகும், இது உணவுப் பொருட்களின் சுற்றுச்சூழலின் தாக்கத்தை ஒப்பிடுவதை எளிதாக்குகிறது."
+msgstr "Green-Score என்பது A+ முதல் F வரையிலான சுற்றுச்சூழல் மதிப்பெண் ஆகும், இது உணவுப் பொருட்களின் சுற்றுச்சூழலின் தாக்கத்தை ஒப்பிடுவதை எளிதாக்குகிறது."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "பச்சை-ஸ்கோர் %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5142,22 +5137,22 @@ msgstr ""
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "பச்சை-ஸ்கோர் ஸ்கோர்"
+msgstr "Green-Score ஸ்கோர்"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "பச்சை-ஸ்கோர் தரம் "
+msgstr "Green-Score தரம்"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "கிரீன் ஸ்கோரின் கணக்கீட்டின் விவரங்கள்"
+msgstr "Green-Score கணக்கீட்டின் விவரங்கள்"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "கிரீன்-ஸ்கோர் பற்றிய தகவல்"
+msgstr "Green-Score பற்றிய தகவல்"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5377,7 +5372,7 @@ msgstr ""
 # It = the platform
 msgctxt "product_edits_by_producers_indicators"
 msgid "It computes indicators such as the Nutri-Score, NOVA, and the Green-Score, and automatically identifies suggestions to improve them (for instance all products that would get a better Nutri-Score grade with a slight composition change)."
-msgstr "இது நியூட்ரி-ஸ்கோர், நோவா மற்றும் கிரீன்-ஸ்கோர் போன்ற குறிகாட்டிகளைக் கணக்கிடுகிறது, மேலும் அவற்றை மேம்படுத்துவதற்கான பரிந்துரைகளை தானாகவே அடையாளம் காட்டுகிறது (உதாரணமாக, சிறிய கலவை மாற்றத்துடன் சிறந்த நியூட்ரி-ஸ்கோர் தரத்தைப் பெறும் அனைத்து தயாரிப்புகளும்)."
+msgstr "இது Nutri-Score, NOVA மற்றும் Green-Score போன்ற குறிகாட்டிகளைக் கணக்கிடுகிறது, மேலும் அவற்றை மேம்படுத்துவதற்கான பரிந்துரைகளை தானாகவே அடையாளம் காட்டுகிறது (உதாரணமாக, சிறிய கலவை மாற்றத்துடன் சிறந்த Nutri-Score தரத்தைப் பெறும் அனைத்து தயாரிப்புகளும்)."
 
 msgctxt "attribute_forest_footprint_name"
 msgid "Forest footprint"
@@ -5458,7 +5453,7 @@ msgstr ""
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "சிறந்த பசுமை ஸ்கோர் கொண்ட தயாரிப்புகள்"
+msgstr "சிறந்த Green-Score கொண்ட தயாரிப்புகள்"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5525,11 +5520,11 @@ msgstr "இந்த வகைக்கு இன்னும் பொருந
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "இந்த வகைக்கு கிரீன்-ஸ்கோர் இன்னும் பொருந்தவில்லை, ஆனால் அதற்கான ஆதரவைச் சேர்க்கும் பணியில் ஈடுபட்டுள்ளோம்."
+msgstr "இந்த வகைக்கு Green-Score இன்னும் பொருந்தவில்லை, ஆனால் அதற்கான ஆதரவைச் சேர்க்கும் பணியில் ஈடுபட்டுள்ளோம்."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "பச்சை-ஸ்கோர் கணக்கிடப்படவில்லை"
+msgstr "Green-Score கணக்கிடப்படவில்லை"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5541,7 +5536,7 @@ msgstr "துல்லியமான வகை இல்லை."
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "இந்தத் தயாரிப்பில் சில தரவு இல்லாததால், அதன் கிரீன் ஸ்கோரை எங்களால் கணக்கிட முடியவில்லை, அதை முடிக்க உதவ முடியுமா?"
+msgstr "இந்தத் தயாரிப்பில் சில தரவு இல்லாததால், அதன் Green-Score எங்களால் கணக்கிட முடியவில்லை, அதை முடிக்க உதவ முடியுமா?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5671,7 +5666,7 @@ msgstr ""
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "தயாரிப்பு போதுமான துல்லியமான வகையைக் கொண்டிருந்தால் மட்டுமே கிரீன் ஸ்கோரைக் கணக்கிட முடியும்."
+msgstr "தயாரிப்பு போதுமான துல்லியமான வகையைக் கொண்டிருந்தால் மட்டுமே Green-Score கணக்கிட முடியும்."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5683,7 +5678,7 @@ msgstr "நீங்கள் இந்தத் தயாரிப்பின�
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "எச்சரிக்கை: கிரீன் ஸ்கோரைத் துல்லியமாகக் கணக்கிடத் தேவையான சில தகவல்கள் வழங்கப்படவில்லை (கீழே உள்ள கணக்கீட்டின் விவரங்களைப் பார்க்கவும்)."
+msgstr "எச்சரிக்கை: Green-Scoreத் துல்லியமாகக் கணக்கிடத் தேவையான சில தகவல்கள் வழங்கப்படவில்லை (கீழே உள்ள கணக்கீட்டின் விவரங்களைப் பார்க்கவும்)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5865,7 +5860,7 @@ msgstr "நீங்கள் இந்தத் தயாரிப்பின�
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "<a href=\"/பச்சை-ஸ்கோர்\">பச்சை-ஸ்கோர்</a> என்பது உணவுப் பொருட்களின் சுற்றுச்சூழல் தாக்கங்களைச் சுருக்கமாகக் கூறும் ஒரு சோதனை மதிப்பெண் ஆகும்."
+msgstr "<a href=\"/green-score\">Green-Score</a> என்பது உணவுப் பொருட்களின் சுற்றுச்சூழல் தாக்கங்களைச் சுருக்கமாகக் கூறும் ஒரு சோதனை மதிப்பெண் ஆகும்."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ஆரம்பத்தில் பிரான்சிற்காக உருவாக்கப்பட்ட கிரீன்-ஸ்கோர், பின்னர் மற்ற ஐரோப்பிய நாடுகளுக்கும் விரிவுபடுத்தப்படுகிறது. கிரீன்-ஸ்கோர் சூத்திரம் மாற்றத்திற்கு உட்பட்டது, ஏனெனில் இது ஒவ்வொரு நாட்டிற்கும் மிகவும் துல்லியமாகவும் பொருத்தமாகவும் இருக்க தொடர்ந்து மேம்படுத்தப்படுகிறது."
+msgstr "ஆரம்பத்தில் பிரான்சிற்காக உருவாக்கப்பட்ட Green-Score, பின்னர் மற்ற ஐரோப்பிய நாடுகளுக்கும் விரிவுபடுத்தப்படுகிறது. Green-Score சூத்திரம் மாற்றத்திற்கு உட்பட்டது, ஏனெனில் இது ஒவ்வொரு நாட்டிற்கும் மிகவும் துல்லியமாகவும் பொருத்தமாகவும் இருக்க தொடர்ந்து மேம்படுத்தப்படுகிறது."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "இந்த தயாரிப்புக்கு எங்களிடம் உள்ள வகை கிரீன்-ஸ்கோரைக் கணக்கிடும் அளவுக்கு துல்லியமாக இல்லை. இன்னும் துல்லியமான தயாரிப்பு வகையைச் சேர்க்க முடியுமா?"
+msgstr "இந்த தயாரிப்புக்கு எங்களிடம் உள்ள வகை Green-Score கணக்கிடும் அளவுக்கு துல்லியமாக இல்லை. இன்னும் துல்லியமான தயாரிப்பு வகையைச் சேர்க்க முடியுமா?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7156,7 +7151,7 @@ msgstr ""
 
 msgctxt "nutriscore_new_computation_title"
 msgid "Discover the new Nutri-Score!"
-msgstr "புதிய நியூட்ரி-ஸ்கோரைக் கண்டறியவும்!"
+msgstr "புதிய Nutri-Score கண்டறியவும்!"
 
 msgctxt "nutriscore_new_computation_description"
 msgid "<p>The computation of the Nutri-Score is evolving to provide better recommendations based on the latest scientific evidence.</p><p>Main improvements:</p><ul><li>Better score for some fatty fish and oils rich in good fats</li><li>Better score for whole products rich in fiber</li><li>Worse score for products containing a lot of salt or sugar</li><li>Worse score for red meat (compared to poultry)</li></ul>"
@@ -7164,7 +7159,7 @@ msgstr ""
 
 msgctxt "nutriscore_new_computation_link_text"
 msgid "Discover all the improvements of the new Nutri-Score"
-msgstr "புதிய நியூட்ரி-ஸ்கோரின் அனைத்து மேம்பாடுகளையும் கண்டறியவும்"
+msgstr "புதிய Nutri-Score அனைத்து மேம்பாடுகளையும் கண்டறியவும்"
 
 msgctxt "nutriscore_explanation_what_it_is"
 msgid "The Nutri-Score is a logo on the overall nutritional quality of products."
@@ -7670,7 +7665,7 @@ msgstr "இந்தப் படத்தை எங்கள் மதிப்
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "நியூட்ரி-ஸ்கோரைக் கணக்கிடுவதற்கான பரிமாறும் அளவு மதிப்பு மற்றும்/அல்லது அலகு எங்களிடம் இல்லை."
+msgstr "Nutri-Score கணக்கிடுவதற்கான பரிமாறும் அளவு மதிப்பு மற்றும்/அல்லது அலகு எங்களிடம் இல்லை."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
@@ -7772,7 +7767,7 @@ msgstr "தேவையற்ற பொருட்கள்"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "இந்த விருப்பம் மூலப்பொருள் பட்டியலைப் பற்றிய ஓபன் ஃபுட் ஃபேக்ட்ஸின் புரிதலை அடிப்படையாகக் கொண்டது மற்றும் துல்லியமாக இருக்காது, எப்போதும் தயாரிப்பை நீங்களே சரிபார்க்கவும்."
+msgstr "இந்த விருப்பம் மூலப்பொருள் பட்டியலைப் பற்றிய Open Food Facts புரிதலை அடிப்படையாகக் கொண்டது மற்றும் துல்லியமாக இருக்காது, எப்போதும் தயாரிப்பை நீங்களே சரிபார்க்கவும்."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "எங்களுக்கு இது தெரியவில்ல�
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "அந்த விருப்பத்தேர்வுகள் மூலப்பொருள் பட்டியலைப் பற்றிய ஓபன் ஃபுட் ஃபேக்ட்ஸின் புரிதலை அடிப்படையாகக் கொண்டவை, மேலும் அது துல்லியமாகவோ அல்லது முழுமையாகவோ இல்லாமல் இருக்க எப்போதும் வாய்ப்பு உள்ளது, எப்போதும் தயாரிப்பை நீங்களே சரிபார்க்கவும்."
+msgstr "அந்த விருப்பத்தேர்வுகள் மூலப்பொருள் பட்டியலைப் பற்றிய Open Food Facts புரிதலை அடிப்படையாகக் கொண்டவை, மேலும் அது துல்லியமாகவோ அல்லது முழுமையாகவோ இல்லாமல் இருக்க எப்போதும் வாய்ப்பு உள்ளது, எப்போதும் தயாரிப்பை நீங்களே சரிபார்க்கவும்."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/te.po
+++ b/po/common/te.po
@@ -42,7 +42,7 @@ msgstr "ప్రపంచవ్యాప్తంగా ఉన్న సౌం�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ఓపెన్ బ్యూటీ ఫ్యాక్ట్స్ ప్రపంచవ్యాప్తంగా ఉన్న సౌందర్య సాధనాల ఉత్పత్తుల గురించిన సమాచారాన్ని మరియు డేటాను సేకరిస్తుంది."
+msgstr "ఓపెన్ Open Beauty Facts ప్రపంచవ్యాప్తంగా ఉన్న సౌందర్య సాధనాల ఉత్పత్తుల గురించిన సమాచారాన్ని మరియు డేటాను సేకరిస్తుంది."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "మరియు సహకారం అందించేవారి క
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "బ్యూటీ ఫ్యాక్ట్స్ ఉత్పత్తి శోధనను తెరవండి"
+msgstr "Open Beauty Facts ఉత్పత్తి శోధనను తెరవండి"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ఈ ఉత్పత్తి పేజీ పూర్తి కాలేదు. మీరు దీన్ని సవరించడం ద్వారా మరియు మా వద్ద ఉన్న ఫోటోల నుండి మరిన్ని డేటాను జోడించడం ద్వారా లేదా <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> లేదా <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>కోసం యూనివర్సల్ ఓపెన్ ఫుడ్ ఫ్యాక్ట్స్ యాప్‌ని ఉపయోగించి మరిన్ని ఫోటోలను తీయడం ద్వారా దీన్ని పూర్తి చేయడంలో సహాయపడవచ్చు. ధన్యవాదాలు!"
+msgstr "ఈ ఉత్పత్తి పేజీ పూర్తి కాలేదు. మీరు దీన్ని సవరించడం ద్వారా మరియు మా వద్ద ఉన్న ఫోటోల నుండి మరిన్ని డేటాను జోడించడం ద్వారా లేదా <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> లేదా <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>కోసం యూనివర్సల్ Open Food Facts యాప్‌ని ఉపయోగించి మరిన్ని ఫోటోలను తీయడం ద్వారా దీన్ని పూర్తి చేయడంలో సహాయపడవచ్చు. ధన్యవాదాలు!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "ఈ ఉత్పత్తి పేజీ పూర్తి కాలేదు. మీరు దీన్ని సవరించడం ద్వారా మరియు మా వద్ద ఉన్న ఫోటోల నుండి మరిన్ని డేటాను జోడించడం ద్వారా లేదా <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> లేదా <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>కోసం యూనివర్సల్ ఓపెన్ ఫుడ్ ఫ్యాక్ట్స్ యాప్‌ని ఉపయోగించి మరిన్ని ఫోటోలను తీయడం ద్వారా దీన్ని పూర్తి చేయడంలో సహాయపడవచ్చు. ధన్యవాదాలు!"
+msgstr "ఈ ఉత్పత్తి పేజీ పూర్తి కాలేదు. మీరు దీన్ని సవరించడం ద్వారా మరియు మా వద్ద ఉన్న ఫోటోల నుండి మరిన్ని డేటాను జోడించడం ద్వారా లేదా <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> లేదా <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>కోసం యూనివర్సల్ Open Food Facts యాప్‌ని ఉపయోగించి మరిన్ని ఫోటోలను తీయడం ద్వారా దీన్ని పూర్తి చేయడంలో సహాయపడవచ్చు. ధన్యవాదాలు!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "న్యూట్రి-స్కోర్ వర్తించదు"
+msgstr "Nutri-Score వర్తించదు"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "గ్రీన్-స్కోర్ అనేది A+ నుండి F వరకు ఉన్న పర్యావరణ స్కోరు, ఇది ఆహార ఉత్పత్తుల పర్యావరణ ప్రభావాన్ని పోల్చడం సులభం చేస్తుంది."
+msgstr "Green-Score అనేది A+ నుండి F వరకు ఉన్న పర్యావరణ స్కోరు, ఇది ఆహార ఉత్పత్తుల పర్యావరణ ప్రభావాన్ని పోల్చడం సులభం చేస్తుంది."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "గ్రీన్-స్కోర్ అనేది A+ నుండి F వరకు ఉన్న పర్యావరణ స్కోరు, ఇది ఆహార ఉత్పత్తుల పర్యావరణ ప్రభావాన్ని పోల్చడం సులభం చేస్తుంది."
+msgstr "Green-Score అనేది A+ నుండి F వరకు ఉన్న పర్యావరణ స్కోరు, ఇది ఆహార ఉత్పత్తుల పర్యావరణ ప్రభావాన్ని పోల్చడం సులభం చేస్తుంది."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "గ్రీన్-స్కోర్‌ను మొదట ఫ్రాన్స్ కోసం అభివృద్ధి చేశారు మరియు దీనిని ఇతర యూరోపియన్ దేశాలకు కూడా విస్తరిస్తున్నారు. గ్రీన్-స్కోర్ ఫార్ములా మార్పుకు లోబడి ఉంటుంది, ఎందుకంటే ఇది ప్రతి దేశానికి మరింత ఖచ్చితమైనదిగా మరియు బాగా సరిపోయేలా క్రమం తప్పకుండా మెరుగుపరచబడుతుంది."
+msgstr "Green-Score‌ను మొదట ఫ్రాన్స్ కోసం అభివృద్ధి చేశారు మరియు దీనిని ఇతర యూరోపియన్ దేశాలకు కూడా విస్తరిస్తున్నారు. Green-Score ఫార్ములా మార్పుకు లోబడి ఉంటుంది, ఎందుకంటే ఇది ప్రతి దేశానికి మరింత ఖచ్చితమైనదిగా మరియు బాగా సరిపోయేలా క్రమం తప్పకుండా మెరుగుపరచబడుతుంది."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "ఈ ఉత్పత్తికి మా వద్ద ఉన్న వర్గం గ్రీన్-స్కోర్‌ను లెక్కించడానికి తగినంత ఖచ్చితమైనది కాదు. మీరు మరింత ఖచ్చితమైన ఉత్పత్తి వర్గాన్ని జోడించగలరా?"
+msgstr "ఈ ఉత్పత్తికి మా వద్ద ఉన్న వర్గం Green-Score‌ను లెక్కించడానికి తగినంత ఖచ్చితమైనది కాదు. మీరు మరింత ఖచ్చితమైన ఉత్పత్తి వర్గాన్ని జోడించగలరా?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,7 +7665,7 @@ msgstr "ఈ చిత్రాన్ని మా మోడరేటర్లక
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "న్యూట్రి-స్కోర్‌ను లెక్కించడానికి మాకు సర్వింగ్ సైజు విలువ మరియు/లేదా యూనిట్ లేదు."
+msgstr "Nutri-Score లెక్కించడానికి మాకు సర్వింగ్ సైజు విలువ మరియు/లేదా యూనిట్ లేదు."
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
@@ -7686,7 +7681,7 @@ msgstr "లిలో సెర్చ్ ఇంజిన్"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "రోబోల దుర్వినియోగం కారణంగా, మేము ఈ పేజీని గుర్తించబడని వినియోగదారులకు అందించలేకపోతున్నాము. దయచేసి అన్ని ఓపెన్ ఫుడ్ ఫ్యాక్ట్‌లను యాక్సెస్ చేయడానికి ఉచిత ఓపెన్ ఫుడ్ ఫ్యాక్ట్స్ ఖాతాను సృష్టించండి."
+msgstr "రోబోల దుర్వినియోగం కారణంగా, మేము ఈ పేజీని గుర్తించబడని వినియోగదారులకు అందించలేకపోతున్నాము. దయచేసి అన్ని Open Food Facts యాక్సెస్ చేయడానికి ఉచిత Open Food Facts ఖాతాను సృష్టించండి."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "అవాంఛిత పదార్థాలు"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "ఈ ప్రాధాన్యత ఓపెన్ ఫుడ్ ఫ్యాక్ట్స్ పదార్థాల జాబితాపై అవగాహనపై ఆధారపడి ఉంటుంది మరియు ఇది ఖచ్చితమైనది కాకపోవచ్చు, ఎల్లప్పుడూ ఉత్పత్తిని మీరే తనిఖీ చేయండి."
+msgstr "ఈ ప్రాధాన్యత Open Food Facts పదార్థాల జాబితాపై అవగాహనపై ఆధారపడి ఉంటుంది మరియు ఇది ఖచ్చితమైనది కాకపోవచ్చు, ఎల్లప్పుడూ ఉత్పత్తిని మీరే తనిఖీ చేయండి."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr "మేము గుర్తించలేదు: {unwanted_ingredients
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "ఆ ప్రాధాన్యతలు ఓపెన్ ఫుడ్ ఫ్యాక్ట్స్ పదార్థాల జాబితా యొక్క అవగాహనపై ఆధారపడి ఉంటాయి మరియు అది ఖచ్చితమైనది లేదా పూర్తిగా ఉండకపోవచ్చు, ఎల్లప్పుడూ ఉత్పత్తిని మీరే తనిఖీ చేయండి."
+msgstr "ఆ ప్రాధాన్యతలు Open Food Facts పదార్థాల జాబితా యొక్క అవగాహనపై ఆధారపడి ఉంటాయి మరియు అది ఖచ్చితమైనది లేదా పూర్తిగా ఉండకపోవచ్చు, ఎల్లప్పుడూ ఉత్పత్తిని మీరే తనిఖీ చేయండి."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/tg.po
+++ b/po/common/tg.po
@@ -63,7 +63,7 @@ msgstr "ва гурӯҳи <a href=\"https://www.facebook.com/groups/OpenBeautyFa
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Ҷустуҷӯи маҳсулоти \"Маълумоти зебоӣ\"-ро кушоед"
+msgstr "Ҷустуҷӯи маҳсулоти \"Open Beauty Facts\"-ро кушоед"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Ҳисоби сабз дар аввал барои Фаронса таҳия шуда буд ва ҳоло ба дигар кишварҳои Аврупо низ паҳн карда мешавад. Формулаи ҳисоби сабз метавонад тағйир ёбад, зеро он мунтазам такмил дода мешавад, то онро дақиқтар ва барои ҳар як кишвар мувофиқтар гардонад."
+msgstr "Green-Score дар аввал барои Фаронса таҳия шуда буд ва ҳоло ба дигар кишварҳои Аврупо низ паҳн карда мешавад. Формулаи Green-Score метавонад тағйир ёбад, зеро он мунтазам такмил дода мешавад, то онро дақиқтар ва барои ҳар як кишвар мувофиқтар гардонад."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Категорияе, ки мо барои ин маҳсулот дорем, барои ҳисоб кардани холҳои сабз кофӣ нест. Метавонед категорияи дақиқтари маҳсулотро илова кунед?"
+msgstr "Категорияе, ки мо барои ин маҳсулот дорем, барои ҳисоб кардани Green-Score кофӣ нест. Метавонед категорияи дақиқтари маҳсулотро илова кунед?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7674,7 +7669,7 @@ msgstr "Мо арзиши андозаи хидмат ва/ё воҳидро б�
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> аз ҷониби ассотсиатсияи ғайритиҷоратӣ, новобаста аз соҳа сохта шудааст. Он барои ҳама, аз ҷониби ҳама сохта шудааст ва аз ҷониби ҳама маблағгузорӣ карда мешавад. Шумо метавонед кори моро тавассути хайрия ба Open Facts дастгирӣ кунед.<br/><b>Ташаккур!</b>"
+msgstr "<<site_name>> аз ҷониби ассотсиатсияи ғайритиҷоратӣ, новобаста аз соҳа сохта шудааст. Он барои ҳама, аз ҷониби ҳама сохта шудааст ва аз ҷониби ҳама маблағгузорӣ карда мешавад. Шумо метавонед кори моро тавассути хайрия ба Open Food Facts дастгирӣ кунед.<br/><b>Ташаккур!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
@@ -7686,7 +7681,7 @@ msgstr "Системаи ҷустуҷӯии Lilo"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Аз сабаби сӯиистифодаи шадиди роботҳо, мо наметавонем ин саҳифаро ба корбарони номаълум хидмат кунем. Лутфан ҳисоби ройгони Open Facts Food эҷод кунед, то ба ҳама далелҳои озуқавории кушод дастрасӣ пайдо кунед."
+msgstr "Аз сабаби сӯиистифодаи шадиди роботҳо, мо наметавонем ин саҳифаро ба корбарони номаълум хидмат кунем. Лутфан ҳисоби ройгони Open Food Facts эҷод кунед, то ба ҳама Open Food Facts дастрасӣ пайдо кунед."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"

--- a/po/common/th.po
+++ b/po/common/th.po
@@ -63,7 +63,7 @@ msgstr "และกลุ่มเฟซบุ๊ก <a href=\"https://www.face
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "เปิดการค้นหาผลิตภัณฑ์ Beauty Facts"
+msgstr "เปิดการค้นหาผลิตภัณฑ์ Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1065,7 +1065,7 @@ msgstr "https://wiki.openfoodfacts.org"
 # Do not translate Open Beauty Facts but do translate Cosmetics
 msgctxt "footer_obf"
 msgid "Open Beauty Facts - Cosmetics"
-msgstr "เปิดเผยข้อมูลความงาม - เครื่องสำอาง"
+msgstr "Open Open Beauty Facts - เครื่องสำอาง"
 
 msgctxt "footer_obf_link"
 msgid "https://world.openbeautyfacts.org"
@@ -1073,7 +1073,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "ข้อมูลอาหารเปิดเผยสำหรับผู้ผลิต"
+msgstr "Open Food Factsสำหรับผู้ผลิต"
 
 msgctxt "for"
 msgid "for"
@@ -1765,11 +1765,6 @@ msgstr ""
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -3999,7 +3994,7 @@ msgstr "ตารางนี้แสดงรายการโอกาสท
 
 msgctxt "improvements_facet_description_2"
 msgid "In order to get relevant results, please make sure the product data is complete (nutrition facts with values for fiber and fruits and vegetables to compute the Nutri-Score, and a precise category to compare each product to similar products)."
-msgstr "เพื่อให้ได้ผลลัพธ์ที่ถูกต้อง โปรดตรวจสอบให้แน่ใจว่าข้อมูลผลิตภัณฑ์ครบถ้วน (ข้อมูลโภชนาการพร้อมค่าใยอาหารและผักผลไม้เพื่อคำนวณคะแนนโภชนาการ และหมวดหมู่ที่ชัดเจนเพื่อเปรียบเทียบแต่ละผลิตภัณฑ์กับผลิตภัณฑ์ที่คล้ายคลึงกัน)"
+msgstr "เพื่อให้ได้ผลลัพธ์ที่ถูกต้อง โปรดตรวจสอบให้แน่ใจว่าข้อมูลผลิตภัณฑ์ครบถ้วน (ข้อมูลโภชนาการพร้อมค่าใยอาหารและผักผลไม้เพื่อคำนวณNutri-Score และหมวดหมู่ที่ชัดเจนเพื่อเปรียบเทียบแต่ละผลิตภัณฑ์กับผลิตภัณฑ์ที่คล้ายคลึงกัน)"
 
 # "product photos" in this sentence means photos for many products, not just one product
 msgctxt "import_photos_title"
@@ -4153,17 +4148,17 @@ msgstr "คะแนนโภชนาการ"
 # Do not translate
 msgctxt "nutriscore_grade"
 msgid "Nutri-Score"
-msgstr "คะแนนโภชนาการ"
+msgstr "Nutri-Score"
 
 # This is not the Nutri-Score grade with letters, but the Nutri-Score number score used to compute the grade. Translate score but not Nutri-Score.
 msgctxt "nutriscore_score_producer"
 msgid "Nutri-Score score"
-msgstr "คะแนนโภชนาการ"
+msgstr "Nutri-Score"
 
 # Do not translate
 msgctxt "nutriscore_grade_producer"
 msgid "Nutri-Score"
-msgstr "คะแนนโภชนาการ"
+msgstr "Nutri-Score"
 
 # free as in not costing something
 msgctxt "donate_free_and_independent"
@@ -4334,7 +4329,7 @@ msgstr "นำเข้าหมวดหมู่"
 
 msgctxt "nutri_score_score_from_producer"
 msgid "Nutri-Score score from producer"
-msgstr "คะแนนโภชนาการจากผู้ผลิต"
+msgstr "Nutri-Scoreจากผู้ผลิต"
 
 msgctxt "nutri_score_score_calculated"
 msgid "Calculated Nutri-Score score"
@@ -4342,11 +4337,11 @@ msgstr "คะแนน Nutri-Score ที่คำนวณได้"
 
 msgctxt "nutri_score_grade_from_producer"
 msgid "Nutri-Score grade from producer"
-msgstr "คะแนนโภชนาการจากผู้ผลิต"
+msgstr "Nutri-Scoreจากผู้ผลิต"
 
 msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
-msgstr "คะแนนโภชนาการที่คำนวณได้"
+msgstr "Nutri-Scoreที่คำนวณได้"
 
 msgctxt "scanned_code"
 msgid "Scanned code"
@@ -4697,7 +4692,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_name"
 msgid "Nutri-Score"
-msgstr "คะแนนโภชนาการ"
+msgstr "Nutri-Score"
 
 msgctxt "attribute_nutriscore_setting_name"
 msgid "Good nutritional quality (Nutri-Score)"
@@ -4710,15 +4705,15 @@ msgstr "ค่าโภชนาการ (Nutri-Score) จะถูกคำน
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "คะแนนโภชนาการ %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
-msgstr "ไม่ทราบค่าโภชนาการ"
+msgstr "ไม่ทราบNutri-Score"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
 msgid "Missing data to compute the Nutri-Score"
-msgstr "ข้อมูลไม่ครบถ้วนสำหรับการคำนวณคะแนนโภชนาการ"
+msgstr "ข้อมูลไม่ครบถ้วนสำหรับการคำนวณNutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
@@ -4948,11 +4943,11 @@ msgstr "สิ่งแวดล้อม"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "คะแนนสีเขียว"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "ผลกระทบต่อสิ่งแวดล้อมต่ำ (คะแนนสีเขียว)"
+msgstr "ผลกระทบต่อสิ่งแวดล้อมต่ำ (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
@@ -4961,11 +4956,11 @@ msgstr "คะแนนสีเขียว (Green-Score) เป็นคะแ
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "คะแนนสีเขียว"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "ผลกระทบต่อสิ่งแวดล้อมต่ำ (คะแนนสีเขียว)"
+msgstr "ผลกระทบต่อสิ่งแวดล้อมต่ำ (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
@@ -4974,7 +4969,7 @@ msgstr "คะแนนสีเขียว (Green-Score) เป็นคะแ
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "คะแนนสีเขียว %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5160,22 +5155,22 @@ msgstr "ผลกระทบต่อสิ่งแวดล้อม"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "คะแนนกรีนสกอร์"
+msgstr "Green-Scoreสกอร์"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "เกรดกรีนสกอร์"
+msgstr "Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "รายละเอียดการคำนวณคะแนนสีเขียว"
+msgstr "รายละเอียดการคำนวณGreen-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "ข้อมูลเกี่ยวกับคะแนนสีเขียว"
+msgstr "ข้อมูลเกี่ยวกับGreen-Score"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5212,19 +5207,19 @@ msgstr "ข้อมูลโภชนาการที่ขาดหายไ
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "คะแนนสีเขียว"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "คะแนนสีเขียว"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "คะแนนสีเขียว"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "คะแนนสีเขียว"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5472,11 +5467,11 @@ msgstr "สินค้าที่ถูกสแกนมากที่สุ
 
 msgctxt "sort_by_nutriscore_score"
 msgid "Products with the best Nutri-Score"
-msgstr "ผลิตภัณฑ์ที่มีคะแนนโภชนาการดีที่สุด"
+msgstr "ผลิตภัณฑ์ที่มีNutri-Scoreดีที่สุด"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "ผลิตภัณฑ์ที่มีคะแนนสีเขียวดีที่สุด"
+msgstr "ผลิตภัณฑ์ที่มีGreen-Scoreดีที่สุด"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5530,7 +5525,7 @@ msgstr "กำลังลบผู้ใช้ อาจใช้เวลา�
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "คะแนนสีเขียวไม่สามารถใช้งานได้"
+msgstr "Green-Scoreไม่สามารถใช้งานได้"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5543,11 +5538,11 @@ msgstr "ยังไม่สามารถใช้งานได้ในห
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "คะแนนสีเขียวยังไม่สามารถใช้งานได้ในหมวดหมู่นี้ แต่เรากำลังดำเนินการเพิ่มการรองรับคะแนนดังกล่าวอยู่"
+msgstr "Green-Scoreยังไม่สามารถใช้งานได้ในหมวดหมู่นี้ แต่เรากำลังดำเนินการเพิ่มการรองรับคะแนนดังกล่าวอยู่"
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "ไม่ได้คำนวณคะแนนสีเขียว"
+msgstr "ไม่ได้คำนวณGreen-Score"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5559,7 +5554,7 @@ msgstr "ขาดหมวดหมู่ที่ชัดเจน"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "เราไม่สามารถคำนวณคะแนนสีเขียวของผลิตภัณฑ์นี้ได้ เนื่องจากข้อมูลบางส่วนไม่ครบถ้วน คุณช่วยกรอกข้อมูลให้ครบถ้วนได้หรือไม่"
+msgstr "เราไม่สามารถคำนวณGreen-Scoreของผลิตภัณฑ์นี้ได้ เนื่องจากข้อมูลบางส่วนไม่ครบถ้วน คุณช่วยกรอกข้อมูลให้ครบถ้วนได้หรือไม่"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5667,7 +5662,7 @@ msgstr "ข้อมูลบางส่วนสำหรับผลิตภ
 
 msgctxt "data_source_database_note_about_the_producers_platform"
 msgid "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_url>\">free plaform for producers</a> to access and complete this data, and to obtain reports, analysis and product improvements opportunities (e.g. better Nutri-Score)."
-msgstr "ผู้ผลิตสามารถใช้แพลตฟอร์ม Open Food Facts <a href=\"<producers_platform_url>\">ฟรีสำหรับผู้ผลิต</a> เพื่อเข้าถึงและกรอกข้อมูลเหล่านี้ให้ครบถ้วน รวมถึงรับรายงาน การวิเคราะห์ และโอกาสในการปรับปรุงผลิตภัณฑ์ (เช่น คะแนนคุณค่าทางโภชนาการที่ดีขึ้น)"
+msgstr "ผู้ผลิตสามารถใช้แพลตฟอร์ม Open Food Facts <a href=\"<producers_platform_url>\">ฟรีสำหรับผู้ผลิต</a> เพื่อเข้าถึงและกรอกข้อมูลเหล่านี้ให้ครบถ้วน รวมถึงรับรายงาน การวิเคราะห์ และโอกาสในการปรับปรุงผลิตภัณฑ์ (เช่น Nutri-Scoreที่ดีขึ้น)"
 
 # variable names between { } must not be translated
 msgctxt "f_data_source_database_provider"
@@ -5701,7 +5696,7 @@ msgstr "หากคุณเป็นผู้ผลิตผลิตภัณ
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "คำเตือน: ข้อมูลบางส่วนที่จำเป็นสำหรับการคำนวณคะแนนสีเขียวอย่างแม่นยำนั้นไม่ได้ระบุไว้ (โปรดดูรายละเอียดการคำนวณด้านล่าง)"
+msgstr "คำเตือน: ข้อมูลบางส่วนที่จำเป็นสำหรับการคำนวณGreen-Scoreอย่างแม่นยำนั้นไม่ได้ระบุไว้ (โปรดดูรายละเอียดการคำนวณด้านล่าง)"
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5856,12 +5851,12 @@ msgstr "ข้อมูลเกี่ยวกับบรรจุภัณฑ
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "เพื่อให้ได้การคำนวณคะแนนสีเขียวที่แม่นยำยิ่งขึ้น คุณสามารถแก้ไขหน้าผลิตภัณฑ์และเพิ่มข้อมูลเหล่านั้นได้"
+msgstr "เพื่อให้ได้การคำนวณGreen-Scoreที่แม่นยำยิ่งขึ้น คุณสามารถแก้ไขหน้าผลิตภัณฑ์และเพิ่มข้อมูลเหล่านั้นได้"
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "หากต้องการคำนวณคะแนนสีเขียวให้แม่นยำยิ่งขึ้น คุณสามารถแก้ไขหน้าผลิตภัณฑ์และเพิ่มข้อมูลเหล่านั้นได้"
+msgstr "หากต้องการคำนวณGreen-Scoreให้แม่นยำยิ่งขึ้น คุณสามารถแก้ไขหน้าผลิตภัณฑ์และเพิ่มข้อมูลเหล่านั้นได้"
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5883,12 +5878,12 @@ msgstr "หากคุณเป็นผู้ผลิตผลิตภัณ
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "คะแนนสีเขียว <a href=\"/green-score\"></a> เป็นคะแนนทดลองที่สรุปผลกระทบต่อสิ่งแวดล้อมของผลิตภัณฑ์อาหาร"
+msgstr "Green-Score <a href=\"/green-score\"></a> เป็นคะแนนทดลองที่สรุปผลกระทบต่อสิ่งแวดล้อมของผลิตภัณฑ์อาหาร"
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
 msgid "The Green-Score formula is subject to change as it is regularly improved to make it more precise."
-msgstr "สูตรการคำนวณคะแนนสีเขียวอาจมีการเปลี่ยนแปลงได้ เนื่องจากมีการปรับปรุงอย่างสม่ำเสมอเพื่อให้มีความแม่นยำยิ่งขึ้น"
+msgstr "สูตรการคำนวณGreen-Scoreอาจมีการเปลี่ยนแปลงได้ เนื่องจากมีการปรับปรุงอย่างสม่ำเสมอเพื่อให้มีความแม่นยำยิ่งขึ้น"
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
@@ -5905,7 +5900,7 @@ msgstr "ผลกระทบอย่างเต็มรูปแบบขอ
 
 msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Green-Score and more!"
-msgstr "สแกนบาร์โค้ดเพื่อดูคะแนนโภชนาการ คะแนนความเป็นมิตรต่อสิ่งแวดล้อม และอื่นๆ อีกมากมาย!"
+msgstr "สแกนบาร์โค้ดเพื่อดูNutri-Score Green-Score และอื่นๆ อีกมากมาย!"
 
 msgctxt "org_gs1_product_name_is_abbreviated"
 msgid "GS1 product names for this manufacturer are abbreviated."
@@ -6216,7 +6211,7 @@ msgstr "โบนัสและค่าปรับ"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "คะแนนความเป็นมิตรต่อสิ่งแวดล้อมสำหรับผลิตภัณฑ์นี้"
+msgstr "Green-Scoreสำหรับผลิตภัณฑ์นี้"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6541,15 +6536,15 @@ msgstr "คุณช่วยเพิ่มรายการส่วนผส
 
 msgctxt "actions_to_compute_nutriscore"
 msgid "Could you add the information needed to compute the Nutri-Score?"
-msgstr "คุณช่วยเพิ่มข้อมูลที่จำเป็นในการคำนวณคะแนนโภชนาการได้ไหม"
+msgstr "คุณช่วยเพิ่มข้อมูลที่จำเป็นในการคำนวณNutri-Scoreได้ไหม"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "คุณช่วยระบุหมวดหมู่สินค้าให้ชัดเจนยิ่งขึ้นได้ไหม เพื่อที่เราจะสามารถคำนวณคะแนนสีเขียวได้"
+msgstr "คุณช่วยระบุหมวดหมู่สินค้าให้ชัดเจนยิ่งขึ้นได้ไหม เพื่อที่เราจะสามารถคำนวณGreen-Scoreได้"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "หมวดหมู่ที่เรามีสำหรับผลิตภัณฑ์นี้ไม่แม่นยำพอที่จะคำนวณคะแนนสีเขียว คุณสามารถเพิ่มหมวดหมู่ผลิตภัณฑ์ที่แม่นยำยิ่งขึ้นได้ไหม"
+msgstr "หมวดหมู่ที่เรามีสำหรับผลิตภัณฑ์นี้ไม่แม่นยำพอที่จะคำนวณGreen-Score คุณสามารถเพิ่มหมวดหมู่ผลิตภัณฑ์ที่แม่นยำยิ่งขึ้นได้ไหม"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/ti.po
+++ b/po/common/ti.po
@@ -42,7 +42,7 @@ msgstr "ናይ ምትሕብባር፣ ነጻን ክፉትን ዳታቤዝ ቀመ�
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "ኦፐን ቢውቲ ፋክትስ ካብ መላእ ዓለም ብዛዕባ ፍርያት መመላኽዒ ሓበሬታን ዳታን ይእክብ።"
+msgstr "Open Beauty Facts ካብ መላእ ዓለም ብዛዕባ ፍርያት መመላኽዒ ሓበሬታን ዳታን ይእክብ።"
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "ከምኡ’ውን <a href=\"https://www.facebook.com/groups/OpenBeautyF
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ክፉት ሓቅታት ጽባቐ product search"
+msgstr "Open Beauty Facts product search"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "ኒውትሪ-ስኮር ኣይምልከትን"
+msgstr "Nutri-Score ኣይምልከትን"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ሓምላይ-ነጥቢ ካብ A+ ክሳብ F ዝበጽሕ ከባብያዊ ነጥቢ ኮይኑ ፍርያት መግቢ ኣብ ከባቢ ዘለዎም ጽልዋ ንምንጽጻር ቀሊል ይገብሮ።"
+msgstr "Green-Score ካብ A+ ክሳብ F ዝበጽሕ ከባብያዊ ነጥቢ ኮይኑ ፍርያት መግቢ ኣብ ከባቢ ዘለዎም ጽልዋ ንምንጽጻር ቀሊል ይገብሮ።"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "ሓምላይ-ነጥቢ ካብ A+ ክሳብ F ዝበጽሕ ከባብያዊ ነጥቢ ኮይኑ ፍርያት መግቢ ኣብ ከባቢ ዘለዎም ጽልዋ ንምንጽጻር ቀሊል ይገብሮ።"
+msgstr "Green-Score ካብ A+ ክሳብ F ዝበጽሕ ከባብያዊ ነጥቢ ኮይኑ ፍርያት መግቢ ኣብ ከባቢ ዘለዎም ጽልዋ ንምንጽጻር ቀሊል ይገብሮ።"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "ግሪን-ስኮር ፈለማ ንፈረንሳ ዝተዳለወ ኮይኑ፡ ናብ ካልኦት ሃገራት ኤውሮጳ ይዝርጋሕ ኣሎ። ቀመር ሓምላይ ነጥቢ ንነፍሲ ወከፍ ሃገር ዝያዳ ልክዕን ብዝበለጸ ዝሰማማዕን ንኽኸውን ብቐጻሊ ስለዝመሓየሽ ክቕየር ይኽእል እዩ።"
+msgstr "Green-Score ፈለማ ንፈረንሳ ዝተዳለወ ኮይኑ፡ ናብ ካልኦት ሃገራት ኤውሮጳ ይዝርጋሕ ኣሎ። ቀመር Green-Score ንነፍሲ ወከፍ ሃገር ዝያዳ ልክዕን ብዝበለጸ ዝሰማማዕን ንኽኸውን ብቐጻሊ ስለዝመሓየሽ ክቕየር ይኽእል እዩ።"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -7686,7 +7681,7 @@ msgstr "ሊሎ ሞተር ምድላይ"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "ብሰንኪ ካብ ሮቦታት ዝመጽእ ከቢድ ግህሰት፡ ነዚ ገጽ ንዘይተፈልጡ ተጠቀምቲ ከነገልግሎ ኣይከኣልናን። ንኹሉ ናይ ክፉት መግቢ ሓቅታት ንምርካብ በጃኹም ነጻ ናይ ክፉት ሓቅታት መግቢ ኣካውንት ፍጠሩ።"
+msgstr "ብሰንኪ ካብ ሮቦታት ዝመጽእ ከቢድ ግህሰት፡ ነዚ ገጽ ንዘይተፈልጡ ተጠቀምቲ ከነገልግሎ ኣይከኣልናን። ንኹሉ ናይ Open Food Facts ንምርካብ በጃኹም ነጻ ናይ Open Food Facts ኣካውንት ፍጠሩ።"
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"

--- a/po/common/tl.po
+++ b/po/common/tl.po
@@ -1760,11 +1760,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Marka ng nutrisyon"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/tn.po
+++ b/po/common/tn.po
@@ -63,7 +63,7 @@ msgstr ""
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Bula patlo ya dikumo tsa Beauty Facts"
+msgstr "Bula patlo ya dikumo tsa Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "Maduo a Nutri ga a dire"
+msgstr "Nutri-Score ga a dire"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -7670,7 +7665,7 @@ msgstr "Begela balekanyetsi ba rona setshwantsho seno"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Re tlhaela boleng jwa bogolo jwa sejana le/kgotsa yuniti ya go balelela Maduo a Nutri"
+msgstr "Re tlhaela boleng jwa bogolo jwa sejana le/kgotsa yuniti ya go balelela Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
@@ -7686,7 +7681,7 @@ msgstr "Enjene ya patlo ya Lilo"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Ka ntlha ya go sotlwa thata ke diroboto, ga re kgone go direla badirisi ba ba sa itsiweng tsebe eno. Tsweetswee tlhama akhaonto ya mahala ya Dintlha tsa Dijo tse di Buletsweng go fitlhelela Dintlha tsotlhe tsa Dijo tse di Buletsweng."
+msgstr "Ka ntlha ya go sotlwa thata ke diroboto, ga re kgone go direla badirisi ba ba sa itsiweng tsebe eno. Tsweetswee tlhama akhaonto ya mahala ya Open Food Facts go fitlhelela Dintlha tsotlhe tsa Dijo tse di Buletsweng."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"

--- a/po/common/tr.po
+++ b/po/common/tr.po
@@ -1072,7 +1072,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "Üreticiler için Açık Gıda Gerçekleri"
+msgstr "Üreticiler için Open Food Facts"
 
 msgctxt "for"
 msgid "for"
@@ -1761,11 +1761,6 @@ msgstr "Beslenme dereceleri"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Beslenme derecesi"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4332,11 +4327,11 @@ msgstr "Kategorileri içe aktarın"
 
 msgctxt "nutri_score_score_from_producer"
 msgid "Nutri-Score score from producer"
-msgstr "Üreticiden Nutri-Skor puanı"
+msgstr "Üreticiden Nutri-Score puanı"
 
 msgctxt "nutri_score_score_calculated"
 msgid "Calculated Nutri-Score score"
-msgstr "Hesaplanan Nutri-Puan skor"
+msgstr "Hesaplanan Nutri-Score skor"
 
 msgctxt "nutri_score_grade_from_producer"
 msgid "Nutri-Score grade from producer"
@@ -4344,7 +4339,7 @@ msgstr "Üreticiden Nutri-Score derecesi"
 
 msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
-msgstr "Hesaplanan Nutri-Skor derecesi"
+msgstr "Hesaplanan Nutri-Score derecesi"
 
 msgctxt "scanned_code"
 msgid "Scanned code"
@@ -4950,11 +4945,11 @@ msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "Düşük çevresel etki (Eko-Skor)"
+msgstr "Düşük çevresel etki (Green-Score)"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Yeşil Puan, gıda ürünlerinin çevre üzerindeki etkisini karşılaştırmayı kolaylaştıran, A+ ile F arasında değişen bir çevre puanı sistemidir."
+msgstr "Green-Score, gıda ürünlerinin çevre üzerindeki etkisini karşılaştırmayı kolaylaştıran, A+ ile F arasında değişen bir çevre puanı sistemidir."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4963,11 +4958,11 @@ msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "Düşük çevresel etki (Eko-Skor)"
+msgstr "Düşük çevresel etki (Green-Score)"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Yeşil Puan, gıda ürünlerinin çevre üzerindeki etkisini karşılaştırmayı kolaylaştıran, A+ ile F arasında değişen bir çevre puanı sistemidir."
+msgstr "Green-Score, gıda ürünlerinin çevre üzerindeki etkisini karşılaştırmayı kolaylaştıran, A+ ile F arasında değişen bir çevre puanı sistemidir."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5557,7 +5552,7 @@ msgstr "Kesin bir kategori eksik"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "Bazı veriler eksik olduğu için bu ürünün Eko-Skorunu hesaplayamadık, tamamlamanıza yardımcı olabilir misiniz?"
+msgstr "Bazı veriler eksik olduğu için bu ürünün Green-Scoreunu hesaplayamadık, tamamlamanıza yardımcı olabilir misiniz?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5891,7 +5886,7 @@ msgstr "Green-Score formülü, daha kesin hale getirmek için düzenli olarak ge
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Yeşil Puanlama sistemi ilk olarak Fransa için geliştirilmiş olup diğer Avrupa ülkelerine de yaygınlaştırılmaktadır. Yeşil Puanlama formülü, her ülkeye daha uygun ve daha doğru hale getirilmesi için düzenli olarak geliştirildiğinden değişime tabidir."
+msgstr "Green-Score sistemi ilk olarak Fransa için geliştirilmiş olup diğer Avrupa ülkelerine de yaygınlaştırılmaktadır. Green-Score formülü, her ülkeye daha uygun ve daha doğru hale getirilmesi için düzenli olarak geliştirildiğinden değişime tabidir."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6214,7 +6209,7 @@ msgstr "Bonuslar ve kötüye kullanımlar"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Bu ürün için Eko-Skor"
+msgstr "Bu ürün için Green-Score"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6543,11 +6538,11 @@ msgstr "Nutri-Score'u hesaplamak için gereken bilgileri ekleyebilir misiniz?"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Eko-Skoru hesaplayabilmemiz için kesin bir ürün kategorisi ekleyebilir misiniz?"
+msgstr "Green-Scoreu hesaplayabilmemiz için kesin bir ürün kategorisi ekleyebilir misiniz?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Bu ürün için belirlediğimiz kategori, Yeşil Puanı hesaplamak için yeterince kesin değil. Daha kesin bir ürün kategorisi ekleyebilir misiniz?"
+msgstr "Bu ürün için belirlediğimiz kategori, Green-Scoreı hesaplamak için yeterince kesin değil. Daha kesin bir ürün kategorisi ekleyebilir misiniz?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/ts.po
+++ b/po/common/ts.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -7686,7 +7681,7 @@ msgstr "Lilo njhini yo lavisisa"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Hikwalaho ka ku xanisiwa lokukulu hi tirhoboto, a hi swi koti ku tirhela pheji leri eka vatirhisi lava nga tiviwiki. Hi kombela u endla akhawunti ya mahala ya Tinhla ta Swakudya leti Pfulekeke ku fikelela hinkwaswo swa Tinhla ta Swakudya leswi Pfulekeke."
+msgstr "Hikwalaho ka ku xanisiwa lokukulu hi tirhoboto, a hi swi koti ku tirhela pheji leri eka vatirhisi lava nga tiviwiki. Hi kombela u endla akhawunti ya mahala ya Open Food Facts ku fikelela hinkwaswo swa Open Food Facts."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"

--- a/po/common/tt.po
+++ b/po/common/tt.po
@@ -63,7 +63,7 @@ msgstr "һәм өлеш кертүчеләр өчен <a href=\"https://www.face
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "\"Матурлык фактлары\" продуктын ачык эзләү"
+msgstr "\"Open Beauty Facts\" продуктын ачык эзләү"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Яшел балл - азык-төлек продуктларының әйләнә-тирә мохиткә йогынтысын чагыштыруны җиңеләйтә торган A+ тан F га кадәрге әйләнә-тирә мохит баллы."
+msgstr "Green-Score - азык-төлек продуктларының әйләнә-тирә мохиткә йогынтысын чагыштыруны җиңеләйтә торган A+ тан F га кадәрге әйләнә-тирә мохит баллы."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Яшел балл - азык-төлек продуктларының әйләнә-тирә мохиткә йогынтысын чагыштыруны җиңеләйтә торган A+ тан F га кадәрге әйләнә-тирә мохит баллы."
+msgstr "Green-Score - азык-төлек продуктларының әйләнә-тирә мохиткә йогынтысын чагыштыруны җиңеләйтә торган A+ тан F га кадәрге әйләнә-тирә мохит баллы."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Бу продукт өчен булган категория яшел-баллны исәпләү өчен төгәл түгел. Сез төгәл продукт категориясен өсти аласызмы?"
+msgstr "Бу продукт өчен булган категория Green-Score исәпләү өчен төгәл түгел. Сез төгәл продукт категориясен өсти аласызмы?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7686,7 +7681,7 @@ msgstr "Лило эзләү системасы"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Роботлардан тупас куллану аркасында, без бу битне билгесез кулланучыларга хезмәт итә алмыйбыз. Зинһар, бушлай Азык-төлек Фактлары счетын булдырыгыз."
+msgstr "Роботлардан тупас куллану аркасында, без бу битне билгесез кулланучыларга хезмәт итә алмыйбыз. Зинһар, бушлай Open Food Facts счетын булдырыгыз."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "Кирәк булмаган ингредиентлар"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "Бу өстенлек Ачык азык фактларының ингредиентлар исемлеген аңлавына нигезләнгән һәм төгәл булмаска мөмкин, продуктны һәрвакыт үзегез тикшерегез."
+msgstr "Бу өстенлек Open Food Facts ингредиентлар исемлеген аңлавына нигезләнгән һәм төгәл булмаска мөмкин, продуктны һәрвакыт үзегез тикшерегез."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr ""
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "Бу өстенлекләр Ачык азык фактларының ингредиентлар исемлеген аңлавына нигезләнә һәм аның төгәл яки тулы булмавы мөмкинлеге бар, продуктны һәрвакыт үзегез тикшерегез."
+msgstr "Бу өстенлекләр Open Food Facts ингредиентлар исемлеген аңлавына нигезләнә һәм аның төгәл яки тулы булмавы мөмкинлеге бар, продуктны һәрвакыт үзегез тикшерегез."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/tw.po
+++ b/po/common/tw.po
@@ -63,7 +63,7 @@ msgstr "ne <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">Facebook
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Bue Ahoɔfɛ Nokwasɛm ahorow product search"
+msgstr "Open Beauty Facts product search"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language

--- a/po/common/ty.po
+++ b/po/common/ty.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/tzl.po
+++ b/po/common/tzl.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/ug.po
+++ b/po/common/ug.po
@@ -42,7 +42,7 @@ msgstr "دۇنيانىڭ ھەرقايسى جايلىرىدىكى گىرىم بۇ
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "«ئوچۇق گۈزەللىك پاكىتلىرى» دۇنيانىڭ ھەرقايسى جايلىرىدىكى گىرىم بۇيۇملىرىغا ئائىت ئۇچۇر ۋە سانلىق مەلۇماتلارنى توپلايدۇ."
+msgstr "«Open Beauty Facts» دۇنيانىڭ ھەرقايسى جايلىرىدىكى گىرىم بۇيۇملىرىغا ئائىت ئۇچۇر ۋە سانلىق مەلۇماتلارنى توپلايدۇ."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "ۋە <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">تۆھ
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "ئوچۇق گۈزەللىك پاكىتلىرى مەھسۇلات ئىزدەش"
+msgstr "Open Beauty Facts مەھسۇلات ئىزدەش"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -121,7 +121,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "بۇ مەھسۇلات بېتى تولۇق ئەمەس. سىز ئۇنى تەھرىرلەپ، قولىمىزدىكى سۈرەتلەردىن كۆپرەك سانلىق مەلۇمات قوشۇش ئارقىلىق ياكى <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ئاندروئىد</a> ياكى <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>ئۈچۈن ئۇنىۋېرسال ئوچۇق يېمەكلىك پاكىتلىرى ئەپ دېتالىنى ئىشلىتىپ كۆپرەك سۈرەتكە تارتىش ئارقىلىق ئۇنى تولۇقلاشقا ياردەم قىلالايسىز. رەھمەت!"
+msgstr "بۇ مەھسۇلات بېتى تولۇق ئەمەس. سىز ئۇنى تەھرىرلەپ، قولىمىزدىكى سۈرەتلەردىن كۆپرەك سانلىق مەلۇمات قوشۇش ئارقىلىق ياكى <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ئاندروئىد</a> ياكى <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>ئۈچۈن ئۇنىۋېرسال Open Food Facts ئەپ دېتالىنى ئىشلىتىپ كۆپرەك سۈرەتكە تارتىش ئارقىلىق ئۇنى تولۇقلاشقا ياردەم قىلالايسىز. رەھمەت!"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr ""
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "بۇ مەھسۇلات بېتى تولۇق ئەمەس. سىز ئۇنى تەھرىرلەپ، قولىمىزدىكى سۈرەتلەردىن كۆپرەك سانلىق مەلۇمات قوشۇش ئارقىلىق ياكى <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ئاندروئىد</a> ياكى <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>ئۈچۈن ئۇنىۋېرسال ئوچۇق يېمەكلىك پاكىتلىرى ئەپ دېتالىنى ئىشلىتىپ كۆپرەك سۈرەتكە تارتىش ئارقىلىق ئۇنى تولۇقلاشقا ياردەم قىلالايسىز. رەھمەت!"
+msgstr "بۇ مەھسۇلات بېتى تولۇق ئەمەس. سىز ئۇنى تەھرىرلەپ، قولىمىزدىكى سۈرەتلەردىن كۆپرەك سانلىق مەلۇمات قوشۇش ئارقىلىق ياكى <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">ئاندروئىد</a> ياكى <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>ئۈچۈن ئۇنىۋېرسال Open Food Facts ئەپ دېتالىنى ئىشلىتىپ كۆپرەك سۈرەتكە تارتىش ئارقىلىق ئۇنى تولۇقلاشقا ياردەم قىلالايسىز. رەھمەت!"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "يېشىل نومۇر A+ دىن F گىچە بولغان مۇھىت نومۇرى بولۇپ، يېمەكلىك مەھسۇلاتلىرىنىڭ مۇھىتقا بولغان تەسىرىنى سېلىشتۇرۇشنى ئاسانلاشتۇرىدۇ."
+msgstr "Green-Score A+ دىن F گىچە بولغان مۇھىت نومۇرى بولۇپ، يېمەكلىك مەھسۇلاتلىرىنىڭ مۇھىتقا بولغان تەسىرىنى سېلىشتۇرۇشنى ئاسانلاشتۇرىدۇ."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "يېشىل نومۇر A+ دىن F گىچە بولغان مۇھىت نومۇرى بولۇپ، يېمەكلىك مەھسۇلاتلىرىنىڭ مۇھىتقا بولغان تەسىرىنى سېلىشتۇرۇشنى ئاسانلاشتۇرىدۇ."
+msgstr "Green-Score A+ دىن F گىچە بولغان مۇھىت نومۇرى بولۇپ، يېمەكلىك مەھسۇلاتلىرىنىڭ مۇھىتقا بولغان تەسىرىنى سېلىشتۇرۇشنى ئاسانلاشتۇرىدۇ."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "يېشىل نومۇر دەسلەپ فرانسىيە ئۈچۈن ئىجاد قىلىنغان بولۇپ، باشقا ياۋروپا دۆلەتلىرىگىمۇ كېڭەيتىلىۋاتىدۇ. يېشىل نومۇر فورمۇلاسى دائىم ياخشىلىنىپ، ھەر بىر دۆلەتكە تېخىمۇ ئېنىق ۋە ماس كېلىدىغان قىلىپ ئۆزگەرتىلىشى مۇمكىن."
+msgstr "Green-Score دەسلەپ فرانسىيە ئۈچۈن ئىجاد قىلىنغان بولۇپ، باشقا ياۋروپا دۆلەتلىرىگىمۇ كېڭەيتىلىۋاتىدۇ. Green-Score فورمۇلاسى دائىم ياخشىلىنىپ، ھەر بىر دۆلەتكە تېخىمۇ ئېنىق ۋە ماس كېلىدىغان قىلىپ ئۆزگەرتىلىشى مۇمكىن."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "بىزنىڭ بۇ مەھسۇلاتقا ئىگە بولغان تۈرىمىز يېشىل نومۇرنى ھېسابلاشقا يېتەرلىك ئېنىق ئەمەس. تېخىمۇ ئېنىق مەھسۇلات تۈرىنى قوشالامسىز؟"
+msgstr "بىزنىڭ بۇ مەھسۇلاتقا ئىگە بولغان تۈرىمىز Green-Scoreنى ھېسابلاشقا يېتەرلىك ئېنىق ئەمەس. تېخىمۇ ئېنىق مەھسۇلات تۈرىنى قوشالامسىز؟"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7686,7 +7681,7 @@ msgstr "Lilo ئىزدەش ماتورى"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "ماشىنا ئادەملەرنىڭ قاتتىق خورلىنىشى سەۋەبىدىن ، بىز بۇ بەتنى نامەلۇم ئىشلەتكۈچىلەرگە مۇلازىمەت قىلالمايمىز. ھەقسىز يېمەكلىك پاكىتلىرى ھېساباتىنى قۇرۇپ ، ئوچۇق يېمەكلىك پاكىتلىرىنىڭ ھەممىسىنى زىيارەت قىلىڭ."
+msgstr "ماشىنا ئادەملەرنىڭ قاتتىق خورلىنىشى سەۋەبىدىن ، بىز بۇ بەتنى نامەلۇم ئىشلەتكۈچىلەرگە مۇلازىمەت قىلالمايمىز. ھەقسىز يېمەكلىك پاكىتلىرى ھېساباتىنى قۇرۇپ ، Open Food Factsنىڭ ھەممىسىنى زىيارەت قىلىڭ."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7772,7 +7767,7 @@ msgstr "كېرەكسىز تەركىبلەر"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "بۇ مايىللىق ئوچۇق يېمەكلىك پاكىتلىرىنىڭ تەركىب تىزىملىكىنى چۈشىنىشىنى ئاساس قىلغان بولۇپ ، توغرا بولماسلىقى مۇمكىن ، مەھسۇلاتنى ھەمىشە ئۆزىڭىز تەكشۈرۈپ بېقىڭ."
+msgstr "بۇ مايىللىق Open Food Factsنىڭ تەركىب تىزىملىكىنى چۈشىنىشىنى ئاساس قىلغان بولۇپ ، توغرا بولماسلىقى مۇمكىن ، مەھسۇلاتنى ھەمىشە ئۆزىڭىز تەكشۈرۈپ بېقىڭ."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7800,7 +7795,7 @@ msgstr ""
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "بۇ ئېتىبارلار ئوچۇق يېمەكلىك پاكىتلىرىنىڭ تەركىبلەر تىزىملىكىنى چۈشىنىشىنى ئاساس قىلغان بولۇپ ، ئۇنىڭ توغرا ياكى تولۇق بولماسلىقى مۇمكىن ، ھەمىشە مەھسۇلاتنى ئۆزىڭىز تەكشۈرۈپ بېقىڭ."
+msgstr "بۇ ئېتىبارلار Open Food Factsنىڭ تەركىبلەر تىزىملىكىنى چۈشىنىشىنى ئاساس قىلغان بولۇپ ، ئۇنىڭ توغرا ياكى تولۇق بولماسلىقى مۇمكىن ، ھەمىشە مەھسۇلاتنى ئۆزىڭىز تەكشۈرۈپ بېقىڭ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/uk.po
+++ b/po/common/uk.po
@@ -1065,7 +1065,7 @@ msgstr "https://wiki.openfoodfacts.org/"
 # Do not translate Open Beauty Facts but do translate Cosmetics
 msgctxt "footer_obf"
 msgid "Open Beauty Facts - Cosmetics"
-msgstr "Відкрити факти про красу-косметика"
+msgstr "Open Beauty Facts — косметика"
 
 msgctxt "footer_obf_link"
 msgid "https://world.openbeautyfacts.org"
@@ -1763,11 +1763,6 @@ msgstr "Харчові цінності"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Харчова цінність"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -4075,7 +4070,7 @@ msgstr "Деталі розрахунку Nutri-Score"
 
 msgctxt "nutriscore_is_beverage"
 msgid "This product is considered a beverage for the calculation of the Nutri-Score."
-msgstr "Цей товар вважається важелем для обчислення Нутрі-Скора."
+msgstr "Цей товар вважається важелем для обчислення Nutri-Scoreа."
 
 msgctxt "nutriscore_is_not_beverage"
 msgid "This product is not considered a beverage for the calculation of the Nutri-Score."
@@ -4977,7 +4972,7 @@ msgstr "Green-Score – це екологічний бал від A+ до F, я�
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Зелена оцінка %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5168,12 +5163,12 @@ msgstr "Оцінка Green-Score"
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "Оцінка за шкалою Зеленої оцінки"
+msgstr "Оцінка за шкалою Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
 msgid "Details of the calculation of the Green-Score"
-msgstr "Подробиці розрахунку Зеленої оцінки"
+msgstr "Подробиці розрахунку Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_information"
@@ -5475,11 +5470,11 @@ msgstr "Найпопулярніші товари"
 
 msgctxt "sort_by_nutriscore_score"
 msgid "Products with the best Nutri-Score"
-msgstr "Продукти з найкращим показником харчової цінності"
+msgstr "Продукти з найкращим Nutri-Score"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "Продукти з найкращим показником впливу на довкілля"
+msgstr "Продукти з найкращим Green-Score"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5533,7 +5528,7 @@ msgstr "Користувач видаляється. Це може зайнят�
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "Green Score не застосовується"
+msgstr "Green-Score не застосовується"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5908,7 +5903,7 @@ msgstr "Повний вплив транспортування на вашу к�
 
 msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Green-Score and more!"
-msgstr "Скануйте штрих-коди, щоб отримати показник харчової цінності, впливу на довкілля та багато іншого!"
+msgstr "Скануйте штрих-коди, щоб отримати Nutri-Score, Green-Score та багато іншого!"
 
 msgctxt "org_gs1_product_name_is_abbreviated"
 msgid "GS1 product names for this manufacturer are abbreviated."
@@ -6548,7 +6543,7 @@ msgstr "Чи не могли б ви додати інформацію, необ
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Чи не могли б ви додати точну категорію товару, щоб ми могли обчислити екологічний бал?"
+msgstr "Чи не могли б ви додати точну категорію товару, щоб ми могли обчислити Green-Score?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"

--- a/po/common/ur.po
+++ b/po/common/ur.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/uz.po
+++ b/po/common/uz.po
@@ -63,7 +63,7 @@ msgstr "va <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\">hissa qo
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Go'zallik faktlarini ochiq qidiruv"
+msgstr "Open Beauty Facts ochiq qidiruv"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4939,7 +4934,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Yashil ball - bu oziq-ovqat mahsulotlarining atrof-muhitga ta'sirini taqqoslashni osonlashtiradigan A+ dan F gacha bo'lgan ekologik ball."
+msgstr "Green-Score - bu oziq-ovqat mahsulotlarining atrof-muhitga ta'sirini taqqoslashni osonlashtiradigan A+ dan F gacha bo'lgan ekologik ball."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4952,7 +4947,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Yashil ball - bu oziq-ovqat mahsulotlarining atrof-muhitga ta'sirini taqqoslashni osonlashtiradigan A+ dan F gacha bo'lgan ekologik ball."
+msgstr "Green-Score - bu oziq-ovqat mahsulotlarining atrof-muhitga ta'sirini taqqoslashni osonlashtiradigan A+ dan F gacha bo'lgan ekologik ball."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5876,7 +5871,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "Yashil ball dastlab Fransiya uchun ishlab chiqilgan va u boshqa Yevropa mamlakatlariga ham tatbiq etilmoqda. Yashil ball formulasi har bir mamlakat uchun aniqroq va mosroq bo'lishi uchun muntazam ravishda takomillashtirilib borilishi sababli o'zgarishi mumkin."
+msgstr "Green-Score dastlab Fransiya uchun ishlab chiqilgan va u boshqa Yevropa mamlakatlariga ham tatbiq etilmoqda. Green-Score formulasi har bir mamlakat uchun aniqroq va mosroq bo'lishi uchun muntazam ravishda takomillashtirilib borilishi sababli o'zgarishi mumkin."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6532,7 +6527,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Ushbu mahsulot uchun bizda mavjud bo'lgan toifa Yashil ballni hisoblash uchun etarli darajada aniq emas. Aniqroq mahsulot toifasini qo'sha olasizmi?"
+msgstr "Ushbu mahsulot uchun bizda mavjud bo'lgan toifa Green-Scoreni hisoblash uchun etarli darajada aniq emas. Aniqroq mahsulot toifasini qo'sha olasizmi?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"

--- a/po/common/val.po
+++ b/po/common/val.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/ve.po
+++ b/po/common/ve.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/vec.po
+++ b/po/common/vec.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/vi.po
+++ b/po/common/vi.po
@@ -1073,7 +1073,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "Thông tin thực phẩm công khai dành cho nhà sản xuất"
+msgstr "Open Food Facts dành cho nhà sản xuất"
 
 msgctxt "for"
 msgid "for"
@@ -1765,11 +1765,6 @@ msgstr "Các lớp dinh dưỡng"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "Lớp dinh dưỡng"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -3996,11 +3991,11 @@ msgstr "Số lượng sản phẩm có cơ hội cải tiến"
 
 msgctxt "improvements_facet_description_1"
 msgid "This table lists possible opportunities to improve the nutritional quality, the Nutri-Score and the composition of food products."
-msgstr "Bảng này liệt kê các phần có thể để cải thiện chất lượng dinh dưỡng, Điểm dinh dưỡng và thành phần của các sản phẩm thực phẩm."
+msgstr "Bảng này liệt kê các phần có thể để cải thiện chất lượng dinh dưỡng, Nutri-Score và thành phần của các sản phẩm thực phẩm."
 
 msgctxt "improvements_facet_description_2"
 msgid "In order to get relevant results, please make sure the product data is complete (nutrition facts with values for fiber and fruits and vegetables to compute the Nutri-Score, and a precise category to compare each product to similar products)."
-msgstr "Để có được kết quả phù hợp, vui lòng đảm bảo dữ liệu sản phẩm đầy đủ (thông tin dinh dưỡng với giá trị chất xơ, trái cây và rau quả để tính Điểm dinh dưỡng, và một danh mục chính xác để so sánh từng sản phẩm với các sản phẩm tương tự)."
+msgstr "Để có được kết quả phù hợp, vui lòng đảm bảo dữ liệu sản phẩm đầy đủ (thông tin dinh dưỡng với giá trị chất xơ, trái cây và rau quả để tính Nutri-Score, và một danh mục chính xác để so sánh từng sản phẩm với các sản phẩm tương tự)."
 
 # "product photos" in this sentence means photos for many products, not just one product
 msgctxt "import_photos_title"
@@ -4069,7 +4064,7 @@ msgstr "Tập tin đã được nhận"
 
 msgctxt "nutriscore_calculation_details"
 msgid "Details of the calculation of the Nutri-Score"
-msgstr "Chi tiết về cách tính điểm dinh dưỡng"
+msgstr "Chi tiết về cách tính Nutri-Score"
 
 msgctxt "nutriscore_is_beverage"
 msgid "This product is considered a beverage for the calculation of the Nutri-Score."
@@ -4154,17 +4149,17 @@ msgstr "Điểm dinh dưỡng"
 # Do not translate
 msgctxt "nutriscore_grade"
 msgid "Nutri-Score"
-msgstr "Điểm dinh dưỡng"
+msgstr "Nutri-Score"
 
 # This is not the Nutri-Score grade with letters, but the Nutri-Score number score used to compute the grade. Translate score but not Nutri-Score.
 msgctxt "nutriscore_score_producer"
 msgid "Nutri-Score score"
-msgstr "Điểm dinh dưỡng"
+msgstr "Nutri-Score"
 
 # Do not translate
 msgctxt "nutriscore_grade_producer"
 msgid "Nutri-Score"
-msgstr "Điểm dinh dưỡng"
+msgstr "Nutri-Score"
 
 # free as in not costing something
 msgctxt "donate_free_and_independent"
@@ -4196,7 +4191,7 @@ msgstr "Giá trị trung bình cho danh mục %s"
 # Keep the %s
 msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
-msgstr "Điểm dinh dưỡng có thể được thay đổi từ %s thành %s bằng cách thay đổi giá trị %s từ %s thành %s (chênh lệch %s phần trăm)."
+msgstr "Nutri-Score có thể được thay đổi từ %s thành %s bằng cách thay đổi giá trị %s từ %s thành %s (chênh lệch %s phần trăm)."
 
 msgctxt "export_products_to_public_database_email"
 msgid "The platform for producers is still under development and we make manual checks before importing products to the public database. Please e-mail us at <a href=\"mailto:producers@openfoodfacts.org\">producers@openfoodfacts.org</a> to update the public database."
@@ -4335,19 +4330,19 @@ msgstr "Nhập Danh Mục"
 
 msgctxt "nutri_score_score_from_producer"
 msgid "Nutri-Score score from producer"
-msgstr "Điểm dinh dưỡng từ nhà sản xuất"
+msgstr "Nutri-Score từ nhà sản xuất"
 
 msgctxt "nutri_score_score_calculated"
 msgid "Calculated Nutri-Score score"
-msgstr "Điểm Dinh dưỡng được tính"
+msgstr "Nutri-Score được tính"
 
 msgctxt "nutri_score_grade_from_producer"
 msgid "Nutri-Score grade from producer"
-msgstr "Mức điểm dinh dưỡng từ nhà sản xuất"
+msgstr "Nutri-Score từ nhà sản xuất"
 
 msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
-msgstr "Mức điểm dinh dưỡng được tính"
+msgstr "Nutri-Score được tính"
 
 msgctxt "scanned_code"
 msgid "Scanned code"
@@ -4572,7 +4567,7 @@ msgstr "Mã nội bộ được nhà sản xuất sử dụng để xác định
 
 msgctxt "categories_import_note"
 msgid "Providing a category is very important to make the product easy to search for, and to compute the Nutri-Score"
-msgstr "Việc cung cấp danh mục là rất quan trọng để giúp sản phẩm có thể được dễ dàng tìm kiếm và tính toán Điểm dinh dưỡng"
+msgstr "Việc cung cấp danh mục là rất quan trọng để giúp sản phẩm có thể được dễ dàng tìm kiếm và tính toán Nutri-Score"
 
 msgctxt "labels_import_note"
 msgid "Some labels such as the organic label are used to filter and/or rank search results, so it is strongly recommended to specify them."
@@ -4698,7 +4693,7 @@ msgstr "Chất lượng dinh dưỡng"
 
 msgctxt "attribute_nutriscore_name"
 msgid "Nutri-Score"
-msgstr "Điểm dinh dưỡng"
+msgstr "Nutri-Score"
 
 msgctxt "attribute_nutriscore_setting_name"
 msgid "Good nutritional quality (Nutri-Score)"
@@ -4706,20 +4701,20 @@ msgstr "Chất lượng dinh dưỡng tốt (Nutri-Score)"
 
 msgctxt "attribute_nutriscore_setting_note"
 msgid "The Nutri-Score is computed and can be taken into account for all products, even if is not displayed on the packaging."
-msgstr "Điểm Dinh Dưỡng được tính toán và có thể được tính đến cho tất cả các sản phẩm, ngay cả khi không được hiển thị trên bao bì."
+msgstr "Nutri-Score được tính toán và có thể được tính đến cho tất cả các sản phẩm, ngay cả khi không được hiển thị trên bao bì."
 
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "Điểm dinh dưỡng %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
-msgstr "Điểm dinh dưỡng không xác định"
+msgstr "Nutri-Score không xác định"
 
 msgctxt "attribute_nutriscore_unknown_description_short"
 msgid "Missing data to compute the Nutri-Score"
-msgstr "Thiếu dữ liệu để tính điểm dinh dưỡng"
+msgstr "Thiếu dữ liệu để tính Nutri-Score"
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
@@ -4836,19 +4831,19 @@ msgstr "Người dùng không xác định."
 
 msgctxt "attribute_low_salt_setting_note"
 msgid "The salt level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low salt diet."
-msgstr "Mức độ muối được tính đến bởi Điểm Dinh Dưỡng. Chỉ sử dụng cài đặt này nếu bạn đang thực hiện chế độ ăn kiêng ít muối."
+msgstr "Mức độ muối được tính đến bởi Nutri-Score. Chỉ sử dụng cài đặt này nếu bạn đang thực hiện chế độ ăn kiêng ít muối."
 
 msgctxt "attribute_low_sugars_setting_note"
 msgid "The sugars level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low sugars diet."
-msgstr "Mức độ đường được tính đến bởi Điểm Dinh Dưỡng. Chỉ sử dụng cài đặt này nếu bạn đang thực hiện chế độ ăn kiêng ít đường."
+msgstr "Mức độ đường được tính đến bởi Nutri-Score. Chỉ sử dụng cài đặt này nếu bạn đang thực hiện chế độ ăn kiêng ít đường."
 
 msgctxt "attribute_low_fat_setting_note"
 msgid "The fat level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low fat diet."
-msgstr "Mức độ chất béo được tính đến bởi Điểm Dinh Dưỡng. Chỉ sử dụng cài đặt này nếu bạn đang thực hiện chế độ ăn kiêng ít béo."
+msgstr "Mức độ chất béo được tính đến bởi Nutri-Score. Chỉ sử dụng cài đặt này nếu bạn đang thực hiện chế độ ăn kiêng ít béo."
 
 msgctxt "attribute_low_saturated_fat_setting_note"
 msgid "The saturated fat level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low saturated fat diet."
-msgstr "Mức độ chất béo chuyển hóa được tính đến bởi Điểm Dinh Dưỡng. Chỉ sử dụng cài đặt này nếu bạn đang thực hiện chế độ ăn kiêng ít chất béo chuyển hóa."
+msgstr "Mức độ chất béo chuyển hóa được tính đến bởi Nutri-Score. Chỉ sử dụng cài đặt này nếu bạn đang thực hiện chế độ ăn kiêng ít chất béo chuyển hóa."
 
 msgctxt "attribute_group_allergens_name"
 msgid "Allergens"
@@ -4949,7 +4944,7 @@ msgstr "Môi trường"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "Điểm sinh thái"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4962,7 +4957,7 @@ msgstr "Điểm Xanh (Green-Score) là thang điểm đánh giá môi trường 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "Điểm sinh thái"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
@@ -4975,7 +4970,7 @@ msgstr "Điểm Xanh (Green-Score) là thang điểm đánh giá môi trường 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "Điểm sinh thái %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5161,12 +5156,12 @@ msgstr "Tác động môi trường"
 # Numerical score for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_score"
 msgid "Green-Score score"
-msgstr "Điểm số Xanh"
+msgstr "Green-Score"
 
 # Letter grade from A to E for the Green-Score (do not translate Green-Score)
 msgctxt "environmental_score_grade"
 msgid "Green-Score grade"
-msgstr "Điểm Xanh"
+msgstr "Green-Score"
 
 # do not translate Green-Score
 msgctxt "environmental_score_calculation_details"
@@ -5176,7 +5171,7 @@ msgstr "Chi tiết về cách tính điểm Xanh (Green-Score)"
 # do not translate Green-Score
 msgctxt "environmental_score_information"
 msgid "Information about the Green-Score"
-msgstr "Thông tin về điểm Xanh"
+msgstr "Thông tin về Green-Score"
 
 msgctxt "preferences_currently_selected_preferences"
 msgid "Currently selected preferences"
@@ -5213,19 +5208,19 @@ msgstr "Thiếu thông tin dinh dưỡng cho sản phẩm đã chế biến"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "Điểm sinh thái"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "Điểm sinh thái"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "Điểm sinh thái"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "Điểm sinh thái"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5473,11 +5468,11 @@ msgstr "Sản phẩm được quét nhiều nhất"
 
 msgctxt "sort_by_nutriscore_score"
 msgid "Products with the best Nutri-Score"
-msgstr "Sản phẩm có điểm Dinh Dưỡng tốt nhất"
+msgstr "Sản phẩm có Nutri-Score tốt nhất"
 
 msgctxt "sort_by_environmental_score_score"
 msgid "Products with the best Green-Score"
-msgstr "Sản phẩm có Điểm Sinh Thái tốt nhất"
+msgstr "Sản phẩm có Green-Score tốt nhất"
 
 msgctxt "sort_by_created_t"
 msgid "Recently added products"
@@ -5531,7 +5526,7 @@ msgstr "Người dùng đang bị xóa. Có thể sẽ mất vài phút."
 
 msgctxt "attribute_environmental_score_not_applicable_title"
 msgid "Green-Score not applicable"
-msgstr "Điểm xanh không áp dụng"
+msgstr "Green-Score không áp dụng"
 
 msgctxt "attribute_environmental_score_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -5544,11 +5539,11 @@ msgstr "Chưa áp dụng cho danh mục: {category}"
 
 msgctxt "environmental_score_not_applicable_coming_soon"
 msgid "The Green-Score is not yet applicable for this category, but we are working on adding support for it."
-msgstr "Điểm sinh thái vẫn chưa áp dụng cho danh mục này, nhưng chúng tôi đang nỗ lực bổ sung hỗ trợ cho danh mục này."
+msgstr "Green-Score vẫn chưa áp dụng cho danh mục này, nhưng chúng tôi đang nỗ lực bổ sung hỗ trợ cho danh mục này."
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "Điểm sinh thái không được tính"
+msgstr "Green-Score không được tính"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5560,7 +5555,7 @@ msgstr "Thiếu một danh mục chính xác"
 
 msgctxt "environmental_score_unknown_call_to_help"
 msgid "We could not compute the Green-Score of this product as it is missing some data, could you help complete it?"
-msgstr "Chúng tôi không thể tính Điểm số sinh thái cho sản phẩm này vì còn thiếu một số dữ liệu, bạn có thể giúp chúng tôi bổ sung thêm được không?"
+msgstr "Chúng tôi không thể tính Green-Score cho sản phẩm này vì còn thiếu một số dữ liệu, bạn có thể giúp chúng tôi bổ sung thêm được không?"
 
 msgctxt "org_list_of_gs1_gln_description"
 msgid "GS1 data is automatically associated with an OFF organization identifier that corresponds to the GS1 partyName field. To change the OFF organization identifier, you can directly assign 1 or more GS1 GLN identifiers."
@@ -5668,7 +5663,7 @@ msgstr "Một số dữ liệu cho sản phẩm của %s đến từ %s."
 
 msgctxt "data_source_database_note_about_the_producers_platform"
 msgid "Manufacturers can use the Open Food Facts <a href=\"<producers_platform_url>\">free plaform for producers</a> to access and complete this data, and to obtain reports, analysis and product improvements opportunities (e.g. better Nutri-Score)."
-msgstr "Các nhà sản xuất có thể sử dụng <a href=\"<producers_platform_url>\"> nền tảng miễn phí dành cho các nhà sản xuất</a> của Open Food Facts để truy cập và hoàn thành dữ liệu này, đồng thời có thêm các báo cáo, phân tích và cơ hội cải tiến sản phẩm (ví dụ: Điểm dinh dưỡng tốt hơn)."
+msgstr "Các nhà sản xuất có thể sử dụng <a href=\"<producers_platform_url>\"> nền tảng miễn phí dành cho các nhà sản xuất</a> của Open Food Facts để truy cập và hoàn thành dữ liệu này, đồng thời có thêm các báo cáo, phân tích và cơ hội cải tiến sản phẩm (ví dụ: Nutri-Score tốt hơn)."
 
 # variable names between { } must not be translated
 msgctxt "f_data_source_database_provider"
@@ -5690,7 +5685,7 @@ msgstr "Dấu chân sinh thái được tính bằng cách tính đến các ngu
 
 msgctxt "environmental_score_agribalyse_match_warning"
 msgid "The Green-Score can only be calculated if the product has a sufficiently precise category."
-msgstr "Điểm sinh thái chỉ có thể được tính nếu sản phẩm có danh mục đủ chính xác."
+msgstr "Green-Score chỉ có thể được tính nếu sản phẩm có danh mục đủ chính xác."
 
 msgctxt "environmental_score_add_more_precise_category"
 msgid "You can modify the product page to add a more precise category."
@@ -5702,7 +5697,7 @@ msgstr "Nếu bạn là nhà sản xuất của sản phẩm này, bạn có th�
 
 msgctxt "environmental_score_warning_missing_information"
 msgid "Warning: some information necessary to calculate the Green-Score with precision is not provided (see the details of the calculation below)."
-msgstr "Cảnh báo: một số thông tin cần thiết để tính Điểm sinh thái với độ chính xác không được cung cấp (xem chi tiết cách tính bên dưới)."
+msgstr "Cảnh báo: một số thông tin cần thiết để tính Green-Score với độ chính xác không được cung cấp (xem chi tiết cách tính bên dưới)."
 
 msgctxt "environmental_score_add_missing_information"
 msgid "You can edit the product to add the missing information."
@@ -5857,12 +5852,12 @@ msgstr "Thông tin về bao bì của sản phẩm này không đủ chính xác
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can modify the product page and add them."
-msgstr "Để tính toán chính xác hơn Điểm sinh thái, bạn có thể sửa đổi và thêm trang thông tin sản phẩm."
+msgstr "Để tính toán chính xác hơn Green-Score, bạn có thể sửa đổi và thêm trang thông tin sản phẩm."
 
 # duplicate
 msgctxt "environmental_score_edit_for_more_precise_environmental_score"
 msgid "For a more precise calculation of the Green-Score, you can edit the product page and add them."
-msgstr "Để tính toán chính xác hơn Điểm sinh thái, bạn có thể chỉnh sửa và bổ sung thêm trang thông tin về sản phẩm."
+msgstr "Để tính toán chính xác hơn Green-Score, bạn có thể chỉnh sửa và bổ sung thêm trang thông tin về sản phẩm."
 
 msgctxt "environmental_score_final_score"
 msgid "Final score"
@@ -5884,12 +5879,12 @@ msgstr "Nếu bạn là nhà sản xuất của sản phẩm này, bạn có th�
 # do not translate Green-Score and the link
 msgctxt "environmental_score_description"
 msgid "The <a href=\"/green-score\">Green-Score</a> is an experimental score that summarizes the environmental impacts of food products."
-msgstr "<a href=\"/green-score\">Điểm sinh thái</a> là điểm số thử nghiệm tóm tắt các tác động môi trường của các sản phẩm thực phẩm."
+msgstr "<a href=\"/green-score\">Green-Score</a> là điểm số thử nghiệm tóm tắt các tác động môi trường của các sản phẩm thực phẩm."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_fr"
 msgid "The Green-Score formula is subject to change as it is regularly improved to make it more precise."
-msgstr "Công thức Điểm Sinh Thái có thể thay đổi vì nó thường xuyên được cải tiến để chính xác hơn."
+msgstr "Công thức Green-Score có thể thay đổi vì nó thường xuyên được cải tiến để chính xác hơn."
 
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
@@ -5906,7 +5901,7 @@ msgstr "Hiện chưa rõ tác động đầy đủ của việc vận chuyển �
 
 msgctxt "app_banner_text"
 msgid "Scan barcodes to get the Nutri-Score, the Green-Score and more!"
-msgstr "Quét mã vạch để nhận Điểm dinh dưỡng, Điểm sinh thái và hơn thế nữa!"
+msgstr "Quét mã vạch để nhận Nutri-Score, Green-Score và hơn thế nữa!"
 
 msgctxt "org_gs1_product_name_is_abbreviated"
 msgid "GS1 product names for this manufacturer are abbreviated."
@@ -5980,7 +5975,7 @@ msgstr "trung bình"
 
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
-msgstr "Lưu ý: Điểm dinh dưỡng của các loại trà và trà thảo mộc tương ứng với sản phẩm được pha chế chỉ với nước, không có đường hoặc sữa."
+msgstr "Lưu ý: Nutri-Score của các loại trà và trà thảo mộc tương ứng với sản phẩm được pha chế chỉ với nước, không có đường hoặc sữa."
 
 msgctxt "g_per_100g"
 msgid "%s g / 100 g"
@@ -6217,7 +6212,7 @@ msgstr "Điểm cộng và điểm trừ"
 
 msgctxt "environmental_score_for_this_product"
 msgid "Green-Score for this product"
-msgstr "Điểm Sinh Thái cho sản phẩm này"
+msgstr "Green-Score cho sản phẩm này"
 
 msgctxt "average_impact_of_the_category"
 msgid "Average impact of products of the same category"
@@ -6245,15 +6240,15 @@ msgstr "Điểm của các sản phẩm có vật liệu đóng gói không th�
 
 msgctxt "nutriscore_not_applicable"
 msgid "Nutri-Score not applicable for this product category."
-msgstr "Điểm Dinh Dưỡng không áp dụng cho danh mục sản phẩm này."
+msgstr "Nutri-Score không áp dụng cho danh mục sản phẩm này."
 
 msgctxt "nutriscore_missing_category"
 msgid "The category of the product must be specified in order to compute the Nutri-Score."
-msgstr "Danh mục của sản phẩm phải được xác định để tính Điểm Dinh Dưỡng."
+msgstr "Danh mục của sản phẩm phải được xác định để tính Nutri-Score."
 
 msgctxt "nutriscore_missing_nutrition_data"
 msgid "The nutrition facts of the product must be specified in order to compute the Nutri-Score."
-msgstr "Thông tin dinh dưỡng của sản phẩm phải được xác định để tính điểm Dinh Dưỡng."
+msgstr "Thông tin dinh dưỡng của sản phẩm phải được xác định để tính Nutri-Score."
 
 msgctxt "nutriscore_missing_nutrition_data_details"
 msgid "Missing nutrition facts:"
@@ -6265,7 +6260,7 @@ msgstr "Thông tin dinh dưỡng còn thiếu trong sản phẩm đã chế bi�
 
 msgctxt "nutriscore_missing_category_and_nutrition_data"
 msgid "The category and the nutrition facts of the product must be specified in order to compute the Nutri-Score."
-msgstr "Danh mục và thông tin dinh dưỡng của sản phẩm phải được xác định để tính Điểm Dinh Dưỡng."
+msgstr "Danh mục và thông tin dinh dưỡng của sản phẩm phải được xác định để tính Nutri-Score."
 
 msgctxt "health"
 msgid "Health"
@@ -6496,7 +6491,7 @@ msgstr ""
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "Tìm hiểu thêm về Điểm Sinh Thái"
+msgstr "Tìm hiểu thêm về Green-Score"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6534,7 +6529,7 @@ msgstr "Sử dụng tiêu chí mặc định"
 
 msgctxt "reset_preferences_details"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "Điểm dinh dưỡng, Điểm sinh thái và mức độ chế biến thực phẩm (NOVA)"
+msgstr "Nutri-Score, Green-Score và mức độ chế biến thực phẩm (NOVA)"
 
 msgctxt "actions_add_ingredients"
 msgid "Could you add the ingredients list?"
@@ -6542,15 +6537,15 @@ msgstr "Bạn có thể thêm danh sách thành phần không?"
 
 msgctxt "actions_to_compute_nutriscore"
 msgid "Could you add the information needed to compute the Nutri-Score?"
-msgstr "Bạn có thể thêm thông tin cần thiết để tính toán Điểm dinh dưỡng không?"
+msgstr "Bạn có thể thêm thông tin cần thiết để tính toán Nutri-Score không?"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "Bạn có thể thêm phân loại sản phẩm để chúng tôi có thể tính Điểm Sinh Thái không?"
+msgstr "Bạn có thể thêm phân loại sản phẩm để chúng tôi có thể tính Green-Score không?"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "Danh mục chúng tôi có cho sản phẩm này không đủ chính xác để tính Điểm Xanh. Bạn có thể thêm danh mục sản phẩm chính xác hơn không?"
+msgstr "Danh mục chúng tôi có cho sản phẩm này không đủ chính xác để tính Green-Score. Bạn có thể thêm danh mục sản phẩm chính xác hơn không?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7673,7 +7668,7 @@ msgstr "Nông nghiệp hữu cơ và thương mại công bằng"
 
 msgctxt "reset_preferences_details_food"
 msgid "Nutri-Score, Green-Score and food processing level (NOVA)"
-msgstr "Điểm dinh dưỡng, Điểm sinh thái và mức độ chế biến thực phẩm (NOVA)"
+msgstr "Nutri-Score, Green-Score và mức độ chế biến thực phẩm (NOVA)"
 
 msgctxt "reset_preferences_details_product"
 msgid "Good repairability"
@@ -7689,7 +7684,7 @@ msgstr "Báo cáo hình ảnh này cho người kiểm duyệt của chúng tôi
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "Chúng tôi đang thiếu giá trị khẩu phần ăn và/hoặc đơn vị để tính Điểm dinh dưỡng"
+msgstr "Chúng tôi đang thiếu giá trị khẩu phần ăn và/hoặc đơn vị để tính Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/vls.po
+++ b/po/common/vls.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/wa.po
+++ b/po/common/wa.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/wo.po
+++ b/po/common/wo.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/xh.po
+++ b/po/common/xh.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -7800,7 +7795,7 @@ msgstr "Asiyibhaqanga: {unwanted_ingredients}. Sisenokuba ziphosile ezinye izith
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "Ezo zinto zikhethwayo zisekwe kukuqonda okuVulekileyo kokutya koluhlu lwezithako kwaye kuhlala kukho ithuba lokuba ingachaneki okanye iphelele, soloko ujonga imveliso ngokwakho."
+msgstr "Ezo zinto zikhethwayo zisekwe kukuqonda Open Food Facts koluhlu lwezithako kwaye kuhlala kukho ithuba lokuba ingachaneki okanye iphelele, soloko ujonga imveliso ngokwakho."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/yi.po
+++ b/po/common/yi.po
@@ -42,7 +42,7 @@ msgstr "א קאלאבאראטיווע, פרייע און אפענע דאטאבא
 
 msgctxt "tagline_obf"
 msgid "Open Beauty Facts gathers information and data on cosmetic products from around the world."
-msgstr "אָפן ביוטי פאַקס זאַמלט אינפֿאָרמאַציע און דאַטן וועגן קאָסמעטישע פּראָדוקטן פֿון אַרום דער וועלט."
+msgstr "Open Beauty Facts זאַמלט אינפֿאָרמאַציע און דאַטן וועגן קאָסמעטישע פּראָדוקטן פֿון אַרום דער וועלט."
 
 msgctxt "footer_tagline_obf"
 msgid "A collaborative, free and open database of cosmetic products from around the world."
@@ -63,7 +63,7 @@ msgstr "און די <a href=\"https://www.facebook.com/groups/OpenBeautyFacts/\"
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "עפֿענען שיינקייט פאַקטן פּראָדוקט זוכן"
+msgstr "עפֿענען Open Beauty Facts פּראָדוקט זוכן"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1756,11 +1756,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4704,7 +4699,7 @@ msgstr ""
 
 msgctxt "attribute_nutriscore_not_applicable_title"
 msgid "Nutri-Score not applicable"
-msgstr "נוטרי-סקאָר נישט אָנווענדלעך"
+msgstr "Nutri-Score נישט אָנווענדלעך"
 
 msgctxt "attribute_nutriscore_not_applicable_description_short"
 msgid "Not applicable for the category"
@@ -4938,7 +4933,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "דער גרין-סקאָר איז אַן ענווייראָנמענטאַל סקאָר פון A+ ביז F וואָס מאַכט עס גרינג צו פאַרגלייַכן די פּראַל פון עסנוואַרג פּראָדוקטן אויף דער סביבה."
+msgstr "דער Green-Score איז אַן ענווייראָנמענטאַל סקאָר פון A+ ביז F וואָס מאַכט עס גרינג צו פאַרגלייַכן די פּראַל פון עסנוואַרג פּראָדוקטן אויף דער סביבה."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4951,7 +4946,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "דער גרין-סקאָר איז אַן ענווייראָנמענטאַל סקאָר פון A+ ביז F וואָס מאַכט עס גרינג צו פאַרגלייַכן די פּראַל פון עסנוואַרג פּראָדוקטן אויף דער סביבה."
+msgstr "דער Green-Score איז אַן ענווייראָנמענטאַל סקאָר פון A+ ביז F וואָס מאַכט עס גרינג צו פאַרגלייַכן די פּראַל פון עסנוואַרג פּראָדוקטן אויף דער סביבה."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5875,7 +5870,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "דער גרין-סקאָר איז אנהייב אנטוויקלט געוואָרן פֿאַר פֿראַנקרײַך און עס ווערט איצט אויסגעברייטערט צו אַנדערע אייראָפּעיִשע לענדער. די גרין-סקאָר פֿאָרמולע קען זיך ענדערן ווײַל עס ווערט קעסיידער פֿאַרבעסערט כּדי עס צו מאַכן מער פּינקטלעך און בעסער פּאַסיק פֿאַר יעדן לאַנד."
+msgstr "דער Green-Score איז אנהייב אנטוויקלט געוואָרן פֿאַר פֿראַנקרײַך און עס ווערט איצט אויסגעברייטערט צו אַנדערע אייראָפּעיִשע לענדער. די Green-Score פֿאָרמולע קען זיך ענדערן ווײַל עס ווערט קעסיידער פֿאַרבעסערט כּדי עס צו מאַכן מער פּינקטלעך און בעסער פּאַסיק פֿאַר יעדן לאַנד."
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6531,7 +6526,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "די קאַטעגאָריע וואָס מיר האָבן פֿאַר דעם פּראָדוקט איז נישט פּינקטלעך גענוג צו רעכענען דעם גרין-סקאָר. קענט איר צולייגן אַ מער פּינקטלעכע פּראָדוקט קאַטעגאָריע?"
+msgstr "די קאַטעגאָריע וואָס מיר האָבן פֿאַר דעם פּראָדוקט איז נישט פּינקטלעך גענוג צו רעכענען דעם Green-Score. קענט איר צולייגן אַ מער פּינקטלעכע פּראָדוקט קאַטעגאָריע?"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7670,7 +7665,7 @@ msgstr "מעלדן דעם בילד צו אונדזערע מאדעראטארן"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "מיר פעלט די סערווינג גרייס ווערט און/אדער איינהייט צו רעכענען די נוטרי-סקאָר"
+msgstr "מיר פעלט די סערווינג גרייס ווערט און/אדער איינהייט צו רעכענען די Nutri-Score"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/yo.po
+++ b/po/common/yo.po
@@ -63,7 +63,7 @@ msgstr "àti ẹgbẹ́ Facebook <a href=\"https://www.facebook.com/groups/OpenB
 
 msgctxt "search_description_opensearch_obf"
 msgid "Open Beauty Facts product search"
-msgstr "Ṣíṣí ọjà Àwọn Òtítọ́ Ẹ̀wà Ṣíṣí"
+msgstr "Ṣíṣí ọjà Open Beauty Facts"
 
 msgctxt "warning_not_complete_obf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal mobile app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
@@ -1757,11 +1757,6 @@ msgstr ""
 
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
-msgstr ""
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 msgstr ""
 
 # Do not change the lang code if the blog doesn't exist in your language
@@ -4939,7 +4934,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Àmì Àwọ̀ Ewé jẹ́ àmì àyíká láti A+ sí F èyí tí ó mú kí ó rọrùn láti fi wé ipa tí àwọn oúnjẹ oúnjẹ ní lórí àyíká."
+msgstr "Green-Score jẹ́ àmì àyíká láti A+ sí F èyí tí ó mú kí ó rọrùn láti fi wé ipa tí àwọn oúnjẹ oúnjẹ ní lórí àyíká."
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4952,7 +4947,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "Àmì Àwọ̀ Ewé jẹ́ àmì àyíká láti A+ sí F èyí tí ó mú kí ó rọrùn láti fi wé ipa tí àwọn oúnjẹ oúnjẹ ní lórí àyíká."
+msgstr "Green-Score jẹ́ àmì àyíká láti A+ sí F èyí tí ó mú kí ó rọrùn láti fi wé ipa tí àwọn oúnjẹ oúnjẹ ní lórí àyíká."
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -7675,11 +7670,11 @@ msgstr "A padanu iye iwọn iṣẹ ati/tabi ẹyọkan lati ṣe iṣiro Nutri-
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> ṣe nipasẹ ẹgbẹ ti kii ṣe ere, ominira lati ile-iṣẹ naa. O ti wa ni ṣe fun gbogbo, nipa gbogbo, ati awọn ti o ti wa ni agbateru nipa gbogbo. O le ṣe atilẹyin iṣẹ wa nipa ṣiṣetọrẹ si Awọn Otitọ Ounjẹ Ṣii.<br/><b>O seun!</b>"
+msgstr "<<site_name>> ṣe nipasẹ ẹgbẹ ti kii ṣe ere, ominira lati ile-iṣẹ naa. O ti wa ni ṣe fun gbogbo, nipa gbogbo, ati awọn ti o ti wa ni agbateru nipa gbogbo. O le ṣe atilẹyin iṣẹ wa nipa ṣiṣetọrẹ si Open Food Facts.<br/><b>O seun!</b>"
 
 msgctxt "bottom_content_split_with_lilo"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts and also by using the Lilo search engine.<br/><b>Thank you!</b>"
-msgstr "<<site_name>> ṣe nipasẹ ẹgbẹ ti kii ṣe ere, ominira lati ile-iṣẹ naa. O ti wa ni ṣe fun gbogbo, nipa gbogbo, ati awọn ti o ti wa ni agbateru nipa gbogbo. O le ṣe atilẹyin iṣẹ wa nipa ṣiṣetọrẹ si Awọn Otitọ Ounjẹ Ṣii ati paapaa nipa lilo ẹrọ wiwa Lilo.<br/><b>O seun!</b>"
+msgstr "<<site_name>> ṣe nipasẹ ẹgbẹ ti kii ṣe ere, ominira lati ile-iṣẹ naa. O ti wa ni ṣe fun gbogbo, nipa gbogbo, ati awọn ti o ti wa ni agbateru nipa gbogbo. O le ṣe atilẹyin iṣẹ wa nipa ṣiṣetọrẹ si Open Food Facts ati paapaa nipa lilo ẹrọ wiwa Lilo.<br/><b>O seun!</b>"
 
 msgctxt "lilo_search_engine"
 msgid "Lilo search engine"
@@ -7687,7 +7682,7 @@ msgstr "Lilo search engine"
 
 msgctxt "robots_not_served_here"
 msgid "Due to heavy abuse from robots, we are unable to serve this page to unidentified users. Please create a free Open Food Facts account to access all of Open Food Facts."
-msgstr "Nitori ilokulo nla lati ọdọ awọn roboti, a ko lagbara lati sin oju-iwe yii si awọn olumulo ti a ko mọ. Jọwọ ṣẹda akọọlẹ Ṣiṣii Awọn Otitọ Ounjẹ ọfẹ lati wọle si gbogbo Awọn Otitọ Ounje Ṣii."
+msgstr "Nitori ilokulo nla lati ọdọ awọn roboti, a ko lagbara lati sin oju-iwe yii si awọn olumulo ti a ko mọ. Jọwọ ṣẹda akọọlẹ Open Food Facts ọfẹ lati wọle si gbogbo Open Food Facts."
 
 msgctxt "origin_of_ingredients"
 msgid "Origin of ingredients"
@@ -7773,7 +7768,7 @@ msgstr "Awọn eroja ti aifẹ"
 
 msgctxt "attribute_unwanted_ingredients_note"
 msgid "This preference is based on Open Food Facts' understanding of the ingredient list and may not be accurate, always check the product yourself."
-msgstr "Iyanfẹ yii da lori Oye Awọn Otitọ Ounjẹ Ṣii ti atokọ eroja ati pe o le ma ṣe deede, nigbagbogbo ṣayẹwo ọja funrararẹ."
+msgstr "Iyanfẹ yii da lori Oye Open Food Facts ti atokọ eroja ati pe o le ma ṣe deede, nigbagbogbo ṣayẹwo ọja funrararẹ."
 
 msgctxt "presence_of_unwanted_ingredients_unknown"
 msgid "Presence of unwanted ingredients unknown"
@@ -7801,7 +7796,7 @@ msgstr "A ko ri: {unwanted_ingredients}. A le ti padanu diẹ ninu awọn eroja,
 
 msgctxt "attribute_group_ingredients_analysis_warning"
 msgid "Those preferences are based on Open Food Facts' understanding of the ingredient list and there is always a possibility that it may not be accurate or complete, always check the product yourself."
-msgstr "Awọn ayanfẹ wọnyẹn da lori oye Awọn Otitọ Ounjẹ Ṣiṣii ti atokọ eroja ati pe o ṣeeṣe nigbagbogbo pe o le ma jẹ deede tabi pipe, nigbagbogbo ṣayẹwo ọja funrararẹ."
+msgstr "Awọn ayanfẹ wọnyẹn da lori oye Open Food Facts ti atokọ eroja ati pe o ṣeeṣe nigbagbogbo pe o le ma jẹ deede tabi pipe, nigbagbogbo ṣayẹwo ọja funrararẹ."
 
 msgctxt "external_sources_empreinte_souffrance_name"
 msgid "Suffering Footprint"

--- a/po/common/zea.po
+++ b/po/common/zea.po
@@ -1622,11 +1622,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/zh.po
+++ b/po/common/zh.po
@@ -21,7 +21,7 @@ msgstr "全球共同开发一个免费开放的数据库，其中涵盖了食品
 
 msgctxt "tagline_off"
 msgid "Open Food Facts gathers information and data on food products from around the world."
-msgstr "打开Food Facts收集来自全世界各地的化妆品产品信息和数据"
+msgstr "Open Food Facts收集来自全世界各地的化妆品产品信息和数据"
 
 msgctxt "footer_tagline_off"
 msgid "A collaborative, free and open database of food products from around the world."
@@ -976,7 +976,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "向制造商公开食品成分"
+msgstr "面向生产者的 Open Food Facts"
 
 msgctxt "for"
 msgid "for"
@@ -1657,7 +1657,7 @@ msgstr "表格默认列出了经常指定的营养素，如果不在标签上，
 
 msgctxt "nutrition_data_table_asterisk"
 msgid "Essential nutrients to calculate the Nutri-Score."
-msgstr "计算营养分数的必需营养素。"
+msgstr "计算Nutri-Score的必需营养素。"
 
 msgctxt "nutrition_grades_p"
 msgid "Nutrition grades"
@@ -1666,11 +1666,6 @@ msgstr "营养等级"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "营养等级"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -3417,7 +3412,7 @@ msgstr "上传包含产品数据的电子表格文件(Excel文件或逗号或tab
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "import_data_file_format"
 msgid "You can upload a table with the columns Open Food Facts import format, or you can upload a table in any format and then select the columns to import."
-msgstr "您可以上传一个带公开食物事实网站导入格式的表，或者您可以上传任何格式的表，然后选择要导入的列。"
+msgstr "您可以上传一个带Open Food Facts导入格式的表，或者您可以上传任何格式的表，然后选择要导入的列。"
 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "upload_product_data_file"
@@ -3646,17 +3641,17 @@ msgstr "平台生产商"
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_description"
 msgid "The platform for producers allows manufacturers to easily manage their product photos and data on Open Food Facts."
-msgstr "该平台允许生产商轻松管理他们的产品照片和数据在公开食品事实网站。"
+msgstr "该平台允许生产商轻松管理他们的产品照片和数据在Open Food Facts网站。"
 
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_private_database"
 msgid "The product data and photos you send on the platform for producers are stored in a private database. You will be able to check that all the data is correct before making it available on the public Open Food Facts database."
-msgstr "你在平台上为生产者发送的产品数据和照片存储在一个私有数据库中。您将能够检查所有的数据是正确的，然后将其公开食品事实网站数据库。"
+msgstr "你在平台上为生产者发送的产品数据和照片存储在一个私有数据库中。您将能够检查所有的数据是正确的，然后将其Open Food Facts网站数据库。"
 
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_licence"
 msgid "The product data and photos will become publicly available in the Open Food Facts database, under the <a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">Open Database License</a>. Individual contents of the database are available under the <a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">Database Contents License</a> and products images are available under the <a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike licence</a>."
-msgstr "产品数据和照片将在开放食品事实数据库中公开，根据<a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">开放数据库许可证</a>。数据库的个别内容可在<a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">数据库内容许可证</a>下获得，产品图片可在<a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike许可证</a>下获得。"
+msgstr "产品数据和照片将在Open Food Facts数据库中公开，根据<a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">开放数据库许可证</a>。数据库的个别内容可在<a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">数据库内容许可证</a>下获得，产品图片可在<a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike许可证</a>下获得。"
 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "import_product_data"
@@ -3905,11 +3900,11 @@ msgstr "有改进机会的产品数量"
 
 msgctxt "improvements_facet_description_1"
 msgid "This table lists possible opportunities to improve the nutritional quality, the Nutri-Score and the composition of food products."
-msgstr "该表列出了改善营养质量、营养分数和食品成分的可能机会。"
+msgstr "该表列出了改善营养质量、Nutri-Score和食品成分的可能机会。"
 
 msgctxt "improvements_facet_description_2"
 msgid "In order to get relevant results, please make sure the product data is complete (nutrition facts with values for fiber and fruits and vegetables to compute the Nutri-Score, and a precise category to compare each product to similar products)."
-msgstr "为了得到相关结果，请确保产品数据完整(含纤维和水果蔬菜值的营养事实，以计算营养评分，以及一个精确的类别，以比较每个产品与类似的产品)。"
+msgstr "为了得到相关结果，请确保产品数据完整(含纤维和水果蔬菜值的营养事实，以计算Nutri-Score，以及一个精确的类别，以比较每个产品与类似的产品)。"
 
 # "product photos" in this sentence means photos for many products, not just one product
 msgctxt "import_photos_title"
@@ -3978,15 +3973,15 @@ msgstr "文件收到了"
 
 msgctxt "nutriscore_calculation_details"
 msgid "Details of the calculation of the Nutri-Score"
-msgstr "详细计算营养分数"
+msgstr "详细计算Nutri-Score"
 
 msgctxt "nutriscore_is_beverage"
 msgid "This product is considered a beverage for the calculation of the Nutri-Score."
-msgstr "该产品被认为是一种饮料的计算营养分数。"
+msgstr "该产品被认为是一种饮料的计算Nutri-Score。"
 
 msgctxt "nutriscore_is_not_beverage"
 msgid "This product is not considered a beverage for the calculation of the Nutri-Score."
-msgstr "在计算营养分数时，产品是否不被认为是饮料"
+msgstr "在计算Nutri-Score时，产品是否不被认为是饮料"
 
 msgctxt "nutriscore_positive_points"
 msgid "Positive points"
@@ -4063,17 +4058,17 @@ msgstr "营养评分"
 # Do not translate
 msgctxt "nutriscore_grade"
 msgid "Nutri-Score"
-msgstr "营养价值评分"
+msgstr "Nutri-Score"
 
 # This is not the Nutri-Score grade with letters, but the Nutri-Score number score used to compute the grade. Translate score but not Nutri-Score.
 msgctxt "nutriscore_score_producer"
 msgid "Nutri-Score score"
-msgstr "营养分数"
+msgstr "Nutri-Score"
 
 # Do not translate
 msgctxt "nutriscore_grade_producer"
 msgid "Nutri-Score"
-msgstr "营养价值评分"
+msgstr "Nutri-Score"
 
 # free as in not costing something
 msgctxt "donate_free_and_independent"
@@ -4105,7 +4100,7 @@ msgstr "%s类别的平均值"
 # Keep the %s
 msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
-msgstr "通过将%s的值从%s更改为%s (%s的百分比差异)，可以将营养分数从%s更改为%s。"
+msgstr "通过将%s的值从%s更改为%s (%s的百分比差异)，可以将Nutri-Score从%s更改为%s。"
 
 msgctxt "export_products_to_public_database_email"
 msgid "The platform for producers is still under development and we make manual checks before importing products to the public database. Please e-mail us at <a href=\"mailto:producers@openfoodfacts.org\">producers@openfoodfacts.org</a> to update the public database."
@@ -4244,19 +4239,19 @@ msgstr "导入类别"
 
 msgctxt "nutri_score_score_from_producer"
 msgid "Nutri-Score score from producer"
-msgstr "来自制作人的营养评分"
+msgstr "来自制作人的Nutri-Score"
 
 msgctxt "nutri_score_score_calculated"
 msgid "Calculated Nutri-Score score"
-msgstr "计算营养分数"
+msgstr "计算Nutri-Score"
 
 msgctxt "nutri_score_grade_from_producer"
 msgid "Nutri-Score grade from producer"
-msgstr "由生产商提供的营养评分等级"
+msgstr "由生产商提供的Nutri-Score等级"
 
 msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
-msgstr "计算营养等级"
+msgstr "计算Nutri-Score"
 
 msgctxt "scanned_code"
 msgid "Scanned code"
@@ -4481,7 +4476,7 @@ msgstr "生产者在产品变化时用来识别特定版本的内部代码。"
 
 msgctxt "categories_import_note"
 msgid "Providing a category is very important to make the product easy to search for, and to compute the Nutri-Score"
-msgstr "提供一个类别对于使产品易于搜索和计算营养分数非常重要"
+msgstr "提供一个类别对于使产品易于搜索和计算Nutri-Score非常重要"
 
 msgctxt "labels_import_note"
 msgid "Some labels such as the organic label are used to filter and/or rank search results, so it is strongly recommended to specify them."
@@ -4501,7 +4496,7 @@ msgstr "产品标签上显示从A到E的Nutri-Score等级"
 
 msgctxt "nutriscore_grade_producer_import_note"
 msgid "Open Food Facts computes the Nutri-Score grade based on the information provided (nutrition facts and category). If the grade we compute is different from the grade you provide, you will get a private notification on the producers platform so that the difference can be resolved."
-msgstr "公开食物事实网站根据提供的信息(营养事实和类别) 计算营养评分等级。如果我们计算的等级与您提供的等级不同，您将在生产者平台上获得一个私有通知，以便解决差异。"
+msgstr "Open Food Facts根据提供的信息(营养事实和类别) 计算Nutri-Score等级。如果我们计算的等级与您提供的等级不同，您将在生产者平台上获得一个私有通知，以便解决差异。"
 
 msgctxt "nutriscore_score_producer_note"
 msgid "Nutri-Score score (numeric value from which the A to E grade is derived)"
@@ -4509,7 +4504,7 @@ msgstr "Nutri-Score 分数（A 至 E 等级的数值）"
 
 msgctxt "nutriscore_score_producer_import_note"
 msgid "Open Food Facts computes the Nutri-Score score based on the information provided (nutrition facts and category). If the score we compute is different from the score you provide, you will get a private notification on the producers platform so that the difference can be resolved."
-msgstr "公开食物事实网站根据提供的信息(营养事实和类别) 计算营养得分。如果我们计算的分数与您提供的分数不同，您将在生产者平台上获得一个私有通知，以便解决差异。"
+msgstr "Open Food Facts根据提供的信息(营养事实和类别) 计算Nutri-Score。如果我们计算的分数与您提供的分数不同，您将在生产者平台上获得一个私有通知，以便解决差异。"
 
 msgctxt "mandatory_field"
 msgid "Mandatory field"
@@ -4607,7 +4602,7 @@ msgstr "营养质量"
 
 msgctxt "attribute_nutriscore_name"
 msgid "Nutri-Score"
-msgstr "营养价值评分"
+msgstr "Nutri-Score"
 
 msgctxt "attribute_nutriscore_setting_name"
 msgid "Good nutritional quality (Nutri-Score)"
@@ -4620,7 +4615,7 @@ msgstr "Nutri-Score 是经过计算得到的，可以用于所有产品，即使
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "营养分数 %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
@@ -4675,7 +4670,7 @@ msgstr "NOVA集团"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
-msgstr "小组不计算"
+msgstr "NOVA不计算"
 
 msgctxt "attribute_nova_unknown_description_short"
 msgid "Food processing level unknown"
@@ -4683,7 +4678,7 @@ msgstr "食品加工水平未知"
 
 msgctxt "attribute_nova_setting_name"
 msgid "No or little food processing (NOVA group)"
-msgstr "没有或很少进行食品加工(小组)"
+msgstr "没有或很少进行食品加工(NOVA)"
 
 msgctxt "attribute_nova_setting_note"
 msgid "To determine the level of processing of a product, we rely on the list of ingredients (markers, processing methods) and categories."
@@ -4692,7 +4687,7 @@ msgstr "为了确定产品的加工水平，我们依靠配料表（标记、加
 # keep %s, it will be replaced by the group 1, 2, 3 or 4
 msgctxt "attribute_nova_group_title"
 msgid "NOVA %s"
-msgstr "小组%s"
+msgstr "NOVA %s"
 
 msgctxt "attribute_nova_1_description_short"
 msgid "Unprocessed or minimally processed foods"
@@ -4858,11 +4853,11 @@ msgstr "环境影响"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "低环境影响（生态得分）"
+msgstr "低环境影响（Green-Score）"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A to E which makes it easy to compare the impact of food products on the environment."
@@ -4871,11 +4866,11 @@ msgstr "Green-Score 是从 A 到 E 的环境评分，可以轻松比较食品对
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "低环境影响（生态得分）"
+msgstr "低环境影响（Green-Score）"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A to E which makes it easy to compare the impact of food products on the environment."
@@ -4884,7 +4879,7 @@ msgstr "Green-Score 是从 A 到 E 的环境评分，可以轻松比较食品对
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "生态得分 %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5122,19 +5117,19 @@ msgstr "缺少预制产品的营养成分表"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5457,7 +5452,7 @@ msgstr "Green-Score 尚不适用于此类别，但我们正在努力增加对它
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "未计算的生态分数"
+msgstr "未计算的Green-Score"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -6365,7 +6360,7 @@ msgstr "了解有关 Nutri-Score 的更多信息"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "了解有关生态评分的更多信息"
+msgstr "了解有关Green-Score的更多信息"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6415,11 +6410,11 @@ msgstr "您能否添加计算 Nutri-Score 所需的信息？"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "您能否对产品进行分类，以便我们能够计算生态得分？"
+msgstr "您能否对产品进行分类，以便我们能够计算Green-Score？"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "该产品的类别不够精确，无法计算绿色评分。您能否添加更精确的产品类别？"
+msgstr "该产品的类别不够精确，无法计算Green-Score。您能否添加更精确的产品类别？"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7311,7 +7306,7 @@ msgstr "没有 Nutri-Score 的产品数量"
 
 msgctxt "percent_of_products_with_nutriscore"
 msgid "% of products where Nutri-Score is computed"
-msgstr "计算营养价值评分的产品百分比"
+msgstr "计算Nutri-Score的产品百分比"
 
 msgctxt "products_to_be_exported"
 msgid "Products to be exported"
@@ -7551,7 +7546,7 @@ msgstr "向我们的版主举报此图片"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "我们缺少计算营养评分所需的份量值和/或单位"
+msgstr "我们缺少计算Nutri-Score所需的份量值和/或单位"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/zh_CN.po
+++ b/po/common/zh_CN.po
@@ -21,7 +21,7 @@ msgstr "全球共同开发一个免费开放的数据库，其中涵盖了食品
 
 msgctxt "tagline_off"
 msgid "Open Food Facts gathers information and data on food products from around the world."
-msgstr "打开Food Facts收集来自全世界各地的化妆品产品信息和数据"
+msgstr "Open Food Facts收集来自全世界各地的化妆品产品信息和数据"
 
 msgctxt "footer_tagline_off"
 msgid "A collaborative, free and open database of food products from around the world."
@@ -121,7 +121,7 @@ msgstr "Open Products Facts 产品搜索"
 
 msgctxt "warning_not_complete_opf"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "此商品页面不完整。 您可以通过编辑它和从照片中添加更多数据来帮助完成它。 或者通过使用 <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> 或 <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>的通用打开食品事实应用程序拍摄更多照片。 谢谢！"
+msgstr "此商品页面不完整。 您可以通过编辑它和从照片中添加更多数据来帮助完成它。 或者通过使用 <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> 或 <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>的通用Open Food Facts应用程序拍摄更多照片。 谢谢！"
 
 msgctxt "brands_example_product"
 msgid "Tide, Persil"
@@ -170,7 +170,7 @@ msgstr "Open Pet Food Facts产品搜索"
 
 msgctxt "warning_not_complete_opff"
 msgid "This product page is not complete. You can help to complete it by editing it and adding more data from the photos we have, or by taking more photos using the universal Open Food Facts app for <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> or <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>. Thank you!"
-msgstr "此商品页面不完整。 您可以通过编辑它和从照片中添加更多数据来帮助完成它。 或者通过使用 <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> 或 <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>的通用打开食品事实应用程序拍摄更多照片。 谢谢！"
+msgstr "此商品页面不完整。 您可以通过编辑它和从照片中添加更多数据来帮助完成它。 或者通过使用 <a href=\"https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=en\">Android</a> 或 <a href=\"https://apps.apple.com/us/app/open-food-facts-product-scan/id588797948\">iPhone/iPad</a>的通用Open Food Facts应用程序拍摄更多照片。 谢谢！"
 
 msgctxt "brands_example_petfood"
 msgid "Purina, Pedigree"
@@ -1072,7 +1072,7 @@ msgstr "https://world.openbeautyfacts.org"
 
 msgctxt "footer_pro"
 msgid "Open Food Facts for Producers"
-msgstr "向制造商公开食品成分"
+msgstr "面向生产者的 Open Food Facts"
 
 msgctxt "for"
 msgid "for"
@@ -1753,7 +1753,7 @@ msgstr "表格默认列出了经常指定的营养素，如果不在标签上，
 
 msgctxt "nutrition_data_table_asterisk"
 msgid "Essential nutrients to calculate the Nutri-Score."
-msgstr "计算营养分数的必需营养素。"
+msgstr "计算Nutri-Score的必需营养素。"
 
 msgctxt "nutrition_grades_p"
 msgid "Nutrition grades"
@@ -1762,11 +1762,6 @@ msgstr "营养等级"
 msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "营养等级"
-
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
 
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
@@ -3501,7 +3496,7 @@ msgstr "上传包含产品数据的电子表格文件(Excel文件或逗号或tab
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "import_data_file_format"
 msgid "You can upload a table with the columns Open Food Facts import format, or you can upload a table in any format and then select the columns to import."
-msgstr "您可以上传一个带公开食物事实网站导入格式的表，或者您可以上传任何格式的表，然后选择要导入的列。"
+msgstr "您可以上传一个带Open Food Facts导入格式的表，或者您可以上传任何格式的表，然后选择要导入的列。"
 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "upload_product_data_file"
@@ -3730,17 +3725,17 @@ msgstr "平台生产商"
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_description"
 msgid "The platform for producers allows manufacturers to easily manage their product photos and data on Open Food Facts."
-msgstr "该平台允许生产商轻松管理他们的产品照片和数据在公开食品事实网站。"
+msgstr "该平台允许生产商轻松管理他们的产品照片和数据在Open Food Facts网站。"
 
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_private_database"
 msgid "The product data and photos you send on the platform for producers are stored in a private database. You will be able to check that all the data is correct before making it available on the public Open Food Facts database."
-msgstr "你在平台上为生产者发送的产品数据和照片存储在一个私有数据库中。您将能够检查所有的数据是正确的，然后将其公开食品事实网站数据库。"
+msgstr "你在平台上为生产者发送的产品数据和照片存储在一个私有数据库中。您将能够检查所有的数据是正确的，然后将其Open Food Facts网站数据库。"
 
 # "product data and photos" in this sentence means data and photos for many products, not just one product
 msgctxt "producers_platform_licence"
 msgid "The product data and photos will become publicly available in the Open Food Facts database, under the <a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">Open Database License</a>. Individual contents of the database are available under the <a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">Database Contents License</a> and products images are available under the <a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike licence</a>."
-msgstr "产品数据和照片将在开放食品事实数据库中公开，根据<a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">开放数据库许可证</a>。数据库的个别内容可在<a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">数据库内容许可证</a>下获得，产品图片可在<a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike许可证</a>下获得。"
+msgstr "产品数据和照片将在Open Food Facts数据库中公开，根据<a href=\"https://opendatacommons.org/licenses/odbl/1.0/\">开放数据库许可证</a>。数据库的个别内容可在<a href=\"https://opendatacommons.org/licenses/dbcl/1.0/\">数据库内容许可证</a>下获得，产品图片可在<a href=\"https://creativecommons.org/licenses/by-sa/3.0/deed.en\">Creative Commons Attribution ShareAlike许可证</a>下获得。"
 
 # "product data" in this sentence means data for many products, not just one product
 msgctxt "import_product_data"
@@ -3989,11 +3984,11 @@ msgstr "有改进机会的产品数量"
 
 msgctxt "improvements_facet_description_1"
 msgid "This table lists possible opportunities to improve the nutritional quality, the Nutri-Score and the composition of food products."
-msgstr "该表列出了改善营养质量、营养分数和食品成分的可能机会。"
+msgstr "该表列出了改善营养质量、Nutri-Score和食品成分的可能机会。"
 
 msgctxt "improvements_facet_description_2"
 msgid "In order to get relevant results, please make sure the product data is complete (nutrition facts with values for fiber and fruits and vegetables to compute the Nutri-Score, and a precise category to compare each product to similar products)."
-msgstr "为了得到相关结果，请确保产品数据完整(含纤维和水果蔬菜值的营养事实，以计算营养评分，以及一个精确的类别，以比较每个产品与类似的产品)。"
+msgstr "为了得到相关结果，请确保产品数据完整(含纤维和水果蔬菜值的营养事实，以计算Nutri-Score，以及一个精确的类别，以比较每个产品与类似的产品)。"
 
 # "product photos" in this sentence means photos for many products, not just one product
 msgctxt "import_photos_title"
@@ -4062,15 +4057,15 @@ msgstr "文件收到了"
 
 msgctxt "nutriscore_calculation_details"
 msgid "Details of the calculation of the Nutri-Score"
-msgstr "详细计算营养分数"
+msgstr "详细计算Nutri-Score"
 
 msgctxt "nutriscore_is_beverage"
 msgid "This product is considered a beverage for the calculation of the Nutri-Score."
-msgstr "该产品被认为是一种饮料的计算营养分数。"
+msgstr "该产品被认为是一种饮料的计算Nutri-Score。"
 
 msgctxt "nutriscore_is_not_beverage"
 msgid "This product is not considered a beverage for the calculation of the Nutri-Score."
-msgstr "在计算营养分数时，产品是否不被认为是饮料"
+msgstr "在计算Nutri-Score时，产品是否不被认为是饮料"
 
 msgctxt "nutriscore_positive_points"
 msgid "Positive points"
@@ -4147,17 +4142,17 @@ msgstr "营养评分"
 # Do not translate
 msgctxt "nutriscore_grade"
 msgid "Nutri-Score"
-msgstr "营养价值评分"
+msgstr "Nutri-Score"
 
 # This is not the Nutri-Score grade with letters, but the Nutri-Score number score used to compute the grade. Translate score but not Nutri-Score.
 msgctxt "nutriscore_score_producer"
 msgid "Nutri-Score score"
-msgstr "营养分数"
+msgstr "Nutri-Score"
 
 # Do not translate
 msgctxt "nutriscore_grade_producer"
 msgid "Nutri-Score"
-msgstr "营养价值评分"
+msgstr "Nutri-Score"
 
 # free as in not costing something
 msgctxt "donate_free_and_independent"
@@ -4189,7 +4184,7 @@ msgstr "%s类别的平均值"
 # Keep the %s
 msgctxt "better_nutriscore"
 msgid "The Nutri-Score can be changed from %s to %s by changing the %s value from %s to %s (%s percent difference)."
-msgstr "通过将%s的值从%s更改为%s (%s的百分比差异)，可以将营养分数从%s更改为%s。"
+msgstr "通过将%s的值从%s更改为%s (%s的百分比差异)，可以将Nutri-Score从%s更改为%s。"
 
 msgctxt "export_products_to_public_database_email"
 msgid "The platform for producers is still under development and we make manual checks before importing products to the public database. Please e-mail us at <a href=\"mailto:producers@openfoodfacts.org\">producers@openfoodfacts.org</a> to update the public database."
@@ -4328,19 +4323,19 @@ msgstr "导入类别"
 
 msgctxt "nutri_score_score_from_producer"
 msgid "Nutri-Score score from producer"
-msgstr "来自制作人的营养评分"
+msgstr "来自制作人的Nutri-Score"
 
 msgctxt "nutri_score_score_calculated"
 msgid "Calculated Nutri-Score score"
-msgstr "计算营养分数"
+msgstr "计算Nutri-Score"
 
 msgctxt "nutri_score_grade_from_producer"
 msgid "Nutri-Score grade from producer"
-msgstr "由生产商提供的营养评分等级"
+msgstr "由生产商提供的Nutri-Score等级"
 
 msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
-msgstr "计算营养等级"
+msgstr "计算Nutri-Score"
 
 msgctxt "scanned_code"
 msgid "Scanned code"
@@ -4565,7 +4560,7 @@ msgstr "生产者在产品变化时用来识别特定版本的内部代码。"
 
 msgctxt "categories_import_note"
 msgid "Providing a category is very important to make the product easy to search for, and to compute the Nutri-Score"
-msgstr "提供一个类别对于使产品易于搜索和计算营养分数非常重要"
+msgstr "提供一个类别对于使产品易于搜索和计算Nutri-Score非常重要"
 
 msgctxt "labels_import_note"
 msgid "Some labels such as the organic label are used to filter and/or rank search results, so it is strongly recommended to specify them."
@@ -4585,7 +4580,7 @@ msgstr "产品标签上显示从A到E的Nutri-Score等级"
 
 msgctxt "nutriscore_grade_producer_import_note"
 msgid "Open Food Facts computes the Nutri-Score grade based on the information provided (nutrition facts and category). If the grade we compute is different from the grade you provide, you will get a private notification on the producers platform so that the difference can be resolved."
-msgstr "公开食物事实网站根据提供的信息(营养事实和类别) 计算营养评分等级。如果我们计算的等级与您提供的等级不同，您将在生产者平台上获得一个私有通知，以便解决差异。"
+msgstr "Open Food Facts根据提供的信息(营养事实和类别) 计算Nutri-Score等级。如果我们计算的等级与您提供的等级不同，您将在生产者平台上获得一个私有通知，以便解决差异。"
 
 msgctxt "nutriscore_score_producer_note"
 msgid "Nutri-Score score (numeric value from which the A to E grade is derived)"
@@ -4593,7 +4588,7 @@ msgstr "Nutri-Score 分数（A 至 E 等级的数值）"
 
 msgctxt "nutriscore_score_producer_import_note"
 msgid "Open Food Facts computes the Nutri-Score score based on the information provided (nutrition facts and category). If the score we compute is different from the score you provide, you will get a private notification on the producers platform so that the difference can be resolved."
-msgstr "公开食物事实网站根据提供的信息(营养事实和类别) 计算营养得分。如果我们计算的分数与您提供的分数不同，您将在生产者平台上获得一个私有通知，以便解决差异。"
+msgstr "Open Food Facts根据提供的信息(营养事实和类别) 计算Nutri-Score。如果我们计算的分数与您提供的分数不同，您将在生产者平台上获得一个私有通知，以便解决差异。"
 
 msgctxt "mandatory_field"
 msgid "Mandatory field"
@@ -4691,7 +4686,7 @@ msgstr "营养质量"
 
 msgctxt "attribute_nutriscore_name"
 msgid "Nutri-Score"
-msgstr "营养价值评分"
+msgstr "Nutri-Score"
 
 msgctxt "attribute_nutriscore_setting_name"
 msgid "Good nutritional quality (Nutri-Score)"
@@ -4704,7 +4699,7 @@ msgstr "Nutri-Score 是经过计算得到的，可以用于所有产品，即使
 # keep %s, it will be replaced by the letter A, B, C, D or E
 msgctxt "attribute_nutriscore_grade_title"
 msgid "Nutri-Score %s"
-msgstr "营养分数 %s"
+msgstr "Nutri-Score %s"
 
 msgctxt "attribute_nutriscore_unknown_title"
 msgid "Nutri-Score unknown"
@@ -4759,7 +4754,7 @@ msgstr "NOVA集团"
 
 msgctxt "attribute_nova_unknown_title"
 msgid "NOVA not computed"
-msgstr "小组不计算"
+msgstr "NOVA不计算"
 
 msgctxt "attribute_nova_unknown_description_short"
 msgid "Food processing level unknown"
@@ -4767,7 +4762,7 @@ msgstr "食品加工水平未知"
 
 msgctxt "attribute_nova_setting_name"
 msgid "No or little food processing (NOVA group)"
-msgstr "没有或很少进行食品加工(小组)"
+msgstr "没有或很少进行食品加工(NOVA)"
 
 msgctxt "attribute_nova_setting_note"
 msgid "To determine the level of processing of a product, we rely on the list of ingredients (markers, processing methods) and categories."
@@ -4776,7 +4771,7 @@ msgstr "为了确定产品的加工水平，我们依靠配料表（标记、加
 # keep %s, it will be replaced by the group 1, 2, 3 or 4
 msgctxt "attribute_nova_group_title"
 msgid "NOVA %s"
-msgstr "小组%s"
+msgstr "NOVA %s"
 
 msgctxt "attribute_nova_1_description_short"
 msgid "Unprocessed or minimally processed foods"
@@ -4942,33 +4937,33 @@ msgstr "环境影响"
 
 msgctxt "attribute_environmental_score_name"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "attribute_environmental_score_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "低环境影响（生态得分）"
+msgstr "低环境影响（Green-Score）"
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "绿色评分是一个从 A+ 到 F 的环境评分，可以方便地比较食品对环境的影响。"
+msgstr "Green-Score是一个从 A+ 到 F 的环境评分，可以方便地比较食品对环境的影响。"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "attribute_ecoscore_setting_name"
 msgid "Low environmental impact (Green-Score)"
-msgstr "低环境影响（生态得分）"
+msgstr "低环境影响（Green-Score）"
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "绿色评分是一个从 A+ 到 F 的环境评分，可以方便地比较食品对环境的影响。"
+msgstr "Green-Score是一个从 A+ 到 F 的环境评分，可以方便地比较食品对环境的影响。"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
 msgid "Green-Score %s"
-msgstr "生态得分 %s"
+msgstr "Green-Score %s"
 
 msgctxt "attribute_environmental_score_a_plus_description_short"
 msgid "Very low environmental impact"
@@ -5206,19 +5201,19 @@ msgstr "缺少预制产品的营养成分表"
 
 msgctxt "ecoscore_p"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "ecoscore_s"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_p"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "environmental_score_s"
 msgid "Green-Score"
-msgstr "绿色评分"
+msgstr "Green-Score"
 
 msgctxt "misc_p"
 msgid "Miscellaneous"
@@ -5541,7 +5536,7 @@ msgstr "Green-Score 尚不适用于此类别，但我们正在努力增加对它
 
 msgctxt "attribute_environmental_score_unknown_title"
 msgid "Green-Score not computed"
-msgstr "未计算的生态分数"
+msgstr "未计算的Green-Score"
 
 msgctxt "attribute_environmental_score_unknown_description_short"
 msgid "Unknown environmental impact"
@@ -5887,7 +5882,7 @@ msgstr "Green-Score 计算公式会定期更新改进，以获得更精确的数
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "绿色评分系统最初是为法国开发的，目前正在推广到其他欧洲国家。绿色评分系统的计算公式会定期更新，以使其更加精准，更适合各个国家的实际情况。"
+msgstr "Green-Score系统最初是为法国开发的，目前正在推广到其他欧洲国家。Green-Score系统的计算公式会定期更新，以使其更加精准，更适合各个国家的实际情况。"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -6489,7 +6484,7 @@ msgstr "了解有关 Nutri-Score 的更多信息"
 
 msgctxt "environmental_score_learn_more"
 msgid "Learn more about the Green-Score"
-msgstr "了解有关生态评分的更多信息"
+msgstr "了解有关Green-Score的更多信息"
 
 # The translation needs to be short as it is displayed at the top of small product cards
 msgctxt "products_match_very_good_match"
@@ -6539,11 +6534,11 @@ msgstr "您能否添加计算 Nutri-Score 所需的信息？"
 
 msgctxt "actions_to_compute_environmental_score"
 msgid "Could you add a precise product category so that we can compute the Green-Score?"
-msgstr "您能否对产品进行分类，以便我们能够计算生态得分？"
+msgstr "您能否对产品进行分类，以便我们能够计算Green-Score？"
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "该产品的类别不够精确，无法计算绿色评分。您能否添加更精确的产品类别？"
+msgstr "该产品的类别不够精确，无法计算Green-Score。您能否添加更精确的产品类别？"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7442,7 +7437,7 @@ msgstr "没有 Nutri-Score 的产品数量"
 
 msgctxt "percent_of_products_with_nutriscore"
 msgid "% of products where Nutri-Score is computed"
-msgstr "计算营养价值评分的产品百分比"
+msgstr "计算Nutri-Score的产品百分比"
 
 msgctxt "products_to_be_exported"
 msgid "Products to be exported"
@@ -7682,7 +7677,7 @@ msgstr "向我们的版主举报此图片"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "我们缺少计算营养评分所需的份量值和/或单位"
+msgstr "我们缺少计算Nutri-Score所需的份量值和/或单位"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/zh_HK.po
+++ b/po/common/zh_HK.po
@@ -1761,11 +1761,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "營養等級"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"

--- a/po/common/zh_TW.po
+++ b/po/common/zh_TW.po
@@ -1764,11 +1764,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr "營養等級"
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"
@@ -4335,7 +4330,7 @@ msgstr ""
 
 msgctxt "nutri_score_score_calculated"
 msgid "Calculated Nutri-Score score"
-msgstr "計算後營養得分分數"
+msgstr "計算後Nutri-Score分數"
 
 msgctxt "nutri_score_grade_from_producer"
 msgid "Nutri-Score grade from producer"
@@ -4343,7 +4338,7 @@ msgstr ""
 
 msgctxt "nutri_score_grade_calculated"
 msgid "Calculated Nutri-Score grade"
-msgstr "計算後營養得分等級"
+msgstr "計算後Nutri-Score等級"
 
 msgctxt "scanned_code"
 msgid "Scanned code"
@@ -4953,7 +4948,7 @@ msgstr ""
 
 msgctxt "attribute_environmental_score_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "綠色評分是一個從 A+ 到 F 的環境評分，可以方便地比較食品對環境的影響。"
+msgstr "Green-Score是一個從 A+ 到 F 的環境評分，可以方便地比較食品對環境的影響。"
 
 # Note: the Eco-Score is renamed to Green-Score, but we keep the ecoscore identifier as it is stored in clients
 msgctxt "attribute_ecoscore_name"
@@ -4966,7 +4961,7 @@ msgstr ""
 
 msgctxt "attribute_ecoscore_setting_note"
 msgid "The Green-Score is an environmental score from A+ to F which makes it easy to compare the impact of food products on the environment."
-msgstr "綠色評分是一個從 A+ 到 F 的環境評分，可以方便地比較食品對環境的影響。"
+msgstr "Green-Score是一個從 A+ 到 F 的環境評分，可以方便地比較食品對環境的影響。"
 
 # keep %s, it will be replaced by the letter A+, A, B, C, D, E or F
 msgctxt "attribute_environmental_score_grade_title"
@@ -5890,7 +5885,7 @@ msgstr ""
 # do not translate Green-Score
 msgctxt "environmental_score_warning_international"
 msgid "The Green-Score was initially developed for France and it is being extended to other European countries. The Green-Score formula is subject to change as it is regularly improved to make it more precise and better suited to each country."
-msgstr "綠色評分系統最初是為法國開發的，目前正在推廣到其他歐洲國家。綠色評分系統的計算公式會定期更新，使其更加精準，更適合各國的實際情況。"
+msgstr "Green-Score系統最初是為法國開發的，目前正在推廣到其他歐洲國家。Green-Score系統的計算公式會定期更新，使其更加精準，更適合各國的實際情況。"
 
 msgctxt "environmental_score_warning_transportation_world"
 msgid "Select a country in order to include the full impact of transportation."
@@ -5976,7 +5971,7 @@ msgstr "中等"
 
 msgctxt "nutrition_grade_fr_tea_bags_note"
 msgid "Note: the Nutri-Score of teas and herbal teas corresponds to the product prepared with water only, without sugar or milk."
-msgstr "注意：茶葉和藥草的營養評分，對應於僅用水製備的產品，且不加糖或牛奶。"
+msgstr "注意：茶葉和藥草的Nutri-Score，對應於僅用水製備的產品，且不加糖或牛奶。"
 
 msgctxt "g_per_100g"
 msgid "%s g / 100 g"
@@ -6546,7 +6541,7 @@ msgstr ""
 
 msgctxt "actions_to_compute_environmental_score_unprecise_category"
 msgid "The category we have for this product is not precise enough to compute the Green-Score. Could you add a more precise product category?"
-msgstr "該產品的類別不夠精確，無法計算綠色評分。您能否新增更精確的產品類別？"
+msgstr "該產品的類別不夠精確，無法計算Green-Score。您能否新增更精確的產品類別？"
 
 msgctxt "action_add_ingredients_text"
 msgid "Add the ingredients"
@@ -7685,7 +7680,7 @@ msgstr "向我們的版主檢舉此圖片"
 
 msgctxt "missing_serving_size_value_and_or_unit"
 msgid "We are missing the serving size value and/or unit to calculate the Nutri-Score"
-msgstr "我們缺少計算營養評分所需的份量值和/或單位"
+msgstr "我們缺少計算Nutri-Score所需的份量值和/或單位"
 
 msgctxt "bottom_content_split"
 msgid "<<site_name>> is made by a non-profit association, independent from the industry. It is made for all, by all, and it is funded by all. You can support our work by donating to Open Food Facts.<br/><b>Thank you!</b>"

--- a/po/common/zu.po
+++ b/po/common/zu.po
@@ -1758,11 +1758,6 @@ msgctxt "nutrition_grades_s"
 msgid "Nutrition grade"
 msgstr ""
 
-# Make sure the translated link works (eg that the image already exists in your language)
-msgctxt "og_image_url"
-msgid "https://static.openfoodfacts.org/images/logos/logo-vertical-white-social-media-preview.png"
-msgstr ""
-
 # Do not change the lang code if the blog doesn't exist in your language
 msgctxt "on_the_blog_content"
 msgid "<p>To learn more about <<site_name>>, visit <a href=\"https://blog.openfoodfacts.org/en/\">our blog</a>!</p>\n"


### PR DESCRIPTION
fix: cleanup translations

- Some brands (OFF, Nutri-Score) were translated
- We had an old url which was refactored away, but still in the translations