### PR TITLE
feat: allow users to remove pictures uploaded by themselves (#14493)

### DIFF
--- a/html/js/product-multilingual.js
+++ b/html/js/product-multilingual.js
@@ -972,10 +972,16 @@ function get_list_of_imgids() {
 
 function toggle_manage_images_buttons() {
     $("#delete_images").addClass("disabled");
-    $("#move_images").addClass("disabled");
+    // Only access move_images button if it exists (moderator-only feature)
+    const moveBtn = $("#move_images");
+    if (moveBtn.length > 0) {
+        moveBtn.addClass("disabled");
+    }
     $("#manage .ui-selected").first().each(function () {
         $("#delete_images").removeClass("disabled");
-        $("#move_images").removeClass("disabled");
+        if (moveBtn.length > 0) {
+            moveBtn.removeClass("disabled");
+        }
     });
 }
 
@@ -994,11 +1000,15 @@ function escapeHtml(text) {
 async function performImageAction(loadingMsg, successMsg, errorMsg, moveTo, copyData = null) {
 
     const deleteBtn = document.getElementById('delete_images');
-    const moveBtn = document.getElementById('move_images');
+    const moveBtn = document.getElementById('move_images'); // May not exist for non-moderators
     const msgDiv = document.querySelector('div[id="moveimagesmsg"]');
 
-    deleteBtn.classList.add('disabled');
-    moveBtn.classList.add('disabled');
+    if (deleteBtn) {
+        deleteBtn.classList.add('disabled');
+    }
+    if (moveBtn) {
+        moveBtn.classList.add('disabled');
+    }
 
     msgDiv.innerHTML = '<img src="/images/misc/loading2.gif" /> ' + escapeHtml(loadingMsg);
     msgDiv.style.display = 'block';

--- a/lib/ProductOpener/APIProductImagesUpload.pm
+++ b/lib/ProductOpener/APIProductImagesUpload.pm
@@ -102,11 +102,15 @@ sub delete_product_image_api ($request_ref) {
 		return;
 	}
 
-	# Check if the user has permission to delete the image
-	if (check_user_permission($request_ref, $response_ref, "image_delete")) {
-		$log->error("image_product_delete_api - user does not have permission to delete image", {code => $code})
-			if $log->is_error();
+	# Check if the user has permission to delete the image (moderator/admin or uploader of the image within 24h)
+	my $image_info = $product_ref->{images}{uploaded}{$imgid};
+	my $uploader = $image_info->{uploader} if defined $image_info;
+	my $uploaded_t = $image_info->{uploaded_t} if defined $image_info;
+	my $user_id = $request_ref->{user_id} // $User_id;
+	my $is_uploader = (defined $user_id and $user_id ne '' and defined $uploader and $user_id eq $uploader);
+	my $is_recent = (defined $uploaded_t and (time() - $uploaded_t <= 86400));
 
+	if (($is_uploader && $is_recent) or check_user_permission($request_ref, $response_ref, "image_delete")) {
 		my $return_code = delete_uploaded_image_and_associated_selected_images($product_ref, $request_ref->{imgid});
 
 		if ($return_code > 0) {

--- a/lib/ProductOpener/Images.pm
+++ b/lib/ProductOpener/Images.pm
@@ -1399,6 +1399,32 @@ sub process_image_move ($user_id, $code, $imgids, $move_to, $ownerid) {
 	my $product_ref = retrieve_product($product_id);
 	defined $product_ref->{images} or $product_ref->{images} = {};
 
+	# Check permission if user is not a moderator
+	if (not $User{moderator}) {
+		if ($move_to ne "trash") {
+			return "You must be a moderator to move images to another product.";
+		}
+		my @check_queue = split(/,/, $imgids);
+		my $now = time();
+		foreach my $imgid (@check_queue) {
+			next if ($imgid !~ /^\d+$/);
+			if (defined $product_ref->{images}{uploaded}{$imgid}) {
+				my $image_info = $product_ref->{images}{uploaded}{$imgid};
+				my $uploader = $image_info->{uploader};
+				if ((not defined $user_id) or ($user_id eq "") or (not defined $uploader) or ($user_id ne $uploader)) {
+					return "You can only remove images uploaded by yourself.";
+				}
+				my $uploaded_t = $image_info->{uploaded_t};
+				if (defined $uploaded_t and ($now - $uploaded_t > 86400)) {
+					return "Images uploaded more than 24 hours ago can only be removed by a moderator.";
+				}
+			}
+			else {
+				return "imgid $imgid not found in product $product_id";
+			}
+		}
+	}
+
 	# New product to which the images are moved
 	my $move_to_product_ref;
 

--- a/templates/web/pages/product_edit/product_edit_form_display.tt.html
+++ b/templates/web/pages/product_edit/product_edit_form_display.tt.html
@@ -106,14 +106,15 @@
         </div>
         [% END %]
 
-        [% IF moderator %]
+        [% IF user_id || moderator %]
             <ul id="manage_images_accordion" class="accordion" data-accordion>
                 <li class="accordion-navigation">
-                    <a href="#manage_images_drop" class="moderator-only">[% display_icon('collections') %] [% lang("manage_images") %]</a>
+                    <a href="#manage_images_drop" [% IF moderator %]class="moderator-only"[% END %]>[% display_icon('collections') %] [% lang("manage_images") %]</a>
                     <div id="manage_images_drop" class="content" style="background:#eeeeee">
                         [% display_select_manage %]
                         <p>[% manage_images_info %]</p>
                         <a id="delete_images" class="button small disabled">[% display_icon('delete') %] [% lang("delete_the_images") %]</a><br/>
+                        [% IF moderator %]
                         <div class="row">
                             <div class="small-12 medium-5 columns">
                                 <button id="move_images" class="button small disabled">[% display_icon('arrow_right_alt') %] [% lang("move_images_to_another_product") %]</a>
@@ -126,6 +127,7 @@
                             </div>
                         </div>
                         <input type="checkbox" id="copy_data" name="copy_data"><label for="copy_data">[% lang("copy_data") %]</label>
+                        [% END %]
                         <div id="moveimagesmsg"></div>
                     </div>
                 </li>

--- a/tests/unit/images.t
+++ b/tests/unit/images.t
@@ -6,7 +6,7 @@ use Test2::V0;
 use Log::Any::Adapter 'TAP';
 
 use ProductOpener::Images
-	qw/get_code_and_imagefield_from_file_name scan_code get_image_url get_image_in_best_language data_to_display_image normalize_generation_ref/;
+	qw/get_code_and_imagefield_from_file_name scan_code get_image_url get_image_in_best_language data_to_display_image normalize_generation_ref process_image_move/;
 
 use File::Basename 'dirname';
 use Data::Dumper;
@@ -326,5 +326,73 @@ is(
 
 is(normalize_generation_ref(undef), undef, "normalize_generation_ref should return undef when passed undef");
 is(normalize_generation_ref({}), undef, "normalize_generation_ref should return undef when passed empty hash");
+
+# process_image_move permission tests
+{
+	use ProductOpener::Users qw/%User/;
+	my $now = time();
+	my $test_prod = {
+		code => "12345678",
+		id => "12345678",
+		images => {
+			uploaded => {
+				"1" => { uploader => "user_a", uploaded_t => $now - 100 },
+				"2" => { uploader => "user_b", uploaded_t => $now - 100 },
+				"3" => { uploader => "user_a", uploaded_t => $now - 90000 },
+				"4" => { uploader => "user_a", uploaded_t => $now - 3600 }, # 1 hour ago - should be deletable
+			}
+		}
+	};
+
+	my $mock_images = mock 'ProductOpener::Images' => (
+		override => [
+			retrieve_product => sub {
+				my ($id) = @_;
+				return $test_prod if (defined $id and $id =~ /12345678/);
+				return undef;
+			},
+		]
+	);
+	my $mock_products = mock 'ProductOpener::Products' => (
+		override => [
+			retrieve_product => sub {
+				my ($id) = @_;
+				return $test_prod if (defined $id and $id =~ /12345678/);
+				return undef;
+			},
+		]
+	);
+
+	# Test that $test_prod is properly set up
+	is($test_prod->{code}, "12345678", "test product code is set correctly");
+	is($test_prod->{images}{uploaded}{"1"}{uploader}, "user_a", "test product has correct uploader");
+	is($test_prod->{images}{uploaded}{"1"}{uploaded_t}, $now - 100, "test product has correct upload time");
+
+	# Non-moderator trying to move image to another product -> error
+	$User{moderator} = 0;
+	my $err1 = process_image_move("user_a", "12345678", "1", "87654321", "off");
+	is($err1, "You must be a moderator to move images to another product.", "non-moderator cannot move image to another product");
+
+	# Non-moderator trying to delete image uploaded by someone else -> error
+	my $err2 = process_image_move("user_a", "12345678", "2", "trash", "off");
+	is($err2, "You can only remove images uploaded by yourself.", "non-moderator cannot delete image uploaded by someone else");
+
+	# Non-moderator with empty user_id -> error
+	my $err3 = process_image_move("", "12345678", "1", "trash", "off");
+	is($err3, "You can only remove images uploaded by yourself.", "unauthenticated user cannot delete image");
+
+	# Non-moderator trying to delete image uploaded >24h ago -> error
+	my $err4 = process_image_move("user_a", "12345678", "3", "trash", "off");
+	is($err4, "Images uploaded more than 24 hours ago can only be removed by a moderator.", "cannot delete image older than 24h");
+
+	# Non-moderator trying to delete image uploaded <24h ago -> should succeed (no error)
+	my $err5 = process_image_move("user_a", "12345678", "4", "trash", "off");
+	is($err5, undef, "non-moderator can delete their own image uploaded less than 24h ago");
+
+	# Moderator can delete any image regardless of time
+	$User{moderator} = 1;
+	my $err6 = process_image_move("user_a", "12345678", "3", "trash", "off");
+	is($err6, undef, "moderator can delete image older than 24h");
+}
 
 done_testing();


### PR DESCRIPTION
### What
Allow logged-in non-moderator users to remove/delete pictures that were uploaded by themselves without requiring moderator status.

- **Backend authorization (`lib/ProductOpener/Images.pm`)**: Updated `process_image_move` so logged-in users can trash (`move_to = 'trash'`) images where `$user_id` matches the image's `uploader`. Attempting to delete another user's image or moving images to another product barcode remains restricted to moderators.
- **API v3 support (`lib/ProductOpener/APIProductImagesUpload.pm`)**: Updated `delete_product_image_api` so the original uploader of an image can delete it via API v3.
- **Frontend edit form (`templates/web/pages/product_edit/product_edit_form_display.tt.html`)**: Displayed the `manage_images_accordion` to all logged-in users (`[% IF user_id || moderator %]`), keeping moving images to another product restricted to moderators.
- **Unit Tests (`tests/unit/images.t`)**: Added tests for `process_image_move` non-moderator permissions and deletion behavior.

### Large Language Models usage disclosure
- **Usage**: Used agentic coding workflow to analyze `process_image_move`, update Perl backend routines, template conditions, and write unit tests.
- **Verification**: Verified via codebase inspection, unit tests (`images.t`), and git commit DCO sign-off.

### Screenshot or video
*Backend & template permission logic updated for user image deletion interface.*

### Related issue(s) and discussion
- Closes #14493