### PR TITLE
fix: preserve additive-class parsing with compound units

### DIFF
--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3045,14 +3045,11 @@ Text to analyze
 					# ingredients tags that are too long (greater than 1024, mongodb max index key size)
 					# will cause issues for the mongodb ingredients_tags index, just drop them
 					if (length($ingredient{id}) < 500) {
-						# Only flatten an additive class when at least one of its children is
-						# recognizable (#6132 follow-up): protecting the solidus of compound
-						# units removed the accidental '/' splits that used to create list
-						# boundaries, so e.g. "Antioxygènes : Avec antioxydant naturel :
-						# mg/kg 1b306(i)" would otherwise be flattened into unknown junk
-						# children and the class tag would be lost entirely.
-						my $flatten_children = 0;
-						if ($is_flattenable_additive_class && $between ne "") {
+						# Only require recognizable children when protected compound-unit slashes
+						# could flatten the class into unknown text, e.g. "mg/kg 1b306(i)".
+						my $flatten_children = $is_flattenable_additive_class && $between ne '';
+						if ($flatten_children && $between =~ /\N{U+2044}/) {
+							$flatten_children = 0;
 							foreach my $raw_chunk (split(/$separators/, $between)) {
 								# $separators contains capturing groups, so split
 								# also yields undef delimiter slots.
@@ -3069,7 +3066,9 @@ Text to analyze
 
 								foreach my $candidate_chunk (@candidate_chunks) {
 									$candidate_chunk =~ s/^\s+|\s+$//g;
-									$candidate_chunk =~ s/\s$percent_or_quantity_regexp$//i;
+									if ($candidate_chunk =~ /\s$percent_or_quantity_regexp$/i && $2 ne '') {
+										$candidate_chunk = $`;
+									}
 									next if $candidate_chunk eq '';
 
 									my $candidate_recognized

--- a/lib/ProductOpener/Ingredients.pm
+++ b/lib/ProductOpener/Ingredients.pm
@@ -3061,17 +3061,36 @@ Text to analyze
 								my $chunk = $raw_chunk;
 								$chunk =~ s/^\s+|\s+$//g;
 								next if $chunk eq '';
-								if (
-									exists_taxonomy_tag("additives",
-										canonicalize_taxonomy_tag($ingredients_lc, "additives", $chunk))
-									or exists_taxonomy_tag(
-										"ingredients", canonicalize_taxonomy_tag($ingredients_lc, "ingredients", $chunk)
-									)
-									)
-								{
-									$flatten_children = 1;
-									last;
+
+								my @candidate_chunks = ($chunk);
+								if ($chunk =~ /$and/i) {
+									push @candidate_chunks, ($`, $');
 								}
+
+								foreach my $candidate_chunk (@candidate_chunks) {
+									$candidate_chunk =~ s/^\s+|\s+$//g;
+									$candidate_chunk =~ s/\s$percent_or_quantity_regexp$//i;
+									next if $candidate_chunk eq '';
+
+									my $candidate_recognized
+										= exists_taxonomy_tag("additives",
+										canonicalize_taxonomy_tag($ingredients_lc, "additives", $candidate_chunk))
+										|| exists_taxonomy_tag("ingredients",
+										canonicalize_taxonomy_tag($ingredients_lc, "ingredients", $candidate_chunk));
+
+									if ((not $candidate_recognized)
+										and defined $ingredients_processing_regexps{$ingredients_lc})
+									{
+										(undef, undef, undef, $candidate_recognized)
+											= parse_processing_from_ingredient($ingredients_lc, $candidate_chunk);
+									}
+
+									if ($candidate_recognized) {
+										$flatten_children = 1;
+										last;
+									}
+								}
+								last if $flatten_children;
 							}
 						}
 						if ($flatten_children) {

--- a/tests/integration/expected_test_results/export/export_database/rows/3256220513173.json
+++ b/tests/integration/expected_test_results/export/export_database/rows/3256220513173.json
@@ -88,7 +88,7 @@
    "image_small_url" : "",
    "image_url" : "",
    "ingredients_analysis_tags" : "en:palm-oil-free,en:maybe-vegan,en:maybe-vegetarian",
-   "ingredients_tags" : "en:sugar,en:disaccharide,en:added-sugar,en:fruit-juice-from-concentrate,en:fruit-juice-concentrate,en:water,en:flavouring,en:e330,en:colour,en:e445,en:peach,en:prunus-species-fruit,en:fruit,en:lemon,en:citrus-fruit,en:e161b,en:e163",
+   "ingredients_tags" : "en:sugar,en:disaccharide,en:added-sugar,en:fruit-juice-from-concentrate,en:fruit-juice-concentrate,en:water,en:flavouring,en:e330,en:e161b,en:e163,en:e445,en:peach,en:prunus-species-fruit,en:fruit,en:lemon,en:citrus-fruit",
    "ingredients_text" : "Sucre, jus de fruits à base de concentrés 40% (pêche 20%, citron), eau, arômes, acidifiant : acide citrique, colorants : lutéine et anthocyanes, stabilisant : E445.",
    "inositol_100g" : "",
    "insoluble-fiber_100g" : "",

--- a/tests/unit/ingredients_tags.t
+++ b/tests/unit/ingredients_tags.t
@@ -323,6 +323,10 @@ my @tests = (
 	[{lc => "fr", ingredients_text => "Ingrédient inconnu et sel"}, ["fr:Ingrédient inconnu", "en:salt"],],
 	[{lc => "fr", ingredients_text => "Sel et ingrédient inconnu"}, ["en:salt", "fr:ingrédient inconnu"],],
 	[{lc => "en", ingredients_text => "Toasted mango and unknown fruit"}, ["en:mango", "en:unknown fruit"],],
+	[
+		{lc => "en", ingredients_text => "colour (Natural Red 4, mg/kg 1b306(i))"},
+		["en:e120", "en:mg/kg 1b306", "en:i"],
+	],
 
 );
 


### PR DESCRIPTION
### What

Fixes the six failing ingredient and taxonomy-enhancer assertions in #14491. Ordinary unknown or misspelled additive children are flattened again, keeping ingredient lists aligned across languages. The child-recognition check is now limited to protected compound-unit cases such as `mg/kg`, where it also handles processing and localized conjunctions.

The class is still kept for unrecognized unit text such as `mg/kg 1b306(i)`. Quantity removal requires an explicit unit, preserving additive names such as `Natural Red 4`; one regression case covers this.

The four taxonomy-enhancer failures also reproduced after merging `main` at `baaa4e0e1` into the original correction branch. They require the parser fix here.

One export snapshot is restored to its value on `main`: #14491's test-result update had recorded the regression for `colorants : lutéine et anthocyanes`. The restored ingredient tags match the actual CI export exactly; no other snapshots change.

### Testing

- On this branch at `bd422c02e3` and on its local merge with `main`: `ingredients_processing.t` 86/86, `ingredients_tags.t` 90/90, `ingredients.t` 132/132, `taxonomies_enhancer.t` 48/48.
- Full unit suite on that local merge: 90 files, 7,446 assertions passed. The sparse checkout was expanded to include the tracked logo and label assets required by the tests.
- The new `Natural Red 4` assertion failed before the quantity fix and passed afterward.
- Perl compilation, perltidy, perlcritic, taxonomy checks, and `git diff --check` passed.
- [Final CI at `48af4e0cc7`](https://github.com/openfoodfacts/openfoodfacts-server/actions/runs/34418608897) passed all six unit groups, all nine integration groups (including `export.t`), Perl checks, frontend checks, and `make dev`. The restored snapshot is valid JSON, identical to `main`, and matches the generated export.

### Large Language Models usage disclosure

OpenAI Codex (GPT-6) was used agentically for investigation, implementation, testing, and review. Local checks ran in Docker; remote checks ran in GitHub Actions.

### Related issue(s) and discussion

- Follow-up to #14491; targets `fix/ingredients-mg-per-kg-6132b`.
- Related to #6132.
