### PR TITLE
fix: move the donation to webcomponent

### DIFF
--- a/conf/nginx/conf.d/tagline_cache.conf
+++ b/conf/nginx/conf.d/tagline_cache.conf
@@ -1,0 +1,2 @@
+# Cache zone for smooth-app_assets tagline feeds and assets proxy
+proxy_cache_path /tmp/nginx_tagline_cache levels=1:2 keys_zone=tagline:2m max_size=50m inactive=60m use_temp_path=off;

--- a/conf/nginx/snippets/productopener-server.include
+++ b/conf/nginx/snippets/productopener-server.include
@@ -57,6 +57,18 @@ location ~ ^/(favicon.ico|robots.txt) {
     try_files $uri $uri/ =404;
 }
 
+# Tagline feeds and assets proxy from smooth-app_assets
+location ^~ /data/tagline/ {
+    proxy_pass https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/;
+    proxy_ssl_server_name on;
+    proxy_set_header Host raw.githubusercontent.com;
+    include snippets/cors-headers.include;
+    proxy_cache tagline;
+    proxy_cache_valid 200 10m;
+    proxy_cache_use_stale error timeout updating;
+    add_header X-Cache-Status $upstream_cache_status always;
+}
+
 # Static files are served directly by NGINX
 location ~ ^/(.well-known|files|data|exports|dump)/ {
     include snippets/cors-headers.include;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,8 @@ services:
       - ./conf/nginx/snippets/expires-no-json-xml.conf:/etc/nginx/conf.d/aa_expires-no-json-xml.conf
       # log format
       - ./conf/nginx/conf.d/log_format_realip.conf:/etc/nginx/conf.d/aa_log_format_realip.conf
+      # cache for tagline proxy
+      - ./conf/nginx/conf.d/tagline_cache.conf:/etc/nginx/conf.d/tagline_cache.conf
       # some redirects
       - ./conf/nginx/snippets/off.locations-redirects.include:/etc/nginx/snippets/off.locations-redirects.include
 

--- a/scripts/deploy/verify-deployment.sh
+++ b/scripts/deploy/verify-deployment.sh
@@ -185,6 +185,7 @@ function compute_expected_links {
   EXPECTED_LINKS["/etc/nginx/snippets/productopener-uploads-large.include"]="$REPO_PATH/conf/nginx/snippets/productopener-uploads-large.include"
   EXPECTED_LINKS["/etc/nginx/conf.d/expires-no-json-xml.conf"]="$REPO_PATH/conf/nginx/conf.d/expires-no-json-xml.conf"
   EXPECTED_LINKS["/etc/nginx/conf.d/log_format_realip.conf"]="$REPO_PATH/conf/nginx/conf.d/log_format_realip.conf"
+  EXPECTED_LINKS["/etc/nginx/conf.d/tagline_cache.conf"]="$REPO_PATH/conf/nginx/conf.d/tagline_cache.conf"
   EXPECTED_LINKS["/etc/nginx/mime.types"]="$REPO_PATH/conf/nginx/mime.types"
   if [[ $SERVICE = "off" ]]
   then

--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -357,66 +357,9 @@
 <!-- Open Food Facts Days end -->
 [% ELSE %]
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>[% lang("donation_hook_2026") %]</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="https://world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">[% lang("donation_title_2026") %]</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>[% lang("donation_list_2026_main") %]</p>
-        <ul>
-          <li>
-            [% lang("donation_list_2026_first") %]
-            <ul>
-              <li>[% lang("donation_list_2026_first_sub") %]</li>
-            </ul>
-          </li>
-          <li>
-            <p>[% lang("donation_list_2026_second") %]</p>
-          </li>
-          <li>
-            <p>[% lang("donation_list_2026_third") %]</p>
-          </li>
-          <li>
-            <p>[% lang("donation_list_2026_fourth") %]</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          [% IF cc == "fr" %]
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          [% ELSE %]
-          [% lang("donation_financial_2026_text") %]
-          [% END %]
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>[% lang("donation_button_2026_text") %]</button>
-        </a>
-      </div>
-    </div>
-  </div>
-[% END %]
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="[% link %]" news-url="https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -455,66 +398,18 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+[% END %]
 
 [% END %]
 <!-- Donation banner TOP END -->
 <!-- Donation banner @ footer start-->
 [% banner_footer = BLOCK %]
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>[% lang("donation_hook_2026") %]</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="https://world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">[% lang("donation_title_2026") %]</h3>
-      </div>
-      <p>[% lang("donation_list_2026_main") %]</p>
-      <ul>
-        <li>
-          [% lang("donation_list_2026_first") %]
-          <ul>
-            <li>[% lang("donation_list_2026_first_sub") %]</li>
-          </ul>
-        </li>
-        <li>
-          <p>[% lang("donation_list_2026_second") %]</p>
-        </li>
-        <li>
-          <p>[% lang("donation_list_2026_third") %]</p>
-        </li>
-        <li>
-          <p>[% lang("donation_list_2026_fourth") %]</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          [% lang("donation_financial_2026_text") %]
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="[% link %]?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>[% lang("donation_button_2026_text") %]</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="[% link %]" news-url="https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 [% END %]
 <!-- Donation banner @ footer end-->

--- a/templates/web/common/includes/donate_banner.tt.html
+++ b/templates/web/common/includes/donate_banner.tt.html
@@ -358,7 +358,7 @@
 [% ELSE %]
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="[% link %]" news-url="https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="[% link %]" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -409,7 +409,7 @@
 <!-- Donation banner @ footer start-->
 [% banner_footer = BLOCK %]
 
-<donation-banner donate-url="[% link %]" news-url="https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="[% link %]" news-url="/data/tagline/web/main.json"></donation-banner>
 
 [% END %]
 <!-- Donation banner @ footer end-->

--- a/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
@@ -341,7 +341,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -450,7 +450,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_read/get-auth-bad-user-password.html
@@ -340,64 +340,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -436,9 +381,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -503,57 +450,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-oauth-token.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-oauth-token.html
@@ -364,64 +364,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -460,9 +405,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -527,57 +474,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-oauth-token.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-oauth-token.html
@@ -365,7 +365,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -474,7 +474,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
@@ -340,64 +340,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -436,9 +381,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -503,57 +450,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
+++ b/tests/integration/expected_test_results/api_v2_product_write/post-product-auth-bad-user-password.html
@@ -341,7 +341,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -450,7 +450,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -655,57 +602,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-category-facet-page.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -602,7 +602,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -353,64 +353,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -449,9 +394,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -4455,57 +4402,7 @@ The score is calculated from the data of the nutrition facts table and the compo
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-access-product-page.html
@@ -354,7 +354,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -4402,7 +4402,7 @@ The score is calculated from the data of the nutrition facts table and the compo
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -676,7 +676,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/crawler-does-not-get-facet-knowledge-panels.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -729,57 +676,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -643,7 +643,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-category-facet-page.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -696,57 +643,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-editor-facet-page.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -548,57 +495,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-list-of-tags.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -495,7 +495,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-nested-facet-page.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -353,64 +353,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -449,9 +394,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -4455,57 +4402,7 @@ The score is calculated from the data of the nutrition facts table and the compo
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-access-product-page.html
@@ -354,7 +354,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -4402,7 +4402,7 @@ The score is calculated from the data of the nutrition facts table and the compo
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -770,57 +717,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-facet-knowledge-panels.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -717,7 +717,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
@@ -341,64 +341,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>¡Todavía necesitamos 120.000 € para terminar 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Hazte mecenas de Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Cada mes atendemos a 8 millones de visitantes, y muchas más veces a través de la API. Tu apoyo es esencial para:</p>
-        <ul>
-          <li>
-            mantener Open Food Facts abierto y disponible para todos,
-            <ul>
-              <li>apoyar la infraestructura, el sitio web, la app móvil y la API con un pequeño equipo permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>permanecer independiente de la industria alimentaria,</p>
-          </li>
-          <li>
-            <p>apoyar a la comunidad</p>
-          </li>
-          <li>
-            <p>apoyar la ciencia</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Si cada visitante este mes hiciera clic en Donar y aportara solo 1 €, ¡obtendríamos más de 8 veces nuestro presupuesto anual!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donar</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -437,9 +382,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -563,57 +510,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>¡Todavía necesitamos 120.000 € para terminar 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Hazte mecenas de Open Food Facts</h3>
-      </div>
-      <p>Cada mes atendemos a 8 millones de visitantes, y muchas más veces a través de la API. Tu apoyo es esencial para:</p>
-      <ul>
-        <li>
-          mantener Open Food Facts abierto y disponible para todos,
-          <ul>
-            <li>apoyar la infraestructura, el sitio web, la app móvil y la API con un pequeño equipo permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>permanecer independiente de la industria alimentaria,</p>
-        </li>
-        <li>
-          <p>apoyar a la comunidad</p>
-        </li>
-        <li>
-          <p>apoyar la ciencia</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si cada visitante este mes hiciera clic en Donar y aportara solo 1 €, ¡obtendríamos más de 8 veces nuestro presupuesto anual!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donar</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
+++ b/tests/integration/expected_test_results/page_crawler/normal-user-get-non-official-cc-lc.html
@@ -342,7 +342,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -510,7 +510,7 @@
 
 				
 
-<donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -352,7 +352,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -6400,7 +6400,7 @@ The score is calculated from the data of the nutrition facts table and the compo
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_read/get-existing-product.html
+++ b/tests/integration/expected_test_results/product_read/get-existing-product.html
@@ -351,64 +351,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -447,9 +392,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -6453,57 +6400,7 @@ The score is calculated from the data of the nutrition facts table and the compo
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_read/get-unexisting-product.html
+++ b/tests/integration/expected_test_results/product_read/get-unexisting-product.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_read/get-unexisting-product.html
+++ b/tests/integration/expected_test_results/product_read/get-unexisting-product.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_write/post-product-add-nutrition.html
+++ b/tests/integration/expected_test_results/product_write/post-product-add-nutrition.html
@@ -366,64 +366,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -462,9 +407,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -1143,57 +1090,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_write/post-product-add-nutrition.html
+++ b/tests/integration/expected_test_results/product_write/post-product-add-nutrition.html
@@ -367,7 +367,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -1090,7 +1090,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-off.html
+++ b/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-off.html
@@ -367,7 +367,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -1056,7 +1056,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-off.html
+++ b/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-off.html
@@ -366,64 +366,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -462,9 +407,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -1109,57 +1056,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-on.html
+++ b/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-on.html
@@ -366,64 +366,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -462,9 +407,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -1075,57 +1022,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-on.html
+++ b/tests/integration/expected_test_results/product_write/post-product-no-nutrition-data-on.html
@@ -367,7 +367,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -1022,7 +1022,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_write/post-product-search-or-add.html
+++ b/tests/integration/expected_test_results/product_write/post-product-search-or-add.html
@@ -384,64 +384,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -480,9 +425,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -34383,57 +34330,7 @@ by typing the first letters of their name in the last row of the table.</p>
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/product_write/post-product-search-or-add.html
+++ b/tests/integration/expected_test_results/product_write/post-product-search-or-add.html
@@ -385,7 +385,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -34330,7 +34330,7 @@ by typing the first letters of their name in the last row of the table.</p>
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
@@ -366,64 +366,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -462,9 +407,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -1024,57 +971,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form-moderator.html
@@ -367,7 +367,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -971,7 +971,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
@@ -366,64 +366,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -462,9 +407,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -1024,57 +971,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-protected-product-web-form.html
@@ -367,7 +367,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -971,7 +971,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
@@ -366,64 +366,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -462,9 +407,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -1024,57 +971,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
+++ b/tests/integration/expected_test_results/protected_product/edit-unprotected-product-web-form.html
@@ -367,7 +367,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -971,7 +971,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
+++ b/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -772,7 +772,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
+++ b/tests/integration/expected_test_results/recipes_stats/parent-ingredients-stats.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -825,57 +772,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -565,7 +565,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-cambodia-exists-but-empty.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -618,57 +565,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients-apple.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist-ingredients.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-doesnotexist.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -634,7 +634,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/country-france-exists.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -687,57 +634,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -725,57 +672,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-apple-exists.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -672,7 +672,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknownandemptyingredient-does-not-exist-and-empty.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -526,7 +526,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty-labels.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -579,57 +526,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -634,7 +634,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
+++ b/tests/integration/expected_test_results/unknown_tags/ingredient-someunknowningredient-does-not-exist-but-not-empty.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -687,57 +634,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/unknown-product.html
+++ b/tests/integration/expected_test_results/unknown_tags/unknown-product.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/unknown_tags/unknown-product.html
+++ b/tests/integration/expected_test_results/unknown_tags/unknown-product.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/upload_images/post-product-image-bad-oauth-token.html
+++ b/tests/integration/expected_test_results/upload_images/post-product-image-bad-oauth-token.html
@@ -341,7 +341,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -450,7 +450,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/upload_images/post-product-image-bad-oauth-token.html
+++ b/tests/integration/expected_test_results/upload_images/post-product-image-bad-oauth-token.html
@@ -340,64 +340,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -436,9 +381,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -503,57 +450,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/es-ingredients.html
+++ b/tests/integration/expected_test_results/web_html/es-ingredients.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -551,7 +551,7 @@
 
 				
 
-<donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/es-ingredients.html
+++ b/tests/integration/expected_test_results/web_html/es-ingredients.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>¡Todavía necesitamos 120.000 € para terminar 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Hazte mecenas de Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Cada mes atendemos a 8 millones de visitantes, y muchas más veces a través de la API. Tu apoyo es esencial para:</p>
-        <ul>
-          <li>
-            mantener Open Food Facts abierto y disponible para todos,
-            <ul>
-              <li>apoyar la infraestructura, el sitio web, la app móvil y la API con un pequeño equipo permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>permanecer independiente de la industria alimentaria,</p>
-          </li>
-          <li>
-            <p>apoyar a la comunidad</p>
-          </li>
-          <li>
-            <p>apoyar la ciencia</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          Si cada visitante este mes hiciera clic en Donar y aportara solo 1 €, ¡obtendríamos más de 8 veces nuestro presupuesto anual!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donar</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -604,57 +551,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>¡Todavía necesitamos 120.000 € para terminar 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Hazte mecenas de Open Food Facts</h3>
-      </div>
-      <p>Cada mes atendemos a 8 millones de visitantes, y muchas más veces a través de la API. Tu apoyo es esencial para:</p>
-      <ul>
-        <li>
-          mantener Open Food Facts abierto y disponible para todos,
-          <ul>
-            <li>apoyar la infraestructura, el sitio web, la app móvil y la API con un pequeño equipo permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>permanecer independiente de la industria alimentaria,</p>
-        </li>
-        <li>
-          <p>apoyar a la comunidad</p>
-        </li>
-        <li>
-          <p>apoyar la ciencia</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si cada visitante este mes hiciera clic en Donar y aportara solo 1 €, ¡obtendríamos más de 8 veces nuestro presupuesto anual!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world-es.openfoodfacts.org/dar-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donar</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world-es.openfoodfacts.org/dar-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-brands.html
+++ b/tests/integration/expected_test_results/web_html/fr-brands.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -491,7 +491,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-brands.html
+++ b/tests/integration/expected_test_results/web_html/fr-brands.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -544,57 +491,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -788,57 +735,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-categories.html
+++ b/tests/integration/expected_test_results/web_html/fr-categories.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -735,7 +735,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-countries.html
+++ b/tests/integration/expected_test_results/web_html/fr-countries.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -505,7 +505,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-countries.html
+++ b/tests/integration/expected_test_results/web_html/fr-countries.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -558,57 +505,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -385,7 +385,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -34614,7 +34614,7 @@ Vous acceptez d'être crédité par les ré-utilisateurs par un lien vers le pro
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-edit-product.html
@@ -384,64 +384,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -480,9 +425,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -34667,57 +34614,7 @@ Vous acceptez d'être crédité par les ré-utilisateurs par un lien vers le pro
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -771,57 +718,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-index.html
+++ b/tests/integration/expected_test_results/web_html/fr-index.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -718,7 +718,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-labels.html
+++ b/tests/integration/expected_test_results/web_html/fr-labels.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -491,7 +491,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-labels.html
+++ b/tests/integration/expected_test_results/web_html/fr-labels.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -544,57 +491,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -354,7 +354,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -6593,7 +6593,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-product-2.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-2.html
@@ -353,64 +353,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -449,9 +394,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -6646,57 +6593,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
@@ -353,64 +353,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -449,9 +394,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -6894,57 +6841,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
+++ b/tests/integration/expected_test_results/web_html/fr-product-raw-panel.html
@@ -354,7 +354,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -6841,7 +6841,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -353,64 +353,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -449,9 +394,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -6617,57 +6564,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-product.html
+++ b/tests/integration/expected_test_results/web_html/fr-product.html
@@ -354,7 +354,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -6564,7 +6564,7 @@ un outil de la Direction générale de la concurrence, de la consommation et de 
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -346,7 +346,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -2148,7 +2148,7 @@ sur les deux axes pour obtenir un nuage de produits.</p>
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-search-form.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-form.html
@@ -345,64 +345,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -441,9 +386,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -2201,57 +2148,7 @@ sur les deux axes pour obtenir un nuage de produits.</p>
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -580,7 +580,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-cached.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -633,57 +580,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -580,7 +580,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results-no-cache.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -633,57 +580,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -580,7 +580,7 @@
 
 				
 
-<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/fr-search-results.html
+++ b/tests/integration/expected_test_results/web_html/fr-search-results.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-        <ul>
-          <li>
-            garder Open Food Facts ouvert et accessible à tous,
-            <ul>
-              <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-            </ul>
-          </li>
-          <li>
-            <p>rester indépendants de l’industrie agroalimentaire,</p>
-          </li>
-          <li>
-            <p>soutenir la communauté</p>
-          </li>
-          <li>
-            <p>soutenir la science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          (déductible à 66 % de vos impôts: ex. un don de 20€ vous reviendra à 6,80€)
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -633,57 +580,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>Il nous manque encore 120 000 € pour terminer 2026 !</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Devenez mécène d'Open Food Facts</h3>
-      </div>
-      <p>Chaque mois, nous accueillons 8 millions de visiteurs, et bien plus via l’API. Votre soutien est essentiel pour :</p>
-      <ul>
-        <li>
-          garder Open Food Facts ouvert et accessible à tous,
-          <ul>
-            <li>soutenir l’infrastructure, le site web, l’application mobile et l’API avec une petite équipe permanente</li>
-          </ul>
-        </li>
-        <li>
-          <p>rester indépendants de l’industrie agroalimentaire,</p>
-        </li>
-        <li>
-          <p>soutenir la communauté</p>
-        </li>
-        <li>
-          <p>soutenir la science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Faire un don</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//fr.openfoodfacts.org/faire-un-don-a-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/report-image-button.html
+++ b/tests/integration/expected_test_results/web_html/report-image-button.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -519,57 +466,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/report-image-button.html
+++ b/tests/integration/expected_test_results/web_html/report-image-button.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -466,7 +466,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/user-register.html
+++ b/tests/integration/expected_test_results/web_html/user-register.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -690,7 +690,7 @@ function togglePasswordVisibility(FieldID) {
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/user-register.html
+++ b/tests/integration/expected_test_results/web_html/user-register.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -743,57 +690,7 @@ function togglePasswordVisibility(FieldID) {
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-brands.html
+++ b/tests/integration/expected_test_results/web_html/world-brands.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -499,7 +499,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-brands.html
+++ b/tests/integration/expected_test_results/web_html/world-brands.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -552,57 +499,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
+++ b/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -559,7 +559,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
+++ b/tests/integration/expected_test_results/web_html/world-categories-nid-stats-sugars.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -612,57 +559,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -861,7 +861,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-categories.html
+++ b/tests/integration/expected_test_results/web_html/world-categories.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -914,57 +861,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-countries.html
+++ b/tests/integration/expected_test_results/web_html/world-countries.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -570,57 +517,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-countries.html
+++ b/tests/integration/expected_test_results/web_html/world-countries.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -517,7 +517,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -384,64 +384,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -480,9 +425,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -34667,57 +34614,7 @@ by typing the first letters of their name in the last row of the table.</p>
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-edit-product.html
+++ b/tests/integration/expected_test_results/web_html/world-edit-product.html
@@ -385,7 +385,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -34614,7 +34614,7 @@ by typing the first letters of their name in the last row of the table.</p>
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -367,7 +367,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -756,7 +756,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-index-signedin.html
+++ b/tests/integration/expected_test_results/web_html/world-index-signedin.html
@@ -366,64 +366,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -462,9 +407,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -809,57 +756,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -732,7 +732,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-index.html
+++ b/tests/integration/expected_test_results/web_html/world-index.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -785,57 +732,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -877,57 +824,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-label-organic.html
+++ b/tests/integration/expected_test_results/web_html/world-label-organic.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -824,7 +824,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-labels.html
+++ b/tests/integration/expected_test_results/web_html/world-labels.html
@@ -343,64 +343,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -439,9 +384,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -548,57 +495,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-labels.html
+++ b/tests/integration/expected_test_results/web_html/world-labels.html
@@ -344,7 +344,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -495,7 +495,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-product-not-found.html
+++ b/tests/integration/expected_test_results/web_html/world-product-not-found.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -452,7 +452,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-product-not-found.html
+++ b/tests/integration/expected_test_results/web_html/world-product-not-found.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -505,57 +452,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -353,64 +353,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -449,9 +394,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -6545,57 +6492,7 @@ Apple pies
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-product.html
+++ b/tests/integration/expected_test_results/web_html/world-product.html
@@ -354,7 +354,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -6492,7 +6492,7 @@ Apple pies
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes-gs1-formats.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes-gs1-formats.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -514,57 +461,7 @@ Products are being loaded, please wait.
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes-gs1-formats.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes-gs1-formats.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -461,7 +461,7 @@ Products are being loaded, please wait.
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -514,57 +461,7 @@ Products are being loaded, please wait.
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
+++ b/tests/integration/expected_test_results/web_html/world-products-multiple-codes.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -461,7 +461,7 @@ Products are being loaded, please wait.
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-search-form.html
+++ b/tests/integration/expected_test_results/web_html/world-search-form.html
@@ -345,64 +345,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -441,9 +386,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -2201,57 +2148,7 @@ get a cloud of products (scatter plot).</p>
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-search-form.html
+++ b/tests/integration/expected_test_results/web_html/world-search-form.html
@@ -346,7 +346,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -2148,7 +2148,7 @@ get a cloud of products (scatter plot).</p>
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-search-histogram-nutrition-sugars.html
+++ b/tests/integration/expected_test_results/web_html/world-search-histogram-nutrition-sugars.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -513,57 +460,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-search-histogram-nutrition-sugars.html
+++ b/tests/integration/expected_test_results/web_html/world-search-histogram-nutrition-sugars.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -460,7 +460,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-search-results.html
+++ b/tests/integration/expected_test_results/web_html/world-search-results.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -633,57 +580,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-search-results.html
+++ b/tests/integration/expected_test_results/web_html/world-search-results.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -580,7 +580,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-search-scatter-plot-nutrition-sugars-fat.html
+++ b/tests/integration/expected_test_results/web_html/world-search-scatter-plot-nutrition-sugars-fat.html
@@ -342,64 +342,9 @@
 
 
 <!-- Donation banner TOP start -->
-<section id="donation-banner-top" class="donation-banner row">
-
-  <div class="donation-banner__left-aside">
-    <div class="donation-banner__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="group photo donation 2024" />
-  </div>
-  <div>
-    <div class="donation-banner__aside">
-      <div class="donation-banner__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <div style="padding:1rem;">
-        <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-        <ul>
-          <li>
-            keep Open Food Facts open & available to all,
-            <ul>
-              <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-            </ul>
-          </li>
-          <li>
-            <p>remain independent of the food industry,</p>
-          </li>
-          <li>
-            <p>support the community</p>
-          </li>
-          <li>
-            <p>support science</p>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div class="donation-banner__actions-section">
-      <div class="donation-banner__actions-section__financial">
-        <p>
-          
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-          
-        </p>
-      </div>
-      <div class="donation-banner__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="donation-banner__close">
+<section id="donation-banner-top" style="position: relative;">
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
 </section>
@@ -438,9 +383,11 @@
   if (getBannerCookie('donation_march_2026') !== '') {
     bannerID.style.display = 'none';
   } else {
-    bannerID.style.display = 'flex';
+    bannerID.style.display = 'block';
   }
 </script>
+
+
 
 
 							
@@ -13271,57 +13218,7 @@
 
 				
 
-<section class="donation-banner-footer row">
-  <div class="donation-banner-footer__left-aside">
-    <div class="donation-banner-footer__hook-section">
-      <p>We still need €120,000 to finish 2026!</p>
-    </div>
-    <img src="/images/misc/donation-banners/donation-banner-group-photo.png" alt="The Open Food Facts community during the Open Food Facts Days" />
-  </div>
-  <div>
-    <div>
-      <div class="donation-banner-footer__main-section">
-        <img
-          width="50"
-          height="50"
-          src="//world.openfoodfacts.org/images/logos/logo-variants/CMJN-ICON_WHITE_BG_OFF.svg"
-          alt="Open Food Facts logo"
-        />
-        <h3 class="donation-banner-footer__main-title">Become an Open Food Facts patron</h3>
-      </div>
-      <p>Every month, we serve 8 million visitors, and many times that through the API. Your support is essential to:</p>
-      <ul>
-        <li>
-          keep Open Food Facts open & available to all,
-          <ul>
-            <li>support infrastructure, the website, mobile app and API with a small permanent team</li>
-          </ul>
-        </li>
-        <li>
-          <p>remain independent of the food industry,</p>
-        </li>
-        <li>
-          <p>support the community</p>
-        </li>
-        <li>
-          <p>support science</p>
-        </li>
-      </ul>
-    </div>
-    <div class="donation-banner-footer__actions-section">
-      <div class="donation-banner-footer__actions-section__financial">
-        <p>
-          If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!
-        </p>
-      </div>
-      <div class="donation-banner-footer__actions-section__donate-button">
-        <a href="//world.openfoodfacts.org/donate-to-open-food-facts?utm_source=off&utm_medium=web&utm_campaign=donate-2026-a&utm_term=en-text-button">
-          <button>Donate</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
 
 
 			

--- a/tests/integration/expected_test_results/web_html/world-search-scatter-plot-nutrition-sugars-fat.html
+++ b/tests/integration/expected_test_results/web_html/world-search-scatter-plot-nutrition-sugars-fat.html
@@ -343,7 +343,7 @@
 
 <!-- Donation banner TOP start -->
 <section id="donation-banner-top" style="position: relative;">
-  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+  <donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
   <div class="donation-banner__close" style="position: absolute; top: 0.3rem; right: 0.3rem; z-index: 2;">
     <button id="hide-donate-banner" class="material-icons modest" onclick="DonationButton();" onkeypress="DonationButton();">close</button>
   </div>
@@ -13218,7 +13218,7 @@
 
 				
 
-<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="//raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"></donation-banner>
+<donation-banner donate-url="//world.openfoodfacts.org/donate-to-open-food-facts" news-url="/data/tagline/web/main.json"></donation-banner>
 
 
 			


### PR DESCRIPTION
fix: move the donation to webcomponent
blocked on https://github.com/openfoodfacts/openfoodfacts-webcomponents/pull/618/changes being merged, and then the webcomponents being released, and upgraded here.

<img width="1687" height="966" alt="image" src="https://github.com/user-attachments/assets/ac5a90e9-f78e-406f-bf74-7883ceb88c69" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable donation banners for page headers and footers, with content loaded dynamically.
  * Added a tagline feed and asset proxy with caching and CORS support.
  * Donation banners retain cookie-based dismissal and close controls.
* **Style**
  * Updated visible banner layout and positioning for consistent rendering across pages.
* **Tests**
  * Updated integration expectations to reflect the new donation banner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->