### PR TITLE
feat: Use preferred tile.openstreetmap.org URL

### DIFF
--- a/html/js/display-map.js
+++ b/html/js/display-map.js
@@ -24,7 +24,7 @@ import { MarkerClusterGroup } from 'leaflet.markercluster';
 export function displayMap(containerId, pointers) {
   const map = new LeafletMap(containerId, { maxZoom: 12 });
 
-  const tileLayer = new TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  const tileLayer = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
   });

--- a/html/js/display-tag.js
+++ b/html/js/display-tag.js
@@ -39,7 +39,7 @@ function ensureLeafletMap() {
   }
 
   const map = new LeafletMap('container');
-  const tileLayer = new TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  const tileLayer = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
   });


### PR DESCRIPTION
`type: chore`

### What
Changes the display map tile URL for the OSM map provider to use the preferred tile.openstreetmap.org URL. See https://github.com/openstreetmap/operations/issues/737

### Related issue(s) and discussion
- Fixes: #14516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated map displays to use the current OpenStreetMap tile URL, improving map tile loading reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->