### PR TITLE
feat: Add Brazilian Portuguese interface and regional taxonomies

### DIFF
--- a/lib/ProductOpener/Config.pm
+++ b/lib/ProductOpener/Config.pm
@@ -110,6 +110,14 @@ autoload("ProductOpener::Config_$flavor");
 	},
 );
 
+# Regional variants of the web interface, mapped to their name in the variant itself.
+# Adding a code here makes it selectable, provided po/common/<code>.po and po/tags/<code>.po
+# exist and the base language is registered in the languages taxonomy.
+# Variants stay out of %Langs: product fields, taxonomies, APIs and exports keep using
+# the base language. Names are given here because the languages taxonomy only has ISO 639-1
+# entries. Codes use the normalized spelling: pt_BR, zh_Hant_TW.
+$ProductOpener::Config::options{interface_language_variants} = {pt_BR => 'Português (Brasil)'};
+
 %ProductOpener::Config::admins = map {$_ => 1} qw(
 	alex-off
 	charlesnepote

--- a/lib/ProductOpener/Display.pm
+++ b/lib/ProductOpener/Display.pm
@@ -133,6 +133,7 @@ use ProductOpener::ProductsTags qw/:all/;
 use ProductOpener::Users qw(:all);
 use ProductOpener::Texts qw(%texts);
 use ProductOpener::Lang qw(:all);
+use ProductOpener::I18N qw/base_language/;
 use ProductOpener::Images qw(display_image data_to_display_image add_images_urls_to_product);
 use ProductOpener::Food qw(:all);
 use ProductOpener::Ingredients qw(flatten_sub_ingredients);
@@ -337,8 +338,8 @@ Add some functions and variables needed by many templates and process the templa
 
 sub process_template ($template_filename, $template_data_ref, $result_content_ref, $request_ref = {}) {
 
-	# give priority to request_ref lc but eventually fallback to global $lc
-	my $target_lc = $request_ref->{lc} // $lc;
+	# Prefer the explicit interface locale, then the request language and globals.
+	my $target_lc = $request_ref->{interface_lc} // $request_ref->{lc} // current_interface_language();
 	# Add functions and values that are passed to all templates
 
 	# Features for each product type
@@ -396,6 +397,7 @@ sub process_template ($template_filename, $template_data_ref, $result_content_re
 	# using short names to favour readability
 	$template_data_ref->{esq} = sub {escape_char(@_, "\'")};    # esq as escape_single_quote_and_newlines
 	$template_data_ref->{edq} = sub {escape_char(@_, '"')};    # edq as escape_double_quote
+	$template_data_ref->{language_tag} = ProductOpener::I18N::language_tag($target_lc);
 	$template_data_ref->{lc} = $lc;
 	$template_data_ref->{cc} //= $request_ref->{cc};
 	$template_data_ref->{display_icon} = \&display_icon;
@@ -496,6 +498,8 @@ Reference to request object.
 =cut
 
 sub init_request ($request_ref = {}) {
+
+	$interface_lc = undef;
 
 	$log->debug("init_request - start", {request_ref => sanitize($request_ref)}) if $log->is_debug();
 
@@ -627,9 +631,9 @@ sub init_request ($request_ref = {}) {
 			$cc = $1;
 			$country = $country_codes{$cc};
 			$lc = $country_languages{$cc}[0];    # first official language
-			if (defined $language_codes{$2}) {
-				$lc = $2;
-				$lc =~ s/-/_/;    # pt-pt -> pt_pt
+			my $requested_lc = ProductOpener::I18N::normalize_language_code($2);
+			if (defined $requested_lc and exists $InterfaceLangs{$requested_lc}) {
+				$lc = $requested_lc;
 			}
 
 			$log->debug("subdomain matches known country code",
@@ -657,9 +661,8 @@ sub init_request ($request_ref = {}) {
 		redirect_to_url($request_ref, 302, $redirect_url);
 	}
 
-	$lc =~ s/_.*//;    # PT_PT doest not work yet: categories
-
-	if ((not defined $lc) or (($lc !~ /^\w\w(_|-)\w\w$/) and (length($lc) != 2))) {
+	$lc = ProductOpener::I18N::normalize_language_code($lc);
+	if ((not defined $lc) or (not exists $InterfaceLangs{$lc})) {
 		$log->debug("replacing unknown lc with en", {lc => $lc}) if $log->debug();
 		$lc = 'en';
 	}
@@ -700,9 +703,10 @@ sub init_request ($request_ref = {}) {
 	my $param_lc = single_param('lc');
 	if (defined $param_lc) {
 		# allow multiple languages in an ordered list
-		@lcs = split(/,/, lc($param_lc));
-		if (defined $language_codes{$lcs[0]}) {
+		@lcs = map {ProductOpener::I18N::normalize_language_code($_)} split(/,/, $param_lc);
+		if (defined $lcs[0] and exists $InterfaceLangs{$lcs[0]}) {
 			$lc = $lcs[0];
+			@lcs = grep {defined $_ and exists $InterfaceLangs{$_}} @lcs;
 			$cc_lc_overrides = 1;
 			$log->debug("lc override from request parameter", {lc => $lc, lcs => \@lcs}) if $log->is_debug();
 		}
@@ -717,9 +721,17 @@ sub init_request ($request_ref = {}) {
 	if ($cc_lc_overrides) {
 		$subdomain = $cc;
 		if (not((defined $country_languages{$cc}[0]) and ($lc eq $country_languages{$cc}[0]))) {
-			$subdomain .= "-" . $lc;
+			$subdomain .= "-" . lc(ProductOpener::I18N::language_tag($lc));
 		}
 	}
+
+	# Keep the selected interface locale out of product fields and taxonomy IDs.
+	# Regional product languages are a separate change.
+	$request_ref->{interface_lc} = $lc;
+	$interface_lc = base_language($lc) ne $lc ? $lc : undef;
+	$lc = base_language($lc);
+	my %seen_lcs;
+	@lcs = grep {!$seen_lcs{$_}++} map {base_language($_)} @lcs;
 
 	# Set cc, lc and lcs in the request object
 	# Ideally, we should rely on those fields in the request object
@@ -989,14 +1001,7 @@ sub set_user_agent_request_ref_attributes ($request_ref) {
 sub _get_date ($t) {
 
 	if (defined $t) {
-		my @codes = DateTime::Locale->codes;
-		my $locale;
-		if (grep {$_ eq $lc} @codes) {
-			$locale = DateTime::Locale->load($lc);
-		}
-		else {
-			$locale = DateTime::Locale->load('en');
-		}
+		my $locale = language_locale(current_interface_language());
 
 		my $dt = DateTime->from_epoch(
 			locale => $locale,
@@ -7705,32 +7710,35 @@ sub display_page ($request_ref) {
 	$template_data_ref->{bodyabout} = $request_ref->{bodyabout};
 	$template_data_ref->{site_name} = $site_name;
 
-	my $en = 0;
+	my $selected_lc = $request_ref->{interface_lc} // $request_lc;
 	my $langs = '';
 	my $selected_lang = '';
-
-	foreach my $olc (@{$country_languages{$request_ref->{cc}}}, 'en') {
-		if ($olc eq 'en') {
-			if ($en) {
-				next;
-			}
-			else {
-				$en = 1;
-			}
+	my %seen_languages;
+	my @country_lcs = @{$country_languages{$request_ref->{cc}} // []};
+	my @variants = grep {
+		my $base = base_language($_);
+		$base ne $_ and any {$base eq $_} @country_lcs
+	} @InterfaceLangs;
+	foreach my $olc (@country_lcs, @variants, $selected_lc, 'en') {
+		next if $seen_languages{$olc}++ or not exists $InterfaceLangs{$olc};
+		my $tag = ProductOpener::I18N::language_tag($olc);
+		my $osubdomain = "$request_ref->{cc}-" . lc($tag);
+		if ($olc eq $country_lcs[0]) {
+			$osubdomain = $request_ref->{cc};
 		}
-		if (exists $Langs{$olc}) {
-			my $osubdomain = "$request_ref->{cc}-$olc";
-			if ($olc eq $country_languages{$request_ref->{cc}}[0]) {
-				$osubdomain = $request_ref->{cc};
-			}
-			if (($olc eq $lc)) {
-				$selected_lang
-					= "<a href=\"" . format_subdomain($osubdomain) . "/\">" . ($Langs{$olc} // $olc) . "</a>\n";
-			}
-			else {
-				$langs
-					.= "<li><a href=\"" . format_subdomain($osubdomain) . "/\">" . ($Langs{$olc} // $olc) . "</a></li>";
-			}
+		my $link
+			= '<a href="'
+			. format_subdomain($osubdomain)
+			. '/" lang="'
+			. $tag
+			. '" hreflang="'
+			. $tag . '">'
+			. encode_entities($InterfaceLangs{$olc} // $olc) . '</a>';
+		if ($olc eq $selected_lc) {
+			$selected_lang = $link;
+		}
+		else {
+			$langs .= '<li>' . $link . '</li>';
 		}
 	}
 

--- a/lib/ProductOpener/I18N.pm
+++ b/lib/ProductOpener/I18N.pm
@@ -39,6 +39,12 @@ The functions used in this module take the directory to look for the .po files a
 package ProductOpener::I18N;
 
 use ProductOpener::PerlStandards;
+use Exporter qw/import/;
+
+our @EXPORT_OK = qw/$language_code_re normalize_language_code language_tag base_language
+	language_fallbacks lookup_with_language_fallback/;
+our %EXPORT_TAGS = (all => \@EXPORT_OK);
+our $language_code_re = qr/[a-z]{2,3}(?:[-_][a-z]{4})?(?:[-_](?:[a-z]{2}|[0-9]{3}))?/iaa;
 
 use File::Basename;
 use File::Find::Rule;
@@ -79,6 +85,119 @@ my @metadata_fields = qw<
 
 =head1 FUNCTIONS
 
+=head2 normalize_language_code( $code )
+
+=head3 Arguments
+
+C<$code> is a two- or three-letter language, optionally followed by a script and
+a region. C<$language_code_re> is the same grammar, without anchors or captures,
+for use in filenames and taxonomy prefixes. Hyphens, underscores and mixed case
+are accepted; callers can require the normalized spelling.
+
+=head3 Return values
+
+The internal spelling (C<pt_BR>, C<zh_Hant_TW>), or undef for unsupported syntax.
+This does not register or enable a language.
+
+=cut
+
+sub normalize_language_code ($code) {
+	return if not defined $code or $code !~ /\A$language_code_re\z/;
+	my ($language, @subtags) = split /[-_]/, $code;
+	return join('_', lc($language), map {length($_) == 4 ? ucfirst(lc($_)) : uc($_)} @subtags);
+}
+
+=head2 language_tag( $code )
+
+=head3 Arguments
+
+C<$code> is a supported internal or external language code.
+
+=head3 Return values
+
+The BCP-47 spelling (C<pt-BR>), or undef for unsupported syntax.
+
+=cut
+
+sub language_tag ($code) {
+	my $tag = normalize_language_code($code);
+	return if not defined $tag;
+	$tag =~ s/_/-/g;
+	return $tag;
+}
+
+=head2 base_language( $code )
+
+=head3 Arguments
+
+C<$code> is a supported internal or external language code.
+
+=head3 Return values
+
+The language without script or region (C<pt>, C<zh>), or undef for invalid syntax.
+
+=cut
+
+sub base_language ($code) {
+	my $canonical = normalize_language_code($code);
+	return if not defined $canonical;
+	return (split /_/, $canonical)[0];
+}
+
+=head2 language_fallbacks( $code )
+
+=head3 Arguments
+
+C<$code> is a supported language code.
+
+=head3 Return values
+
+An ordered list of normalized codes, from specific to general, for example
+C<zh_Hant_TW>, C<zh_Hant>, C<zh>. An invalid code returns an empty list.
+No unrelated language is added.
+
+=cut
+
+sub language_fallbacks ($code) {
+	my $canonical = normalize_language_code($code);
+	return () if not defined $canonical;
+	my @languages = ($canonical);
+	while ($canonical =~ s/_[^_]+$//) {
+		push @languages, $canonical;
+	}
+	return @languages;
+}
+
+=head2 lookup_with_language_fallback( $hash_ref, $code, $matched_code_ref = undef )
+
+=head3 Arguments
+
+C<$hash_ref> maps normalized language codes to values. C<$code> selects the
+language. The optional C<$matched_code_ref> receives the code that supplied the
+value, or undef on a miss. Non-language keys such as C<no_language> are exact-only.
+
+=head3 Return values
+
+The first defined value in the language's fallback chain, or undef. Zero and
+empty strings are values too. The hash is not modified, and English fallback is
+left to the caller.
+
+=cut
+
+sub lookup_with_language_fallback ($hash_ref, $code, $matched_code_ref = undef) {
+	$$matched_code_ref = undef if defined $matched_code_ref;
+	return if not defined $code or not defined $hash_ref;
+	my @languages = language_fallbacks($code);
+	@languages = ($code) if not @languages;
+	foreach my $language (@languages) {
+		if (defined $hash_ref->{$language}) {
+			$$matched_code_ref = $language if defined $matched_code_ref;
+			return $hash_ref->{$language};
+		}
+	}
+	return;
+}
+
 =head2 read_po_files( $dir, $languages_ref )
 
 Read and merge .po files into one hash, removing gettext metadata and empty
@@ -88,9 +207,9 @@ translations written by Crowdin.
 
 C<$dir> is the directory containing the .po files.
 
-Basenames must use two or three lowercase language letters, optionally followed by
-C<_> and two uppercase region letters or three digits: C<en.po>, C<pt_BR.po>,
-C<kmr_TR.po>, C<es_419.po>. The complete code remains the translation key.
+Basenames must use the normalized spelling: C<en.po>, C<pt_BR.po>, C<kmr_TR.po>,
+C<es_419.po>, C<zh_Hant.po> or C<zh_Hant_TW.po>.
+The complete code remains the translation key.
 
 The optional C<$languages_ref> hash restricts loading to its keys, matched exactly
 including case (C<pt_BR>, not C<pt_br>). Omit it to load all matching catalogs.
@@ -123,13 +242,14 @@ sub read_po_files ($dir, $languages_ref = undef) {
 		$log->debug("Reading po file");
 
 		my $lc;
-		if ($filename =~ /\A([a-z]{2,3}(?:_(?:[A-Z]{2}|[0-9]{3}))?)\.po\z/) {
-			$lc = $1;
+		if ($filename =~ /\A($language_code_re)\.po\z/) {
+			$lc = normalize_language_code($1);
 		}
 		else {
-			$log->debug("Skipping file (not in language.po or language_REGION.po format)");
+			$log->debug("Skipping file (not in language.po format)");
 			next;
 		}
+		next if $filename ne "$lc.po";
 
 		if ((defined $languages_ref) and (not exists $languages_ref->{$lc})) {
 			$log->debug("Skipping file (language code is not registered with this exact case)", {lc => $lc});
@@ -226,4 +346,3 @@ sub split_tags {
 1;
 
 __END__
-

--- a/lib/ProductOpener/I18N.pm
+++ b/lib/ProductOpener/I18N.pm
@@ -329,8 +329,11 @@ sub split_tags {
 	my ($l10n) = @_;
 
 	my (%singular, %plural);
-	$singular{":langname"} = $plural{":langname"} = delete $l10n->{":langname"};
-	$singular{":langtag"} = $plural{":langtag"} = delete $l10n->{":langtag"};
+	# Do not create undefined entries: po/tags catalogs do not all define these keys.
+	foreach my $key (":langname", ":langtag") {
+		next if not exists $l10n->{$key};
+		$singular{$key} = $plural{$key} = delete $l10n->{$key};
+	}
 
 	for my $key (keys %{$l10n}) {
 		my ($tag, $kind) = split /:/, $key;

--- a/lib/ProductOpener/I18N.pm
+++ b/lib/ProductOpener/I18N.pm
@@ -79,24 +79,31 @@ my @metadata_fields = qw<
 
 =head1 FUNCTIONS
 
-=head2 read_po_files()
+=head2 read_po_files( $dir, $languages_ref )
 
-C<read_po_files()> takes directory of the .po files as an input parameter, reads and merges them in one hash
-That hash is returned as a reference. (Done to spare the stack) Returning a reference uses a bit less memory since there's no copy.
-This function also cleans up the %Lexicon from gettext metadata 
-and cleans up the empty values that are put in .po files by Crowdin when the string is not translated.
+Read and merge .po files into one hash, removing gettext metadata and empty
+translations written by Crowdin.
 
 =head3 Arguments
 
-The directory containing .po files are passed as an argument.
+C<$dir> is the directory containing the .po files.
+
+Basenames must use two or three lowercase language letters, optionally followed by
+C<_> and two uppercase region letters or three digits: C<en.po>, C<pt_BR.po>,
+C<kmr_TR.po>, C<es_419.po>. The complete code remains the translation key.
+
+The optional C<$languages_ref> hash restricts loading to its keys, matched exactly
+including case (C<pt_BR>, not C<pt_br>). Omit it to load all matching catalogs.
+Callers handle language registration and translation fallbacks.
 
 =head3 Return values
 
-Returns a reference to a hash on successful execution.
+A hash reference mapping string IDs to translations by language. Returning a
+reference avoids copying the hash and spares the stack.
 
 =cut
 
-sub read_po_files ($dir) {
+sub read_po_files ($dir, $languages_ref = undef) {
 
 	local $log->context->{directory} = $dir;
 	$log->debug("Reading po files from disk");
@@ -111,16 +118,21 @@ sub read_po_files ($dir) {
 
 	for my $file (sort @files) {
 		# read the .po file
-		local $log->context->{file} = basename($file);
+		my $filename = basename($file);
+		local $log->context->{file} = $filename;
 		$log->debug("Reading po file");
 
 		my $lc;
-
-		if ($file =~ /\/(\w\w).po/) {
+		if ($filename =~ /\A([a-z]{2,3}(?:_(?:[A-Z]{2}|[0-9]{3}))?)\.po\z/) {
 			$lc = $1;
 		}
 		else {
-			$log->debug("Skipping file (not in [2-letter code].po format)");
+			$log->debug("Skipping file (not in language.po or language_REGION.po format)");
+			next;
+		}
+
+		if ((defined $languages_ref) and (not exists $languages_ref->{$lc})) {
+			$log->debug("Skipping file (language code is not registered with this exact case)", {lc => $lc});
 			next;
 		}
 

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -293,8 +293,9 @@ else {
 my @debug_taxonomies = ("categories", "labels", "additives");
 
 # Build hashes to map a translated tag type (e.g. "catégorie") in singular or plural to the tag type (e.g. "categories")
+# The registry must include en, which supplies the fallback paths for all languages.
 
-sub build_lang_tags() {
+sub build_lang_tags ($Languages_ref) {
 
 	# Tags types to path components in URLS: in ascii, lowercase, unaccented,
 	# transliterated (in Roman characters)
@@ -302,11 +303,13 @@ sub build_lang_tags() {
 	# Note: a lot of plurals are currently missing below, commented-out are
 	# the singulars that need to be changed to plurals
 	my ($tag_type_singular_ref, $tag_type_plural_ref)
-		= ProductOpener::I18N::split_tags(ProductOpener::I18N::read_po_files("$data_root/po/tags/"));
+		= ProductOpener::I18N::split_tags(ProductOpener::I18N::read_po_files("$data_root/po/tags/", $Languages_ref));
 	%tag_type_singular = %{$tag_type_singular_ref};
 	%tag_type_plural = %{$tag_type_plural_ref};
+	%tag_type_from_singular = ();
+	%tag_type_from_plural = ();
 
-	foreach my $l (@Langs) {
+	foreach my $l (sort keys %{$Languages_ref}) {
 
 		my $short_l = undef;
 		if ($l =~ /_/) {
@@ -372,7 +375,9 @@ sub build_lang ($Languages_ref) {
 	# UI strings, non-Roman characters can be used
 	my $path = "$data_root/po/common/";
 	$log->info("Loading common \%Lang", {path => $path});
-	%Lang = %{ProductOpener::I18N::read_po_files($path)};
+	# Only compile registered languages. Otherwise, regional entries in the 'add' key
+	# would become selectable languages when Lang.sto is loaded, without initialization.
+	%Lang = %{ProductOpener::I18N::read_po_files($path, $Languages_ref)};
 
 	# Load the .pot file
 	my %common_keys = %{ProductOpener::I18N::read_pot_file($path . "common.pot")};

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -51,6 +51,7 @@ BEGIN {
 		%Langs
 		@Langs
 
+		&language_locale
 		&lang
 		&f_lang
 		&f_lang_in_lc
@@ -64,7 +65,7 @@ BEGIN {
 }
 
 use vars @EXPORT_OK;
-use ProductOpener::I18N;
+use ProductOpener::I18N qw/normalize_language_code language_tag lookup_with_language_fallback/;
 use ProductOpener::Store qw/get_string_id_for_lang retrieve/;
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/%BASE_DIRS ensure_dir_created_or_die/;
@@ -80,6 +81,26 @@ use Log::Any qw($log);
 $lc = "en";
 
 =head1 FUNCTIONS
+
+=head2 language_locale( $code )
+
+Return the calendar locale for a language, falling back through its language
+parents and then to English when missing.
+Chinese catalog region codes need an explicit script for DateTime::Locale.
+
+=cut
+
+sub language_locale ($code) {
+	my %chinese_locales = (zh_CN => 'zh-Hans-CN', zh_TW => 'zh-Hant-TW', zh_HK => 'zh-Hant-HK');
+	my $canonical = normalize_language_code($code);
+	state %available = map {
+		my $language = normalize_language_code($_);
+		defined $language ? ($language => $_) : ()
+	} DateTime::Locale->codes;
+	my $requested = defined $canonical ? ($chinese_locales{$canonical} // $canonical) : undef;
+	my $locale = lookup_with_language_fallback(\%available, $requested) // 'en';
+	return DateTime::Locale->load($locale);
+}
 
 =head2 separator_before_colon( $l )
 
@@ -309,35 +330,16 @@ sub build_lang_tags ($Languages_ref) {
 	%tag_type_from_singular = ();
 	%tag_type_from_plural = ();
 
+	foreach my $paths_ref (\%tag_type_singular, \%tag_type_plural) {
+		foreach my $type (keys %{$paths_ref}) {
+			my %translations = %{$paths_ref->{$type}};
+			foreach my $l (sort keys %{$Languages_ref}) {
+				$paths_ref->{$type}{$l} = lookup_with_language_fallback(\%translations, $l) // $translations{en};
+			}
+		}
+	}
+
 	foreach my $l (sort keys %{$Languages_ref}) {
-
-		my $short_l = undef;
-		if ($l =~ /_/) {
-			$short_l = $`;    # pt_pt
-		}
-
-		foreach my $type (keys %tag_type_singular) {
-
-			if (not defined $tag_type_singular{$type}{$l}) {
-				if ((defined $short_l) and (defined $tag_type_singular{$type}{$short_l})) {
-					$tag_type_singular{$type}{$l} = $tag_type_singular{$type}{$short_l};
-				}
-				else {
-					$tag_type_singular{$type}{$l} = $tag_type_singular{$type}{en};
-				}
-			}
-		}
-
-		foreach my $type (keys %tag_type_plural) {
-			if (not defined $tag_type_plural{$type}{$l}) {
-				if ((defined $short_l) and (defined $tag_type_plural{$type}{$short_l})) {
-					$tag_type_plural{$type}{$l} = $tag_type_plural{$type}{$short_l};
-				}
-				else {
-					$tag_type_plural{$type}{$l} = $tag_type_plural{$type}{en};
-				}
-			}
-		}
 
 		$tag_type_from_singular{$l} or $tag_type_from_singular{$l} = {};
 		$tag_type_from_plural{$l} or $tag_type_from_plural{$l} = {};
@@ -407,24 +409,10 @@ sub build_lang ($Languages_ref) {
 
 	foreach my $key (sort keys %common_keys) {
 		if ((defined $Lang{$key}{en}) and ($Lang{$key}{en} ne '')) {
+			my %translations = %{$Lang{$key}};
 			foreach my $l (@Langs) {
-
-				my $short_l = undef;
-				if ($l =~ /_/) {
-					$short_l = $`;    # pt_pt
-				}
-
-				if (not defined $Lang{$key}{$l}) {
-					if ((defined $short_l) and (defined $Lang{$key}{$short_l})) {
-						$Lang{$key}{$l} = $Lang{$key}{$short_l};
-					}
-					elsif (defined $Lang{$key}{en}) {
-						$Lang{$key}{$l} = $Lang{$key}{en};
-					}
-					else {
-						$Lang{$key}{$l} = $Lang{$key}{fr};
-					}
-				}
+				$Lang{$key}{$l} = lookup_with_language_fallback(\%translations, $l) // $translations{en}
+					// $translations{fr};
 
 				my $tagid = get_string_id_for_lang($l, $Lang{$key}{$l});
 			}
@@ -467,16 +455,8 @@ sub build_lang ($Languages_ref) {
 		}
 	}
 
-	my $en_locale = DateTime::Locale->load('en');
-	my @locale_codes = DateTime::Locale->codes;
 	foreach my $l (@Langs) {
-		my $locale;
-		if (grep {$_ eq $l} @locale_codes) {
-			$locale = DateTime::Locale->load($l);
-		}
-		else {
-			$locale = $en_locale;
-		}
+		my $locale = language_locale($l);
 
 		my @months = ();
 		foreach my $month (1 .. 12) {
@@ -508,27 +488,12 @@ sub build_json {
 	}
 
 	foreach my $l (@Langs) {
-		my $target_dir = "$i18n_root/$l";
+		my $target_dir = "$i18n_root/" . language_tag($l);
 		ensure_dir_created_or_die($target_dir);
-
-		my $short_l = undef;
-		if ($l =~ /_/) {
-			$short_l = $`;    # pt_pt
-		}
 
 		my %result = ();
 		foreach my $s (keys %Lang) {
-			my $value;
-
-			if (defined $Lang{$s}{$l}) {
-				$value = $Lang{$s}{$l};
-			}
-			elsif ((defined $short_l) and (defined $Lang{$s}{$short_l}) and ($Lang{$s}{$short_l} ne '')) {
-				$value = $Lang{$s}{$short_l};
-			}
-			elsif ((defined $Lang{$s}{en}) and ($Lang{$s}{en} ne '')) {
-				$value = $Lang{$s}{en};
-			}
+			my $value = lookup_with_language_fallback($Lang{$s}, $l) // $Lang{$s}{en};
 
 			$result{$s} = $value if $value;
 		}

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -332,6 +332,7 @@ sub build_lang_tags ($Languages_ref) {
 
 	foreach my $paths_ref (\%tag_type_singular, \%tag_type_plural) {
 		foreach my $type (keys %{$paths_ref}) {
+			next if not defined $paths_ref->{$type};
 			my %translations = %{$paths_ref->{$type}};
 			foreach my $l (sort keys %{$Languages_ref}) {
 				$paths_ref->{$type}{$l} = lookup_with_language_fallback(\%translations, $l) // $translations{en};

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -42,6 +42,9 @@ BEGIN {
 	use vars qw(@ISA @EXPORT_OK %EXPORT_TAGS);
 	@EXPORT_OK = qw(
 		$lc
+		$interface_lc
+		%InterfaceLangs
+		@InterfaceLangs
 
 		%tag_type_singular
 		%tag_type_from_singular
@@ -51,6 +54,8 @@ BEGIN {
 		%Langs
 		@Langs
 
+		&interface_languages
+		&current_interface_language
 		&language_locale
 		&lang
 		&f_lang
@@ -65,7 +70,7 @@ BEGIN {
 }
 
 use vars @EXPORT_OK;
-use ProductOpener::I18N qw/normalize_language_code language_tag lookup_with_language_fallback/;
+use ProductOpener::I18N qw/normalize_language_code language_tag base_language lookup_with_language_fallback/;
 use ProductOpener::Store qw/get_string_id_for_lang retrieve/;
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/%BASE_DIRS ensure_dir_created_or_die/;
@@ -81,6 +86,43 @@ use Log::Any qw($log);
 $lc = "en";
 
 =head1 FUNCTIONS
+
+=head2 interface_languages( $languages_ref )
+
+Build the interface registry from the product languages and the variants listed in
+$options{interface_language_variants}. Variants have their own native names; they
+are not ISO 639-1 codes in the languages taxonomy. A variant whose base language is
+not registered is skipped.
+
+=cut
+
+sub interface_languages ($languages_ref) {
+	my %registry = %{$languages_ref};
+	my $variants_ref = $options{interface_language_variants} // {};
+	foreach my $code (sort keys %{$variants_ref}) {
+		my $canonical = normalize_language_code($code);
+		if (not defined $canonical) {
+			$log->error("Ignoring interface language variant with invalid syntax", {code => $code})
+				if $log->is_error();
+			next;
+		}
+		my $base = base_language($canonical);
+		next if not exists $registry{$base};
+		$registry{$canonical} = {%{$registry{$base}}, $canonical => $variants_ref->{$code}};
+	}
+	return \%registry;
+}
+
+=head2 current_interface_language()
+
+Use the selected interface variant while its base matches C<$lc>. Code that
+explicitly switches C<$lc>, for example to generate an English link, keeps working.
+
+=cut
+
+sub current_interface_language () {
+	return defined $interface_lc && base_language($interface_lc) eq $lc ? $interface_lc : $lc;
+}
 
 =head2 language_locale( $code )
 
@@ -100,6 +142,17 @@ sub language_locale ($code) {
 	my $requested = defined $canonical ? ($chinese_locales{$canonical} // $canonical) : undef;
 	my $locale = lookup_with_language_fallback(\%available, $requested) // 'en';
 	return DateTime::Locale->load($locale);
+}
+
+# Keep the registries used by product forms, APIs and exports limited to base
+# languages. Interface variants are selectable only through %InterfaceLangs.
+sub init_language_names () {
+	@InterfaceLangs = sort keys %{$Lang{add}};
+	%InterfaceLangs = map {$_ => $Lang{'language_' . $_}{$_}} @InterfaceLangs;
+	@Langs = grep {base_language($_) eq $_} @InterfaceLangs;
+	%Langs = map {$_ => $InterfaceLangs{$_}} @Langs;
+	%lang_lc = map {$_ => $_} @Langs;
+	return;
 }
 
 =head2 separator_before_colon( $l )
@@ -127,7 +180,7 @@ sub separator_before_colon ($l) {
 
 =head2 lang( $stringid )
 
-Returns a translation for a specific string id in the language defined in the $lc global variable.
+Returns a translation in $interface_lc when selected, or in $lc otherwise.
 
 If a translation is not available, the function returns English.
 
@@ -140,13 +193,13 @@ In the .po translation files, we use the msgctxt field for the string id.
 =cut
 
 sub lang ($stringid) {
-	return lang_in_other_lc($lc, $stringid);
+	return lang_in_other_lc(current_interface_language(), $stringid);
 }
 
 =head2 f_lang( $stringid, $variables_ref )
 
 Returns a translation for a specific string id with specific arguments
-in the language defined in the $lc global variable.
+in $interface_lc when selected, or in $lc otherwise.
 
 The translation is stored using Python's f-string format with
 named parameters between { }.
@@ -172,7 +225,7 @@ Reference to a hash that contains values for the variables that will be replaced
 
 sub f_lang ($stringid, $variables_ref) {
 
-	return f_lang_in_lc($lc, $stringid, $variables_ref);
+	return f_lang_in_lc(current_interface_language(), $stringid, $variables_ref);
 }
 
 =head2 f_lang_in_lc ( $target_lc, $stringid, $variables_ref )
@@ -275,13 +328,7 @@ if (-e $path) {
 			if $log->is_error();
 		die("Language translation file does not contain the 'add' key, \%Lang will be empty.");
 	}
-	@Langs = sort keys %{$Lang{$msgctxt}};
-	%Langs = ();
-	%lang_lc = ();
-	foreach my $l (@Langs) {
-		$lang_lc{$l} = $l;
-		$Langs{$l} = $Lang{"language_" . $l}{$l};    # Name of the language in the language itself
-	}
+	init_language_names();
 
 	$log->info("Loaded languages", {langs => (scalar @Langs)}) if $log->is_info();
 }
@@ -371,8 +418,8 @@ sub build_lang_tags ($Languages_ref) {
 # - compute missing values by assigning English values
 
 sub build_lang ($Languages_ref) {
-	# $Languages_ref is a hash of languages with translations initialized from the languages taxonomy by Tags.pm
-	# Note: all .po files must have a corresponding entry in the languages.txt taxonomy
+	# $Languages_ref contains language names from the taxonomy and the explicitly
+	# enabled interface variants returned by interface_languages().
 
 	# Load the strings from the .po files
 	# UI strings, non-Roman characters can be used
@@ -385,13 +432,11 @@ sub build_lang ($Languages_ref) {
 	# Load the .pot file
 	my %common_keys = %{ProductOpener::I18N::read_pot_file($path . "common.pot")};
 
-	# Initialize %Langs and @Langs and add language names to %Lang
+	# Add language names before initializing the product and interface registries.
 
-	%Langs = %{$Languages_ref};
-	@Langs = sort keys %{$Languages_ref};
-	foreach my $l (@Langs) {
+	my @languages = sort keys %{$Languages_ref};
+	foreach my $l (@languages) {
 		$Lang{"language_" . $l} = $Languages_ref->{$l};
-		$Langs{$l} = $Languages_ref->{$l}{$l};    # Name of the language in the language itself
 	}
 
 	# Save to file, for debugging and comparing purposes
@@ -411,7 +456,7 @@ sub build_lang ($Languages_ref) {
 	foreach my $key (sort keys %common_keys) {
 		if ((defined $Lang{$key}{en}) and ($Lang{$key}{en} ne '')) {
 			my %translations = %{$Lang{$key}};
-			foreach my $l (@Langs) {
+			foreach my $l (@languages) {
 				$Lang{$key}{$l} = lookup_with_language_fallback(\%translations, $l) // $translations{en}
 					// $translations{fr};
 
@@ -447,7 +492,7 @@ sub build_lang ($Languages_ref) {
 	# Some translations have <<site_name>> in them, replace it with the site name
 	my $site_name = $options{site_name};
 
-	foreach my $l (@Langs) {
+	foreach my $l (@languages) {
 		foreach my $key (keys %Lang) {
 			if (not defined $Lang{$key}{$l}) {
 				next;
@@ -456,7 +501,7 @@ sub build_lang ($Languages_ref) {
 		}
 	}
 
-	foreach my $l (@Langs) {
+	foreach my $l (@languages) {
 		my $locale = language_locale($l);
 
 		my @months = ();
@@ -477,6 +522,7 @@ sub build_lang ($Languages_ref) {
 		$Lang{weekdays}{$l} = decode("utf8", encode_json(\@weekdays));
 	}
 
+	init_language_names();
 	return;
 }    # build_lang
 
@@ -488,7 +534,7 @@ sub build_json {
 		mkdir($i18n_root, 0755) or die("Could not create target directory $i18n_root : $!\n");
 	}
 
-	foreach my $l (@Langs) {
+	foreach my $l (@InterfaceLangs) {
 		my $target_dir = "$i18n_root/" . language_tag($l);
 		ensure_dir_created_or_die($target_dir);
 

--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -57,6 +57,7 @@ BEGIN {
 use vars @EXPORT_OK;    # no 'my' keyword for these
 
 use ProductOpener::Config qw/:all/;
+use ProductOpener::I18N qw/lookup_with_language_fallback/;
 use ProductOpener::Paths qw/:all/;
 
 use Storable qw(lock_store lock_retrieve);
@@ -130,14 +131,9 @@ sub get_string_id_for_lang ($lc, $string) {
 	my $unaccent = $string_normalization_for_lang{default}{unaccent};
 	my $lowercase = $string_normalization_for_lang{default}{lowercase};
 
-	if (defined $string_normalization_for_lang{$lc}) {
-		if (defined $string_normalization_for_lang{$lc}{unaccent}) {
-			$unaccent = $string_normalization_for_lang{$lc}{unaccent};
-		}
-		if (defined $string_normalization_for_lang{$lc}{lowercase}) {
-			$lowercase = $string_normalization_for_lang{$lc}{lowercase};
-		}
-	}
+	my $normalization_ref = lookup_with_language_fallback(\%string_normalization_for_lang, $lc) // {};
+	$unaccent = $normalization_ref->{unaccent} // $unaccent;
+	$lowercase = $normalization_ref->{lowercase} // $lowercase;
 
 	if ($lowercase) {
 		# do not lowercase UUIDs

--- a/lib/ProductOpener/Tags.pm
+++ b/lib/ProductOpener/Tags.pm
@@ -181,6 +181,8 @@ use ProductOpener::Store qw/:all/;
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/%BASE_DIRS ensure_dir_created_or_die get_files_for_taxonomy get_path_for_taxonomy_file/;
 use ProductOpener::Lang qw/$lc  %Lang %tag_type_plural %tag_type_singular lang/;
+use ProductOpener::I18N qw/$language_code_re normalize_language_code base_language
+	language_fallbacks lookup_with_language_fallback/;
 use ProductOpener::Text qw/normalize_percentages regexp_escape/;
 use ProductOpener::PackagerCodes qw/localize_packager_code normalize_packager_codes/;
 use ProductOpener::Texts qw/$lang_dir/;
@@ -808,18 +810,24 @@ Lowercased, unaccented depending on language, non-alphanumeric chars turned to d
 
 sub remove_stopwords ($tagtype, $lc, $tagid) {
 
-	if (defined $stopwords{$tagtype}{$lc}) {
+	# Use base-language stopwords when a variant has no list of its own.
+	my $words_lc;
+	my $words_ref = lookup_with_language_fallback($stopwords{$tagtype}, $lc, \$words_lc);
+	my $base_lc = base_language($lc) // $lc;
+	$lc = $words_lc // $lc;
+
+	if (defined $words_ref) {
 
 		my $uppercased_stopwords_overrides = 0;
 
-		if ($lc eq 'en') {
+		if ($base_lc eq 'en') {
 			# in English, "a" is a stopwords for ingredients, but we do not want to remove it at the end of a tag
 			# e.g. "Cochineal Red A" -> "cochineal-red-a" --> "a" should not be a stopword
 			$tagid =~ s/a$/A/;
 			$uppercased_stopwords_overrides = 1;
 		}
 
-		if ($lc eq 'fr') {
+		if ($base_lc eq 'fr') {
 			# "Dés de tomates" -> "des-de-tomates" --> "dés" should not be a stopword
 			$tagid =~ s/\bdes-de\b/DES-DE/g;
 			$tagid =~ s/\ben-des\b/EN-DES/g;
@@ -833,7 +841,7 @@ sub remove_stopwords ($tagtype, $lc, $tagid) {
 		my $regexp = $stopwords_regexps{$tagtype . '.' . $lc};
 
 		# In Japanese, do not require a word boundary, and do not introduce a hyphen
-		if ($lc eq 'ja') {
+		if ($base_lc eq 'ja') {
 			$tagid =~ s/$regexp//g;
 		}
 		# In other languages, require a word boundary, and replace stopwords with a hyphen
@@ -853,6 +861,8 @@ sub remove_stopwords ($tagtype, $lc, $tagid) {
 }
 
 sub remove_plurals ($lc, $tagid) {
+
+	$lc = base_language($lc) // $lc;
 
 	if ($lc eq 'en') {
 		$tagid =~ s/s$//;
@@ -884,6 +894,9 @@ Sanitize a taxonomy line before processing
 sub sanitize_taxonomy_line ($line) {
 
 	chomp($line);
+
+	# Normalize translation, parent, synonym, stopword and property language prefixes.
+	$line =~ s/^((?:<\s*|[a-z0-9_.-]+:)?)( $language_code_re ):/$1 . normalize_language_code($2) . ':'/ex;
 
 	$line =~ s/’/'/g;    # normalize quotes
 
@@ -995,7 +1008,7 @@ sub get_file_from_cache ($source, $target) {
 # e.g. if the taxonomy building algorithm or configuration has changed
 # This needs to be done also when the unaccenting parameters for languages set in Config.pm are changed
 
-my $BUILD_TAGS_VERSION = "20260806 - fix the computation of levels for parents";
+my $BUILD_TAGS_VERSION = "20260912 - preserve regional taxonomy languages";
 
 sub get_from_cache ($tagtype, @files) {
 	# If the full set of cached files can't be found then returns the hash to be used
@@ -1389,7 +1402,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				# Parent
 				# Ignore in first pass as it may be a synonym, or a translation, for the canonical parent
 			}
-			elsif ($line =~ /^stopwords:(\w\w):(\s*)(.*)/) {
+			elsif ($line =~ /^stopwords:($language_code_re):(\s*)(.*)/) {
 				# stop words definition
 				my $lc = $1;
 				my $rest = $3;
@@ -1409,7 +1422,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 					push @{$stopwords{$tagtype}{$lc . ".strings"}}, $tag;
 				}
 			}
-			elsif ($line =~ /^(synonyms:)?(\w\w):(.*)/) {
+			elsif ($line =~ /^(synonyms:)?($language_code_re):((?!$language_code_re:).*)/) {
 				# line with regular entry or a synonyms entry
 				my $qualifier = $1;    # eventual synonyms prefix
 				my $lc = $2;
@@ -1841,7 +1854,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 			# skip comments lines
 			next if ($line =~ /^\#/);
 
-			if ($line =~ /^<(\s*)(\w\w):/) {
+			if ($line =~ /^<(\s*)($language_code_re):/) {
 				# Parent lines, starting with "<".
 
 				my $lc = $2;
@@ -1852,7 +1865,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				$parents{$main_parentid}++;
 				# display a warning if the same parent is specified twice?
 			}
-			elsif ($line =~ /^(\w\w):/) {
+			elsif ($line =~ /^($language_code_re):(?!$language_code_re:)/) {
 				# Synonym/translation lines, starting with a language code.
 
 				my $lc = $1;
@@ -1912,7 +1925,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 					}
 				}
 			}
-			elsif ($line =~ /^([a-z0-9_\-\.]+):(\w\w):(\s*)/) {
+			elsif ($line =~ /^([a-z0-9_\-\.]+):($language_code_re):(\s*)/) {
 				# property lines - wikidata:en:, description:fr:, etc.
 
 				my $property = $1;
@@ -1974,7 +1987,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				# ignore comments lines
 				next if ($line =~ /^\#/);
 
-				if ($line =~ /^(\w\w):/) {
+				if ($line =~ /^($language_code_re):(?!$language_code_re:)/) {
 					my $lc = $1;
 					$line = $';
 					# TODO: why not use get_lc_tagid here ?
@@ -1988,7 +2001,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 						$canon_tagid = "$lc:$lc_tagid";
 					}
 				}
-				elsif ($line =~ /^([a-z0-9_\-\.]+):(\w\w):(\s*)/) {
+				elsif ($line =~ /^([a-z0-9_\-\.]+):($language_code_re):(\s*)/) {
 					my $property = $1;
 					my $lc = $2;
 					$line = $';
@@ -2131,7 +2144,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 				$taxonomy_full_json{$tagid}{parents} = [];
 				foreach my $parentid (sort keys %{$direct_parents{$tagtype}{$tagid}}) {
 					my $lc = $parentid;
-					$lc =~ s/^(\w\w):.*/$1/;
+					$lc =~ s/^($language_code_re):.*/$1/;
 					if (not exists $translations_to{$tagtype}{$parentid}{$lc}) {
 						my $msg = "$tagid has an undefined parent $parentid\n";
 						push(@taxonomy_errors, _taxonomy_error("ERROR", "unknown_parent", $msg));
@@ -2156,7 +2169,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 			}
 
 			my $main_lc = $tagid;
-			$main_lc =~ s/^(\w\w):.*/$1/;
+			$main_lc =~ s/^($language_code_re):.*/$1/;
 
 			my $i = 0;
 
@@ -2219,7 +2232,7 @@ sub build_tags_taxonomy ($tagtype, $publish) {
 
 				foreach my $prop_lc (sort keys %{$properties{$tagtype}{$tagid}}) {
 					print $OUT "$prop_lc: " . $properties{$tagtype}{$tagid}{$prop_lc} . "\n";
-					if ($prop_lc =~ /^(.*):(\w\w)$/) {
+					if ($prop_lc =~ /^(.*):($language_code_re)$/) {
 						my $prop = $1;
 						my $lc = $2;
 
@@ -3017,7 +3030,7 @@ sub get_city_code ($tag) {
 # This function is not efficient (calls too many other functions) and should be removed
 sub get_tag_css_class ($target_lc, $tagtype, $tag) {
 
-	$target_lc =~ s/_.*//;
+	$target_lc = base_language($target_lc) // $target_lc;
 	$tag = display_taxonomy_tag($target_lc, $tagtype, $tag);
 
 	my $canon_tagid = canonicalize_taxonomy_tag($target_lc, $tagtype, $tag);
@@ -3116,7 +3129,7 @@ Can be - to indicate that the tag is a negative tag
 
 sub canonicalize_taxonomy_tag_link ($target_lc, $tagtype, $tag, $tag_prefix = undef) {
 
-	$target_lc =~ s/_.*//;
+	$target_lc = base_language($target_lc) // $target_lc;
 	$tag = display_taxonomy_tag($target_lc, $tagtype, $tag);
 	my $tagurl = get_tag_url_id($tagtype, $tag);
 	my $path = $tag_type_plural{$tagtype}{$target_lc};
@@ -3130,7 +3143,7 @@ sub display_taxonomy_tag_link ($target_lc, $tagtype, $tag) {
 
 	my $taxonomy = $taxonomy_fields{$tagtype};
 
-	$target_lc =~ s/_.*//;
+	$target_lc = base_language($target_lc) // $target_lc;
 	$tag = display_taxonomy_tag($target_lc, $taxonomy, $tag);
 	my $tagid = $tag;
 	my $tagurl = get_tag_url_id($tagtype, $tagid);
@@ -3307,7 +3320,7 @@ sub display_tag_and_parents_taxonomy ($tagtype, $tagid) {
 
 sub display_parents_and_children ($target_lc, $tagtype, $tagid) {
 
-	$target_lc =~ s/_.*//;
+	$target_lc = base_language($target_lc) // $target_lc;
 	my $html = '';
 
 	if (defined $taxonomy_fields{$tagtype}) {
@@ -3613,6 +3626,9 @@ sub canonicalize_taxonomy_tag_or_die ($tag_lc, $tagtype, $tag) {
 
 Canonicalize a string to check if matches an entry in a taxonomy
 
+Regional codes are normalized (C<pt-br> becomes C<pt_BR>). Matching tries the
+variant before its base language, then the taxonomy's existing language fallbacks.
+
 =head3 Arguments
 
 =head4 $tag_lc
@@ -3670,10 +3686,12 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 
 	# If we are passed a tag string that starts with a language code (e.g. fr:café)
 	# override the input language
-	if ($tag =~ /^(\w\w):/) {
+	if ($tag =~ /^($language_code_re):/) {
 		$tag_lc = $1;
 		$tag = $';
 	}
+
+	$tag_lc = normalize_language_code($tag_lc) // $tag_lc;
 
 	# Language less taxonomies (e.g. brands): consider the input to be in the xx language
 	if ($tagtype eq "brands") {
@@ -3752,6 +3770,18 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 			$found = 1;
 		}
 		else {
+
+			# A regional match wins over the base language, including its synonyms.
+			# Only try other languages after exhausting the variant's parent languages.
+			my (undef, $base_lc) = language_fallbacks($tag_lc);
+			if (defined $base_lc) {
+				my $base_exists;
+				my $base_tagid = canonicalize_taxonomy_tag($base_lc, $tagtype, $tag, \$base_exists);
+				if ($base_exists) {
+					$$exists_in_taxonomy_ref = 1 if defined $exists_in_taxonomy_ref;
+					return $base_tagid;
+				}
+			}
 
 			# try matching in other languages (by default, in the "language-less" language xx, and in English)
 			# note that there may be conflicts where a non-English word matches an English entry,
@@ -3854,7 +3884,7 @@ sub canonicalize_taxonomy_tag ($tag_lc, $tagtype, $tag, $exists_in_taxonomy_ref 
 	}
 
 	# $tagid may already be a canon tagid with a language prefix, in which case do not add the language prefix
-	if ($tagid !~ /^\w\w:/) {
+	if ($tagid !~ /^$language_code_re:/) {
 		$tagid = $tag_lc . ':' . $tagid;
 	}
 
@@ -4070,9 +4100,20 @@ sub cached_display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 	return $value;
 }
 
+# Select a regional display name before trying its base language.
+sub _taxonomy_display_language ($taxonomy, $tagid, $target_lc) {
+	my $translations_ref = ($translations_to{$taxonomy} // {})->{$tagid} // {};
+	my $matched_lc;
+	lookup_with_language_fallback($translations_ref, $target_lc, \$matched_lc);
+	return $matched_lc // base_language($target_lc) // $target_lc;
+}
+
 =head2 display_taxonomy_tag ( $target_lc, $tagtype, $canon_tagid )
 
 Return the name of a tag for displaying it to the user
+
+Regional names take priority over base-language names. Script subtags are kept
+when falling back, for example C<zh_Hant_TW> to C<zh_Hant> to C<zh>.
 
 =head3 Arguments
 
@@ -4091,7 +4132,7 @@ otherwise, the tag id.
 
 sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 
-	$target_lc =~ s/_.*//;
+	$target_lc = normalize_language_code($target_lc) // $target_lc;
 
 	if (not defined $tag) {
 		$log->warn("display_taxonomy_tag() called for undefined \$tag") if $log->is_warn();
@@ -4110,7 +4151,7 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 
 	my $tag_lc;
 
-	if ($tag =~ /^(\w\w):/) {
+	if ($tag =~ /^($language_code_re):/) {
 		$tag_lc = $1;
 		$tag = $';
 	}
@@ -4119,17 +4160,20 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 		$tag_lc = $target_lc;
 	}
 
+	$tag_lc = normalize_language_code($tag_lc) // $tag_lc;
+
 	my $tagid_no_lc = get_string_id_for_lang($tag_lc, $tag);
 	my $tagid = $tag_lc . ':' . $tagid_no_lc;
 
 	my $display = '';
+	my $display_lc = _taxonomy_display_language($taxonomy, $tagid, $target_lc);
 
 	if (    (defined $translations_to{$taxonomy})
 		and (defined $translations_to{$taxonomy}{$tagid})
-		and (defined $translations_to{$taxonomy}{$tagid}{$target_lc}))
+		and (defined $translations_to{$taxonomy}{$tagid}{$display_lc}))
 	{
 		# we have a translation for the target language
-		$display = $translations_to{$taxonomy}{$tagid}{$target_lc};
+		$display = $translations_to{$taxonomy}{$tagid}{$display_lc};
 	}
 	elsif ( (defined $translations_to{$taxonomy})
 		and (defined $translations_to{$taxonomy}{$tagid})
@@ -4155,12 +4199,14 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 			$tagid = $translations_from{$taxonomy}{$tagid};
 		}
 
+		$display_lc = _taxonomy_display_language($taxonomy, $tagid, $target_lc);
+
 		if (    (defined $translations_to{$taxonomy})
 			and (defined $translations_to{$taxonomy}{$tagid})
-			and (defined $translations_to{$taxonomy}{$tagid}{$target_lc}))
+			and (defined $translations_to{$taxonomy}{$tagid}{$display_lc}))
 		{
 			# we have a translation for the target language
-			$display = $translations_to{$taxonomy}{$tagid}{$target_lc};
+			$display = $translations_to{$taxonomy}{$tagid}{$display_lc};
 		}
 		elsif ( (defined $translations_to{$taxonomy})
 			and (defined $translations_to{$taxonomy}{$tagid})
@@ -4191,7 +4237,7 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 		else {
 			$display = $tag;
 
-			if ($target_lc ne $tag_lc) {
+			if (($target_lc ne $tag_lc) and ($display_lc ne $tag_lc)) {
 				# If the tag language is xx:, we don't want to add the language code
 				# This happens for language less taxonomies (e.g. brands) when we don't have a taxonomized entry
 				# So if someone enters SomeUnknownBrand in the brands field, it is normalized to xx:SomeUnknownBrand
@@ -4207,11 +4253,11 @@ sub display_taxonomy_tag ($target_lc, $tagtype, $tag) {
 	# for additives, add the first synonym
 	if ($taxonomy eq 'additives') {
 		$tagid =~ s/.*://;
-		if (    (defined $synonyms_for{$taxonomy}{$target_lc})
-			and (defined $synonyms_for{$taxonomy}{$target_lc}{$tagid})
-			and (defined $synonyms_for{$taxonomy}{$target_lc}{$tagid}[1]))
+		if (    (defined $synonyms_for{$taxonomy}{$display_lc})
+			and (defined $synonyms_for{$taxonomy}{$display_lc}{$tagid})
+			and (defined $synonyms_for{$taxonomy}{$display_lc}{$tagid}[1]))
 		{
-			$display .= " - " . ucfirst($synonyms_for{$taxonomy}{$target_lc}{$tagid}[1]);
+			$display .= " - " . ucfirst($synonyms_for{$taxonomy}{$display_lc}{$tagid}[1]);
 		}
 	}
 
@@ -4244,7 +4290,7 @@ otherwise, the tag in its primary language
 sub display_taxonomy_tag_name ($target_lc, $tagtype, $canon_tagid) {
 	my $display_value = display_taxonomy_tag($target_lc, $tagtype, $canon_tagid);
 	# remove eventual leading language code
-	$display_value =~ s/^\w\w://;
+	$display_value =~ s/^$language_code_re://;
 	return $display_value;
 }
 

--- a/scripts/build_lang.pl
+++ b/scripts/build_lang.pl
@@ -43,7 +43,7 @@ retrieve_tags_taxonomy("languages");
 init_languages();
 
 ProductOpener::Lang::build_lang(\%Languages);
-my $tags_ref = ProductOpener::Lang::build_lang_tags();
+my $tags_ref = ProductOpener::Lang::build_lang_tags(\%Languages);
 
 print STDERR "Build \%Lang - done, saving sto files \n";
 # use $server_domain in part of the name so that we have different files

--- a/scripts/build_lang.pl
+++ b/scripts/build_lang.pl
@@ -42,7 +42,8 @@ print STDERR "Build \%Lang - data_root: $data_root - server_domain: $server_doma
 retrieve_tags_taxonomy("languages");
 init_languages();
 
-ProductOpener::Lang::build_lang(\%Languages);
+my $interface_languages_ref = ProductOpener::Lang::interface_languages(\%Languages);
+ProductOpener::Lang::build_lang($interface_languages_ref);
 my $tags_ref = ProductOpener::Lang::build_lang_tags(\%Languages);
 
 print STDERR "Build \%Lang - done, saving sto files \n";

--- a/templates/web/common/site_layout.tt.html
+++ b/templates/web/common/site_layout.tt.html
@@ -1,7 +1,7 @@
 <!-- start templates/[% template.name %] -->
 
 <!doctype html>
-<html class="no-js" lang="[% language %]" data-serverdomain="[% server_domain %]" dir="[% edq(lang('text_direction')) %]">
+<html class="no-js" lang="[% language_tag %]" data-serverdomain="[% server_domain %]" dir="[% edq(lang('text_direction')) %]">
 <head>
     <meta charset="utf-8">
     <title>[% title %]</title>

--- a/tests/unit/i18n_language_variants.t
+++ b/tests/unit/i18n_language_variants.t
@@ -1,0 +1,101 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use File::Temp qw/tempdir/;
+use Test2::V0;
+use Test2::Plugin::UTF8;
+use Log::Any::Adapter 'TAP';
+
+use ProductOpener::I18N;
+
+sub write_po_file ($path, $translation) {
+
+	open(my $fh, '>:encoding(UTF-8)', $path) or die "Cannot write $path: $!";
+	print {$fh} <<PO;
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Language: ignored\\n"
+
+msgctxt "greeting"
+msgid "Hello"
+msgstr "$translation"
+
+msgctxt "untranslated"
+msgid "Not translated yet"
+msgstr ""
+
+PO
+	close($fh) or die "Cannot close $path: $!";
+	return;
+}
+
+subtest 'Load regional catalogs without merging their translations' => sub {
+	my $dir = tempdir(CLEANUP => 1);
+	my %translations = (
+		ast => 'Asturian translation',
+		en => 'Hello',
+		en_GB => 'Hello from the UK',
+		es => 'Hola',
+		es_419 => 'Latin American Spanish translation',
+		kmr_TR => 'Kurdish translation',
+		pt => 'Olá',
+		pt_PT => 'Olá de Portugal',
+		pt_BR => 'Olá do Brasil',
+		zh => '你好',
+		zh_CN => '简体中文',
+		zh_TW => '繁體中文',
+		zh_HK => '香港繁體中文',
+	);
+	foreach my $language (sort keys %translations) {
+		write_po_file("$dir/$language.po", $translations{$language});
+	}
+
+	my $terms_ref = ProductOpener::I18N::read_po_files($dir);
+	is($terms_ref->{greeting}, \%translations, 'Catalog names determine the language, not the PO header');
+	is($terms_ref->{untranslated}, {}, 'Empty translations stay absent so the caller can apply a fallback');
+	is([sort keys %{$terms_ref}], ['greeting', 'untranslated'], 'Gettext metadata is not exposed as translations');
+	is(ProductOpener::I18N::read_po_files("$dir/"), $terms_ref, 'A trailing slash does not change the result');
+	is(
+		ProductOpener::I18N::read_po_files($dir, {pt => {}, zh => {}})->{greeting},
+		{pt => $translations{pt}, zh => $translations{zh}},
+		'Loading catalogs for a language registry does not implicitly enable variants'
+	);
+	is(
+		ProductOpener::I18N::read_po_files($dir, {ast => {}, es_419 => {}, kmr_TR => {}, pt_BR => {}, zh_TW => {}})
+			->{greeting},
+		{map {$_ => $translations{$_}} qw/ast es_419 kmr_TR pt_BR zh_TW/},
+		'Explicitly registered variants retain their full language codes'
+	);
+	is(ProductOpener::I18N::read_po_files($dir, {pt_br => {}}), {}, 'Registry keys must match the catalog code case');
+	is(ProductOpener::I18N::read_po_files($dir, {}), {}, 'An empty language registry loads no catalogs');
+	done_testing();
+};
+
+subtest 'Validate the complete catalog filename' => sub {
+	my $dir = tempdir(CLEANUP => 1);
+	foreach my $filename (
+		'ptXpo.po', 'pt.po.backup.po', 'pt_BR_extra.po', 'invalid.po', 'abcd.po', 'ast_TR_extra.po',
+		'es_41.po', 'es_4190.po', 'es_4A9.po', 'pt_br.po', 'pt-BR.po', 'PT.po'
+		)
+	{
+		write_po_file("$dir/$filename", 'Not a language catalog');
+	}
+	is(ProductOpener::I18N::read_po_files($dir), {}, 'Ignore filenames that only partially match a language code');
+	done_testing();
+};
+
+subtest 'Use the filename, not a parent directory, as the language code' => sub {
+	my $dir = tempdir(CLEANUP => 1);
+	mkdir("$dir/fr.po") or die "Cannot create nested directory: $!";
+	write_po_file("$dir/fr.po/pt_BR.po", 'Olá do Brasil');
+	is(
+		ProductOpener::I18N::read_po_files($dir),
+		{greeting => {pt_BR => 'Olá do Brasil'}, untranslated => {}},
+		'A directory that looks like a catalog does not change the language'
+	);
+	done_testing();
+};
+
+done_testing();

--- a/tests/unit/i18n_language_variants.t
+++ b/tests/unit/i18n_language_variants.t
@@ -47,6 +47,8 @@ subtest 'Load regional catalogs without merging their translations' => sub {
 		zh_CN => '简体中文',
 		zh_TW => '繁體中文',
 		zh_HK => '香港繁體中文',
+		zh_Hant => '繁體',
+		zh_Hant_TW => '臺灣',
 	);
 	foreach my $language (sort keys %translations) {
 		write_po_file("$dir/$language.po", $translations{$language});
@@ -76,8 +78,10 @@ subtest 'Load regional catalogs without merging their translations' => sub {
 subtest 'Validate the complete catalog filename' => sub {
 	my $dir = tempdir(CLEANUP => 1);
 	foreach my $filename (
-		'ptXpo.po', 'pt.po.backup.po', 'pt_BR_extra.po', 'invalid.po', 'abcd.po', 'ast_TR_extra.po',
-		'es_41.po', 'es_4190.po', 'es_4A9.po', 'pt_br.po', 'pt-BR.po', 'PT.po'
+		'ptXpo.po', 'pt.po.backup.po', 'pt_BR_extra.po', 'invalid.po',
+		'abcd.po', 'ast_TR_extra.po', 'es_41.po', 'es_4190.po',
+		'es_4A9.po', 'pt_br.po', 'pt-BR.po', 'PT.po',
+		'zh_hant.po', 'zh-Hant.po', 'zh_Hant_tw.po', 'zh_Hant_TW_extra.po'
 		)
 	{
 		write_po_file("$dir/$filename", 'Not a language catalog');

--- a/tests/unit/inputs/taxonomy_language_variants/regional_test.properties.txt
+++ b/tests/unit/inputs/taxonomy_language_variants/regional_test.properties.txt
@@ -1,0 +1,2 @@
+pt-br: Especialidade regional
+description:pt_br: Propriedade regional

--- a/tests/unit/inputs/taxonomy_language_variants/regional_test.txt
+++ b/tests/unit/inputs/taxonomy_language_variants/regional_test.txt
@@ -1,0 +1,42 @@
+stopwords:pt: de
+stopwords:fr: de
+
+en: Wheat couscous
+pt: Cuscuz
+
+en: Corn couscous
+pt_br: Cuscuz de milho, Cuscuz
+
+en: Cream
+pt: Natas
+PT-br: Creme de leite
+description:pt-br: Nome regional
+url:en: https://example.org/cream
+
+en: Salt
+pt: Sal
+
+en: French specialty
+fr: Spécialité
+fr-ca: Spécialité régionale
+
+en: Chinese label
+zh: 中文
+zh-hant: 繁體
+zh-Hant-TW: 臺灣
+
+en: Numeric region
+es-419: Nombre regional
+
+en: Three-letter language
+kmr-tr: Navê herêmî
+
+pt_br: Especialidade regional
+
+< pt-BR: Especialidade regional
+en: Regional child
+pt_br: Especialidade filha
+
+xx: Universal name
+
+en: English only

--- a/tests/unit/interface_languages.t
+++ b/tests/unit/interface_languages.t
@@ -1,0 +1,224 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use File::Path qw/make_path/;
+use File::Temp qw/tempdir/;
+use JSON::MaybeXS qw/decode_json/;
+use Test2::V0;
+use Test2::Plugin::UTF8;
+use Log::Any::Adapter 'TAP';
+
+use ProductOpener::APIProductWrite qw/update_product_field_api_v2_and_cgi/;
+use ProductOpener::Config qw/$server_domain %options/;
+use ProductOpener::Display qw/init_request process_template display_date display_page/;
+use ProductOpener::I18N;
+use ProductOpener::Lang qw/$lc $interface_lc %Lang %Langs %InterfaceLangs %lang_lc interface_languages lang f_lang/;
+use ProductOpener::Paths qw/%BASE_DIRS/;
+use ProductOpener::Store qw/store/;
+use ProductOpener::Tags qw/init_languages %Languages %language_codes %country_codes %country_languages/;
+use ProductOpener::Web qw/get_languages_options_list/;
+
+# Use the real taxonomy initializer and the same activation function as build_lang.pl.
+init_languages();
+my %product_languages = map {$_ => $Languages{$_}} qw/en pt/;
+my $registry_ref = interface_languages(\%product_languages);
+is([sort keys %{$registry_ref}], [qw/en pt pt_BR/], 'The activation list adds Brazilian Portuguese');
+is($registry_ref->{pt_BR}{pt_BR}, 'Português (Brasil)', 'The variant has its native name');
+ok(
+	!exists $Languages{pt_BR} && !exists $language_codes{pt_BR},
+	'A variant is not added as an ISO 639-1 product language'
+);
+is(
+	interface_languages({en => $Languages{en}}),
+	{en => $Languages{en}},
+	'Do not activate a variant without its base language'
+);
+
+{
+	# The activation list is configuration: enabling a variant does not change the code.
+	local $options{interface_language_variants} = {zh_TW => 'Chinese (Taiwan)', 'not a code' => 'Ignored'};
+	my $configured_ref = interface_languages({map {$_ => $Languages{$_}} qw/en zh/});
+	is([sort keys %{$configured_ref}], [qw/en zh zh_TW/], 'Variants come from the configuration');
+	is($configured_ref->{zh_TW}{zh_TW}, 'Chinese (Taiwan)', 'The configured native name is used');
+}
+
+my $dir = tempdir(CLEANUP => 1);
+make_path("$dir/po/common", "$dir/public", "$dir/private");
+my %english = (
+	add => 'Add',
+	base_only => 'Base fallback',
+	english_only => 'English fallback',
+	formatted => 'Hello {name}',
+	footer_join_us_on => 'Join us on %s'
+);
+my %catalogs = (
+	en => \%english,
+	pt => {add => 'Adicionar', base_only => 'Texto português', formatted => 'Olá {name}'},
+	pt_BR => {add => 'Adicionar Brasil', base_only => ''},
+	pt_PT => {add => 'Unregistered'},
+);
+
+foreach my $catalog (sort keys %catalogs, 'common') {
+	my $extension = $catalog eq 'common' ? 'pot' : 'po';
+	open(my $fh, '>:encoding(UTF-8)', "$dir/po/common/$catalog.$extension") or die "Cannot write catalog: $!";
+	print {$fh} "msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; charset=UTF-8\\n\"\n\n";
+	my $strings_ref = $catalog eq 'common' ? \%english : $catalogs{$catalog};
+	foreach my $key (sort keys %{$strings_ref}) {
+		my $translation = $catalog eq 'common' ? '' : $strings_ref->{$key};
+		print {$fh} "msgctxt \"$key\"\nmsgid \"$english{$key}\"\nmsgstr \"$translation\"\n\n";
+	}
+	close($fh) or die "Cannot close catalog: $!";
+}
+local $ProductOpener::Lang::data_root = $dir;
+local $BASE_DIRS{PUBLIC_DATA} = "$dir/public";
+ProductOpener::Lang::build_lang($registry_ref);
+is($Lang{add}{pt_BR}, 'Adicionar Brasil', 'Compile the enabled regional catalog');
+is($Lang{base_only}{pt_BR}, 'Texto português', 'Missing regional strings fall back to Portuguese');
+is($Lang{english_only}{pt_BR}, 'English fallback', 'Missing Portuguese strings fall back to English');
+is($InterfaceLangs{pt_BR}, 'Português (Brasil)', 'The variant is selectable in the interface');
+is([sort keys %Langs], [qw/en pt/], 'Product language names still contain only the base languages');
+is([sort keys %lang_lc], [qw/en pt/], 'API and export language codes exclude the interface variant');
+my $product_options = get_languages_options_list('pt');
+is([sort map {$_->{value}} @{$product_options}], [qw/en pt/], 'Product forms do not offer a regional data language');
+like($Lang{months}{pt_BR}, qr/janeiro/, 'Months use the Portuguese calendar');
+like($Lang{weekdays}{pt_BR}, qr/segunda-feira/, 'Weekdays use the Portuguese calendar');
+
+ProductOpener::Lang::build_json();
+open(my $json_fh, '<:raw', "$dir/public/i18n/pt-BR/lang.json") or die "Cannot read JSON: $!";
+my $json_ref = decode_json(do {local $/; <$json_fh>});
+close($json_fh);
+is($json_ref->{add}, 'Adicionar Brasil', 'JSON includes the regional translation');
+is($json_ref->{base_only}, 'Texto português', 'JSON includes the Portuguese fallback');
+ok(!-d "$dir/public/i18n/pt-PT", 'An unregistered catalog is not exported');
+store("$dir/private/Lang.$server_domain.sto", \%Lang);
+my $reload_script = <<'PERL';
+$ProductOpener::Paths::BASE_DIRS{PRIVATE_DATA} = shift;
+require ProductOpener::Lang;
+require JSON::MaybeXS;
+print JSON::MaybeXS::encode_json({
+    interface => \%ProductOpener::Lang::InterfaceLangs,
+    product => \%ProductOpener::Lang::Langs,
+    codes => \%ProductOpener::Lang::lang_lc,
+    add => $ProductOpener::Lang::Lang{add}{pt_BR},
+});
+PERL
+open(my $reload_fh, '-|', $^X, '-MProductOpener::Paths', '-e', $reload_script, "$dir/private")
+	or die "Cannot reload: $!";
+my $reloaded_ref = decode_json(do {local $/; <$reload_fh>});
+ok(close($reload_fh), 'Reload the compiled catalog in a new process');
+is(
+	$reloaded_ref,
+	{interface => \%InterfaceLangs, product => \%Langs, codes => \%lang_lc, add => 'Adicionar Brasil'},
+	'Reloading preserves translations and the separation of interface and product languages'
+);
+
+local %country_codes = (world => 'en:world', br => 'en:brazil');
+local %country_languages = (world => ['en'], br => ['pt']);
+local $ENV{SCRIPT_NAME} = '/cgi/display.pl';
+local $ENV{QUERY_STRING} = '';
+local $ENV{REMOTE_ADDR} = '127.0.0.1';
+my $hostname;
+my %params;
+my @mocks = (
+	mock('Apache2::RequestUtil' => (add => [request => sub {return bless {}, 'Local::LanguageRequest';}])),
+	mock(
+		'Local::LanguageRequest' => (
+			add => [
+				method => sub {return 'GET';},
+				hostname => sub {return $hostname;},
+				rflush => sub {return;},
+				status => sub {return;},
+				headers_out => sub {return bless {}, 'Local::LanguageHeaders';},
+			]
+		)
+	),
+	mock('Local::LanguageHeaders' => (add => [set => sub {return;}])),
+	mock(
+		'ProductOpener::Display' => (
+			override => [
+				single_param => sub {return $params{$_[0]};},
+				log_request_stats => sub {return;},
+				# Run real language and URL initialization, stopping before authentication.
+				process_auth_header => sub {die "language initialized\n";},
+			]
+		)
+	),
+);
+foreach my $case_ref (
+	{host => 'world', param => 'PT-br', ui => 'pt_BR', lc => 'pt', lcs => ['pt'], subdomain => 'world-pt-br'},
+	{host => 'world', param => 'pt_br', ui => 'pt_BR', lc => 'pt', lcs => ['pt'], subdomain => 'world-pt-br'},
+	{host => 'world-pt-br', ui => 'pt_BR', lc => 'pt', lcs => ['pt'], subdomain => 'world-pt-br'},
+	{host => 'br-pt-br', ui => 'pt_BR', lc => 'pt', lcs => ['pt'], subdomain => 'br-pt-br'},
+	{
+		host => 'world',
+		param => 'pt-BR,pt,en,invalid',
+		ui => 'pt_BR',
+		lc => 'pt',
+		lcs => ['pt', 'en'],
+		subdomain => 'world-pt-br'
+	},
+	{host => 'world', param => 'pt-PT', ui => 'en', lc => 'en', lcs => ['en'], subdomain => 'world'},
+	{host => 'world', param => 'pt-BR-extra', ui => 'en', lc => 'en', lcs => ['en'], subdomain => 'world'},
+	{host => 'world', param => 'pt', ui => 'pt', lc => 'pt', lcs => ['pt'], subdomain => 'world-pt'},
+	{host => 'br', ui => 'pt', lc => 'pt', lcs => ['pt'], subdomain => 'br'},
+	{host => 'world', ui => 'en', lc => 'en', lcs => ['en'], subdomain => 'world'},
+	)
+{
+	subtest $case_ref->{host} . ' lc=' . ($case_ref->{param} // '(none)') => sub {
+		$hostname = "$case_ref->{host}.openfoodfacts.localhost";
+		%params = defined $case_ref->{param} ? (lc => $case_ref->{param}) : ();
+		my $request_ref = {};
+		like(
+			dies {init_request($request_ref);},
+			qr/^language initialized\n/,
+			'Reach authentication after language resolution'
+		);
+		is($request_ref->{interface_lc}, $case_ref->{ui}, 'Resolve the registered interface locale');
+		is($request_ref->{lc}, $case_ref->{lc}, 'Product and taxonomy operations keep the base language');
+		is($request_ref->{lcs}, $case_ref->{lcs}, 'Ordered product languages use base codes without duplicates');
+		is($lc, $case_ref->{lc}, 'Legacy product operations keep the base language too');
+		is($request_ref->{subdomain}, $case_ref->{subdomain}, 'Links use lowercase hyphens');
+		my $html = '';
+		my $template = '<button>[% lang("add") %]</button>';
+		ok(process_template(\$template, {}, \$html, $request_ref), 'Render through the real template helper');
+		is($html, '<button>' . $Lang{add}{$case_ref->{ui}} . '</button>', 'Templates use the interface translation');
+		is(lang('add'), $Lang{add}{$case_ref->{ui}}, 'Perl interface helpers use the same translation');
+
+		if ($case_ref->{host} eq 'br-pt-br' or $case_ref->{host} eq 'br') {
+			my $product_ref = {};
+			update_product_field_api_v2_and_cgi($product_ref, $request_ref->{lc}, 'product_name', 'Example',
+				'packaging');
+			is($product_ref->{product_name_pt}, 'Example', 'The CGI/API write helper writes the base-language field');
+			ok(!exists $product_ref->{product_name_pt_BR},
+				'Selecting the interface variant creates no regional product field');
+
+			my $content = '<p>Example</p>';
+			$request_ref->{content_ref} = \$content;
+			$request_ref->{title} = 'Example';
+			my $page = '';
+			{
+				open(my $output, '>', \$page) or die "Cannot capture rendered page: $!";
+				local *STDOUT = $output;
+				display_page($request_ref);
+			}
+			my $html_tag = $case_ref->{ui} eq 'pt_BR' ? 'pt-BR' : 'pt';
+			like($page, qr/<html [^>]*lang="$html_tag"/, 'The real page layout emits the BCP-47 language tag');
+			like(
+				$page,
+				qr{href="[^" ]*br-pt-br[^" ]*/" lang="pt-BR" hreflang="pt-BR"},
+				'The interface selector links to the variant with BCP-47 attributes'
+			);
+			like($page, qr/Portugu.*?\(Brasil\)/, 'The interface selector includes the native variant name');
+		}
+
+	};
+}
+$lc = 'pt';
+$interface_lc = 'pt_BR';
+is(f_lang('formatted', {name => 'Alice'}), 'Olá Alice', 'Formatted helpers use the base-language fallback');
+like(display_date(1472292529), qr/agosto/, 'Dates displayed in the interface use Portuguese');
+$lc = 'en';
+is(lang('add'), 'Add', 'An explicit switch to another base language takes priority over the interface variant');
+
+done_testing();

--- a/tests/unit/lang_tags.t
+++ b/tests/unit/lang_tags.t
@@ -162,6 +162,9 @@ subtest 'Compile, export and reload a registered variant with both fallback leve
 		},
 		pt_BR => {add => 'Adicionar Brasil', base_only => ''},
 		pt_PT => {add => 'Unregistered translation'},
+		zh => {add => '添加', greeting => '中文'},
+		zh_Hant => {add => '新增', base_only => '繁體'},
+		zh_Hant_TW => {add => '新增臺灣'},
 	);
 	foreach my $catalog (sort keys %catalogs, 'common') {
 		my $extension = $catalog eq 'common' ? 'pot' : 'po';
@@ -186,6 +189,9 @@ subtest 'Compile, export and reload a registered variant with both fallback leve
 		en => {en => 'English'},
 		pt => {pt => 'Português'},
 		pt_BR => {pt_BR => 'Português (Brasil)'},
+		zh => {zh => '中文'},
+		zh_Hant => {zh_Hant => '繁體中文'},
+		zh_Hant_TW => {zh_Hant_TW => '臺灣'},
 	};
 	local $ProductOpener::Lang::data_root = $case_dir;
 	local $BASE_DIRS{PUBLIC_DATA} = "$case_dir/public";
@@ -193,12 +199,19 @@ subtest 'Compile, export and reload a registered variant with both fallback leve
 	ProductOpener::Lang::build_lang($languages_ref);
 	my $lang_ref = \%ProductOpener::Lang::Lang;
 	is($lang_ref->{add}{pt_BR}, 'Adicionar Brasil', 'Keep the regional translation');
+	is($lang_ref->{base_only}{zh_Hant_TW}, '繁體', 'Use the script catalog before the base language');
+	is($lang_ref->{greeting}{zh_Hant_TW},
+		'中文', 'An initialized English fallback does not mask the original base catalog');
 	is($lang_ref->{base_only}{pt_BR}, 'Texto português', 'An empty regional translation falls back to Portuguese');
 	is($lang_ref->{english_only}{pt_BR}, 'English fallback', 'Fall back to English when Portuguese is also missing');
 	is($lang_ref->{greeting}{pt_BR}, "Bem-vindo a $options{site_name}", 'Resolve site placeholders after fallback');
 	is(ProductOpener::Lang::f_lang_in_lc('pt_BR', 'formatted', {name => 'Alice'}),
 		'Olá Alice', 'Formatted messages use the compiled base-language fallback');
-	is([sort keys %{$lang_ref->{add}}], [qw/en pt pt_BR/], 'Only registered languages enter the compiled catalog');
+	is(
+		[sort keys %{$lang_ref->{add}}],
+		[qw/en pt pt_BR zh zh_Hant zh_Hant_TW/],
+		'Only registered languages enter the compiled catalog'
+	);
 
 	my $compiled_tags_ref = ProductOpener::Lang::build_lang_tags($languages_ref);
 	is($compiled_tags_ref->{tag_type_singular}{categories}{pt_BR}, 'categoria-br', 'Compile the regional tag path');
@@ -206,13 +219,13 @@ subtest 'Compile, export and reload a registered variant with both fallback leve
 		'categorias-base', 'Compile the base-language fallback for the tag path');
 
 	ProductOpener::Lang::build_json();
-	open(my $json_fh, '<:raw', "$case_dir/public/i18n/pt_BR/lang.json") or die "Cannot read JSON catalog: $!";
+	open(my $json_fh, '<:raw', "$case_dir/public/i18n/pt-BR/lang.json") or die "Cannot read JSON catalog: $!";
 	my $json_ref = decode_json(do {local $/; <$json_fh>});
 	close($json_fh) or die "Cannot close JSON catalog: $!";
 	is($json_ref->{add}, 'Adicionar Brasil', 'Export the regional translation to JavaScript');
 	is($json_ref->{base_only}, 'Texto português', 'Export the Portuguese fallback to JavaScript');
 	is($json_ref->{english_only}, 'English fallback', 'Export the English fallback to JavaScript');
-	ok(!-d "$case_dir/public/i18n/pt_PT", 'Do not export an unregistered locale');
+	ok(!-d "$case_dir/public/i18n/pt-PT", 'Do not export an unregistered locale');
 
 	store("$case_dir/data/Lang.$server_domain.sto", $lang_ref);
 	store("$case_dir/data/Lang_tags.$server_domain.sto", $compiled_tags_ref);
@@ -239,7 +252,11 @@ PERL
 	ok(close($reload_fh), 'Reload both compiled catalogs in a fresh process');
 	is($reloaded_ref->{lang}, $lang_ref, 'All translations and fallbacks survive reloading');
 	is($reloaded_ref->{tags}, $compiled_tags_ref, 'All tag paths and reverse indexes survive reloading');
-	is($reloaded_ref->{languages}, [qw/en pt pt_BR/], 'Reloading does not activate an unregistered locale');
+	is(
+		$reloaded_ref->{languages},
+		[qw/en pt pt_BR zh zh_Hant zh_Hant_TW/],
+		'Reloading does not activate an unregistered locale'
+	);
 	is(
 		$reloaded_ref->{names},
 		{map {$_ => $languages_ref->{$_}{$_}} keys %{$languages_ref}},

--- a/tests/unit/lang_tags.t
+++ b/tests/unit/lang_tags.t
@@ -265,4 +265,42 @@ PERL
 	done_testing();
 };
 
+subtest 'Catalogs without language name keys' => sub {
+	# po/tags/*.po define no :langname and no :langtag, unlike the fixtures above.
+	my $plain_dir = tempdir(CLEANUP => 1);
+	make_path("$plain_dir/po/tags");
+	open(my $fh, '>:encoding(UTF-8)', "$plain_dir/po/tags/en.po") or die "Cannot write catalog: $!";
+	print {$fh} <<'PO';
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgctxt "categories:singular"
+msgid "category"
+msgstr "category"
+
+msgctxt "categories:plural"
+msgid "categories"
+msgstr "categories"
+
+PO
+	close($fh) or die "Cannot close catalog: $!";
+
+	local $ProductOpener::Lang::data_root = $plain_dir;
+	local %ProductOpener::Lang::tag_type_singular;
+	local %ProductOpener::Lang::tag_type_plural;
+	local %ProductOpener::Lang::tag_type_from_singular;
+	local %ProductOpener::Lang::tag_type_from_plural;
+
+	my $plain_tags_ref;
+	ok(lives {$plain_tags_ref = ProductOpener::Lang::build_lang_tags({en => {}})}, 'Build without the language keys')
+		or note($@);
+	is($plain_tags_ref->{tag_type_singular}{categories}, {en => 'category'}, 'Tag paths are still built');
+	ok(
+		!exists $plain_tags_ref->{tag_type_singular}{':langname'},
+		'No empty entry is created for a missing language name'
+	);
+	done_testing();
+};
+
 done_testing();

--- a/tests/unit/lang_tags.t
+++ b/tests/unit/lang_tags.t
@@ -236,8 +236,8 @@ require ProductOpener::Lang;
 require JSON::MaybeXS;
 print JSON::MaybeXS::encode_json({
     lang => \%ProductOpener::Lang::Lang,
-    names => \%ProductOpener::Lang::Langs,
-    languages => \@ProductOpener::Lang::Langs,
+    names => \%ProductOpener::Lang::InterfaceLangs,
+    languages => \@ProductOpener::Lang::InterfaceLangs,
     tags => {
         tag_type_singular => \%ProductOpener::Lang::tag_type_singular,
         tag_type_plural => \%ProductOpener::Lang::tag_type_plural,

--- a/tests/unit/lang_tags.t
+++ b/tests/unit/lang_tags.t
@@ -1,0 +1,251 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use File::Path qw/make_path/;
+use File::Temp qw/tempdir/;
+use JSON::MaybeXS qw/decode_json/;
+use Test2::V0;
+use Test2::Plugin::UTF8;
+use Log::Any::Adapter 'TAP';
+
+use ProductOpener::Config qw/$server_domain %options/;
+use ProductOpener::Lang;
+use ProductOpener::Paths qw/%BASE_DIRS/;
+use ProductOpener::Store qw/store/;
+
+sub write_tag_catalog ($dir, $language, $singular, $plural) {
+
+	open(my $fh, '>:encoding(UTF-8)', "$dir/po/tags/$language.po") or die "Cannot write catalog: $!";
+	print {$fh} <<PO;
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt ":langname"
+msgid "Language name"
+msgstr "$language"
+
+msgctxt ":langtag"
+msgid "Language code"
+msgstr "$language"
+
+msgctxt "categories:singular"
+msgid "category"
+msgstr "$singular"
+
+msgctxt "categories:plural"
+msgid "categories"
+msgstr "$plural"
+
+PO
+	close($fh) or die "Cannot close catalog: $!";
+	return;
+}
+
+my $dir = tempdir(CLEANUP => 1);
+make_path("$dir/po/tags");
+write_tag_catalog($dir, 'en', 'category', 'categories');
+write_tag_catalog($dir, 'pt_BR', 'categoria', 'categorias');
+
+local $ProductOpener::Lang::data_root = $dir;
+local @ProductOpener::Lang::Langs = ();
+local %ProductOpener::Lang::Langs = ();
+local %ProductOpener::Lang::tag_type_singular;
+local %ProductOpener::Lang::tag_type_plural;
+local %ProductOpener::Lang::tag_type_from_singular;
+local %ProductOpener::Lang::tag_type_from_plural;
+
+my $tags_ref = ProductOpener::Lang::build_lang_tags({en => {}, pt_BR => {}});
+is(
+	$tags_ref->{tag_type_singular}{categories},
+	{en => 'category', pt_BR => 'categoria'},
+	'Build singular paths from the explicit registry without calling build_lang first'
+);
+is(
+	$tags_ref->{tag_type_plural}{categories},
+	{en => 'categories', pt_BR => 'categorias'},
+	'Build plural paths from the same explicit registry'
+);
+is(
+	$tags_ref->{tag_type_from_singular},
+	{en => {category => 'categories'}, pt_BR => {categoria => 'categories'}},
+	'Reverse singular paths include both registered languages'
+);
+is(
+	$tags_ref->{tag_type_from_plural},
+	{en => {categories => 'categories'}, pt_BR => {categorias => 'categories'}},
+	'Reverse plural paths include both registered languages'
+);
+
+$tags_ref = ProductOpener::Lang::build_lang_tags({en => {}});
+is($tags_ref->{tag_type_singular}{categories}, {en => 'category'}, 'Only load catalogs from the new registry');
+is(
+	$tags_ref->{tag_type_from_singular},
+	{en => {category => 'categories'}},
+	'Rebuilding does not keep singular paths for languages from a previous build'
+);
+is(
+	$tags_ref->{tag_type_from_plural},
+	{en => {categories => 'categories'}},
+	'Rebuilding does not keep plural paths for languages from a previous build'
+);
+
+foreach my $case_ref (
+	{
+		name => 'Missing regional singular falls back to pt while the regional plural is kept',
+		regional => ['', 'categorias-regionais'],
+		expected => ['categoria-base', 'categorias-regionais'],
+	},
+	{
+		name => 'Missing regional plural falls back to pt while the regional singular is kept',
+		regional => ['categoria-regional', ''],
+		expected => ['categoria-regional', 'categorias-base'],
+	},
+	{
+		name => 'Both missing regional paths fall back to pt',
+		regional => ['', ''],
+		expected => ['categoria-base', 'categorias-base'],
+	},
+	)
+{
+	subtest $case_ref->{name} => sub {
+		my $case_dir = tempdir(CLEANUP => 1);
+		make_path("$case_dir/po/tags");
+		write_tag_catalog($case_dir, 'en', 'category', 'categories');
+		write_tag_catalog($case_dir, 'pt', 'categoria-base', 'categorias-base');
+		write_tag_catalog($case_dir, 'pt_BR', @{$case_ref->{regional}});
+		local $ProductOpener::Lang::data_root = $case_dir;
+		my $tags_ref = ProductOpener::Lang::build_lang_tags({en => {}, pt => {}, pt_BR => {}});
+		my ($singular, $plural) = @{$case_ref->{expected}};
+		is($tags_ref->{tag_type_singular}{categories}{pt_BR}, $singular, 'Resolve the singular path');
+		is($tags_ref->{tag_type_plural}{categories}{pt_BR}, $plural, 'Resolve the plural path');
+		is(
+			$tags_ref->{tag_type_from_singular}{pt_BR},
+			{$singular => 'categories'},
+			'Reverse lookup uses the resolved singular'
+		);
+		is(
+			$tags_ref->{tag_type_from_plural}{pt_BR},
+			{$plural => 'categories'},
+			'Reverse lookup uses the resolved plural'
+		);
+		done_testing();
+	};
+}
+
+write_tag_catalog($dir, 'pt', 'categoria-base', 'categorias-base');
+write_tag_catalog($dir, 'pt_BR', '', '');
+$tags_ref = ProductOpener::Lang::build_lang_tags({en => {}, pt_BR => {}});
+is($tags_ref->{tag_type_singular}{categories}{pt_BR},
+	'category', 'Use English when the base language is not registered');
+is($tags_ref->{tag_type_plural}{categories}{pt_BR},
+	'categories', 'Use English for the plural when the base language is not registered');
+
+subtest 'Compile, export and reload a registered variant with both fallback levels' => sub {
+	my $case_dir = tempdir(CLEANUP => 1);
+	make_path("$case_dir/po/common", "$case_dir/po/tags", "$case_dir/public", "$case_dir/data");
+	my %english = (
+		add => 'Add',
+		base_only => 'Base fallback',
+		english_only => 'English fallback',
+		greeting => 'Welcome to <<site_name>>',
+		formatted => 'Hello {name}',
+	);
+	my %catalogs = (
+		en => \%english,
+		pt => {
+			add => 'Adicionar',
+			base_only => 'Texto português',
+			greeting => 'Bem-vindo a <<site_name>>',
+			formatted => 'Olá {name}',
+		},
+		pt_BR => {add => 'Adicionar Brasil', base_only => ''},
+		pt_PT => {add => 'Unregistered translation'},
+	);
+	foreach my $catalog (sort keys %catalogs, 'common') {
+		my $extension = $catalog eq 'common' ? 'pot' : 'po';
+		open(my $fh, '>:encoding(UTF-8)', "$case_dir/po/common/$catalog.$extension")
+			or die "Cannot write catalog: $!";
+		print {$fh} "msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; charset=UTF-8\\n\"\n\n";
+		my $strings_ref = $catalog eq 'common' ? \%english : $catalogs{$catalog};
+		foreach my $key (sort keys %{$strings_ref}) {
+			my $translation = $catalog eq 'common' ? '' : $strings_ref->{$key};
+			print {$fh} "msgctxt \"$key\"\nmsgid \"$english{$key}\"\nmsgstr \"$translation\"\n\n";
+		}
+		close($fh) or die "Cannot close catalog: $!";
+	}
+	write_tag_catalog($case_dir, 'en', 'category', 'categories');
+	write_tag_catalog($case_dir, 'pt', 'categoria-base', 'categorias-base');
+	write_tag_catalog($case_dir, 'pt_BR', 'categoria-br', '');
+	write_tag_catalog($case_dir, 'pt_PT', 'unregistered', 'unregistered');
+
+	# The builders take an explicit registry. Normalizing the taxonomy-derived registry
+	# and enabling regional request languages are separate from catalog compilation.
+	my $languages_ref = {
+		en => {en => 'English'},
+		pt => {pt => 'Português'},
+		pt_BR => {pt_BR => 'Português (Brasil)'},
+	};
+	local $ProductOpener::Lang::data_root = $case_dir;
+	local $BASE_DIRS{PUBLIC_DATA} = "$case_dir/public";
+	local %ProductOpener::Lang::Lang;
+	ProductOpener::Lang::build_lang($languages_ref);
+	my $lang_ref = \%ProductOpener::Lang::Lang;
+	is($lang_ref->{add}{pt_BR}, 'Adicionar Brasil', 'Keep the regional translation');
+	is($lang_ref->{base_only}{pt_BR}, 'Texto português', 'An empty regional translation falls back to Portuguese');
+	is($lang_ref->{english_only}{pt_BR}, 'English fallback', 'Fall back to English when Portuguese is also missing');
+	is($lang_ref->{greeting}{pt_BR}, "Bem-vindo a $options{site_name}", 'Resolve site placeholders after fallback');
+	is(ProductOpener::Lang::f_lang_in_lc('pt_BR', 'formatted', {name => 'Alice'}),
+		'Olá Alice', 'Formatted messages use the compiled base-language fallback');
+	is([sort keys %{$lang_ref->{add}}], [qw/en pt pt_BR/], 'Only registered languages enter the compiled catalog');
+
+	my $compiled_tags_ref = ProductOpener::Lang::build_lang_tags($languages_ref);
+	is($compiled_tags_ref->{tag_type_singular}{categories}{pt_BR}, 'categoria-br', 'Compile the regional tag path');
+	is($compiled_tags_ref->{tag_type_plural}{categories}{pt_BR},
+		'categorias-base', 'Compile the base-language fallback for the tag path');
+
+	ProductOpener::Lang::build_json();
+	open(my $json_fh, '<:raw', "$case_dir/public/i18n/pt_BR/lang.json") or die "Cannot read JSON catalog: $!";
+	my $json_ref = decode_json(do {local $/; <$json_fh>});
+	close($json_fh) or die "Cannot close JSON catalog: $!";
+	is($json_ref->{add}, 'Adicionar Brasil', 'Export the regional translation to JavaScript');
+	is($json_ref->{base_only}, 'Texto português', 'Export the Portuguese fallback to JavaScript');
+	is($json_ref->{english_only}, 'English fallback', 'Export the English fallback to JavaScript');
+	ok(!-d "$case_dir/public/i18n/pt_PT", 'Do not export an unregistered locale');
+
+	store("$case_dir/data/Lang.$server_domain.sto", $lang_ref);
+	store("$case_dir/data/Lang_tags.$server_domain.sto", $compiled_tags_ref);
+	my $reload_script = <<'PERL';
+$ProductOpener::Config::data_root = shift;
+$ProductOpener::Paths::BASE_DIRS{PRIVATE_DATA} = "$ProductOpener::Config::data_root/data";
+require ProductOpener::Lang;
+require JSON::MaybeXS;
+print JSON::MaybeXS::encode_json({
+    lang => \%ProductOpener::Lang::Lang,
+    names => \%ProductOpener::Lang::Langs,
+    languages => \@ProductOpener::Lang::Langs,
+    tags => {
+        tag_type_singular => \%ProductOpener::Lang::tag_type_singular,
+        tag_type_plural => \%ProductOpener::Lang::tag_type_plural,
+        tag_type_from_singular => \%ProductOpener::Lang::tag_type_from_singular,
+        tag_type_from_plural => \%ProductOpener::Lang::tag_type_from_plural,
+    },
+});
+PERL
+	open(my $reload_fh, '-|', $^X, '-MProductOpener::Paths', '-e', $reload_script, $case_dir)
+		or die "Cannot reload translations: $!";
+	my $reloaded_ref = decode_json(do {local $/; <$reload_fh>});
+	ok(close($reload_fh), 'Reload both compiled catalogs in a fresh process');
+	is($reloaded_ref->{lang}, $lang_ref, 'All translations and fallbacks survive reloading');
+	is($reloaded_ref->{tags}, $compiled_tags_ref, 'All tag paths and reverse indexes survive reloading');
+	is($reloaded_ref->{languages}, [qw/en pt pt_BR/], 'Reloading does not activate an unregistered locale');
+	is(
+		$reloaded_ref->{names},
+		{map {$_ => $languages_ref->{$_}{$_}} keys %{$languages_ref}},
+		'Reloading preserves the registered language names'
+	);
+	done_testing();
+};
+
+done_testing();

--- a/tests/unit/language_codes.t
+++ b/tests/unit/language_codes.t
@@ -1,0 +1,74 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+use Test2::V0;
+use Test2::Plugin::UTF8;
+
+use ProductOpener::I18N qw/$language_code_re normalize_language_code language_tag base_language
+	language_fallbacks lookup_with_language_fallback/;
+use ProductOpener::Lang qw/language_locale/;
+use ProductOpener::Store qw/get_string_id_for_lang/;
+
+foreach my $case_ref (
+	['pt_BR', 'pt_BR', 'pt-BR', 'pt'],
+	['PT-br', 'pt_BR', 'pt-BR', 'pt'],
+	['pt_br', 'pt_BR', 'pt-BR', 'pt'],
+	['EN', 'en', 'en', 'en'],
+	['es-419', 'es_419', 'es-419', 'es'],
+	['kmr-tr', 'kmr_TR', 'kmr-TR', 'kmr'],
+	['zh-hant-tw', 'zh_Hant_TW', 'zh-Hant-TW', 'zh'],
+	['zh_HANS', 'zh_Hans', 'zh-Hans', 'zh'],
+	)
+{
+	my ($input, $normalized, $tag, $base) = @{$case_ref};
+	like($input, qr/\A$language_code_re\z/, "Shared grammar accepts $input");
+	is(normalize_language_code($input), $normalized, 'Normalize the code');
+	is(language_tag($input), $tag, 'Format a BCP-47 tag');
+	is(base_language($input), $base, 'Return the root language');
+}
+
+foreach my $invalid (undef, '', 'pt-BR-extra', "pt_BR\n", '../pt', 'pt_4A9', 'pt_KK') {
+	is(normalize_language_code($invalid), undef, 'Reject invalid language syntax');
+	is(language_tag($invalid), undef, 'No BCP-47 tag for invalid input');
+	is(base_language($invalid), undef, 'No base language for invalid input');
+	is([language_fallbacks($invalid)], [], 'No fallback chain for invalid input');
+}
+
+is([language_fallbacks('zh-hant-tw')], [qw/zh_Hant_TW zh_Hant zh/], 'Keep the script before the root language');
+is([language_fallbacks('pt-br')], [qw/pt_BR pt/], 'Region falls back to root');
+is([language_fallbacks('en')], ['en'], 'A base language has no implicit English or other fallback');
+
+my %values = (zh => 'base', zh_Hant => 'script', zh_Hans => 'other script', en => 'English');
+my $matched;
+is(lookup_with_language_fallback(\%values, 'zh-hant-tw', \$matched), 'script', 'Choose the closest defined value');
+is($matched, 'zh_Hant', 'Report the language of the value');
+is(lookup_with_language_fallback(\%values, 'pt_BR', \$matched), undef, 'Do not add an English fallback');
+is($matched, undef, 'Clear a previous match on a miss');
+is(lookup_with_language_fallback({pt_PT => 'Portugal'}, 'pt_BR'), undef, 'Do not cross into a sibling region');
+is(lookup_with_language_fallback({zh_Hans => 'Simplified'}, 'zh_Hant_TW'), undef, 'Do not cross into another script');
+is(lookup_with_language_fallback({pt_BR => undef, pt => 'base'}, 'pt_BR'), 'base', 'Skip undefined values');
+is(lookup_with_language_fallback({pt_BR => 0, pt => 1}, 'pt_BR'), 0, 'Preserve zero');
+is(lookup_with_language_fallback({pt_BR => '', pt => 'base'}, 'pt_BR'), '', 'Preserve an explicit empty value');
+is(lookup_with_language_fallback({no_language => 'special', no => 'Norwegian'}, 'no_language'),
+	'special', 'Preserve exact non-language configuration keys');
+is(lookup_with_language_fallback({no => 'Norwegian'}, 'no_language'),
+	undef, 'Do not derive a language from a special key');
+is(lookup_with_language_fallback(undef, 'pt_BR'), undef, 'Accept an absent dictionary');
+is(lookup_with_language_fallback(\%values, undef), undef, 'Accept an absent language');
+is(
+	\%values,
+	{zh => 'base', zh_Hant => 'script', zh_Hans => 'other script', en => 'English'},
+	'Lookups leave the dictionary unchanged'
+);
+
+is(language_locale('pt_br')->id, 'pt-BR', 'Normalize before mapping the calendar locale');
+is(language_locale('pt_ZZ')->id, 'pt', 'Use a Portuguese calendar when a region is unavailable');
+is(language_locale('zh-TW')->id, 'zh-Hant-TW', 'Keep the traditional Chinese calendar mapping');
+is(language_locale('zh_HK')->id, 'zh-Hant-HK', 'Keep the Hong Kong calendar mapping');
+is(language_locale('zh_CN')->id, 'zh-Hans-CN', 'Keep the simplified Chinese calendar mapping');
+is(language_locale('invalid')->id, 'en', 'Unknown calendar locales retain English fallback');
+is(get_string_id_for_lang('fr_CA', 'Café crème'), 'cafe-creme', 'Inherit French accent normalization');
+is(get_string_id_for_lang('de_AT', 'Äpfel'), 'äpfel', 'Inherit German accent normalization');
+is(get_string_id_for_lang('no_language', 'Café crème'), 'cafe-creme', 'Keep special normalization settings');
+
+done_testing();

--- a/tests/unit/taxonomy_language_variants.t
+++ b/tests/unit/taxonomy_language_variants.t
@@ -1,0 +1,126 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use File::Basename qw/dirname/;
+use File::Path qw/make_path/;
+use File::Temp qw/tempdir/;
+use JSON::MaybeXS qw/decode_json/;
+use Test2::V0;
+use Test2::Plugin::UTF8;
+use Log::Any::Adapter 'TAP';
+
+use ProductOpener::Paths qw/%BASE_DIRS/;
+use ProductOpener::Tags qw/build_tags_taxonomy retrieve_tags_taxonomy canonicalize_taxonomy_tag
+	display_taxonomy_tag display_taxonomy_tag_name get_property is_a sanitize_taxonomy_line/;
+
+my $dir = tempdir(CLEANUP => 1);
+make_path("$dir/cache/taxonomies", "$dir/public");
+local $BASE_DIRS{TAXONOMIES_SRC} = dirname(__FILE__) . '/inputs/taxonomy_language_variants';
+local $BASE_DIRS{CACHE_BUILD} = "$dir/cache";
+local $BASE_DIRS{PUBLIC_DATA} = "$dir/public";
+local $ENV{TAXONOMY_NO_GET_FROM_CACHE} = 1;
+local $ENV{GITHUB_TOKEN} = '';
+
+is([build_tags_taxonomy('regional_test', 1)], [], 'Compile regional prefixes without taxonomy errors');
+retrieve_tags_taxonomy('regional_test', 1);
+
+subtest 'Regional matching and base-language fallback' => sub {
+	foreach my $case_ref (
+		['pt', 'Cuscuz', 'en:wheat-couscous'],
+		['pt_BR', 'Cuscuz', 'en:corn-couscous'],
+		['pt-br', 'Cuscuz', 'en:corn-couscous'],
+		['pt_br', 'Cuscuz', 'en:corn-couscous'],
+		['pt_PT', 'Cuscuz', 'en:wheat-couscous'],
+		['en', 'pt-br:Cuscuz', 'en:corn-couscous'],
+		['pt_BR', 'pt:Cuscuz', 'en:wheat-couscous'],
+		['pt_BR', 'Sal', 'en:salt'],
+		['pt_BR', 'de Sal', 'en:salt'],
+		['pt_BR', 'Creme leite', 'en:cream'],
+		['fr_CA', 'specialite regionale', 'en:french-specialty'],
+		['zh_Hant_HK', '繁體', 'en:chinese-label'],
+		['zh_Hant_HK', '中文', 'en:chinese-label'],
+		['pt_BR', 'Universal name', 'xx:universal-name'],
+		['pt_BR', 'English only', 'en:english-only'],
+		['pt_br', 'Especialidade regional', 'pt_BR:especialidade-regional'],
+		)
+	{
+		my ($language, $text, $expected) = @{$case_ref};
+		my $exists;
+		is(canonicalize_taxonomy_tag($language, 'regional_test', $text, \$exists), $expected, "$language: $text");
+		is($exists, 1, 'The match exists in the taxonomy');
+	}
+	my $exists;
+	is(canonicalize_taxonomy_tag('pt-br', 'regional_test', 'Desconhecido', \$exists),
+		'pt_BR:Desconhecido', 'An unknown term retains its regional context');
+	is($exists, 0, 'Fallback does not invent a match');
+};
+
+subtest 'Regional display names' => sub {
+	foreach my $case_ref (
+		['pt', 'en:cream', 'Natas'],
+		['pt_BR', 'en:cream', 'Creme de leite'],
+		['pt-br', 'en:cream', 'Creme de leite'],
+		['pt_PT', 'en:cream', 'Natas'],
+		['pt_BR', 'en:salt', 'Sal'],
+		['zh_Hant_TW', 'en:chinese-label', '臺灣'],
+		['zh_Hant_HK', 'en:chinese-label', '繁體'],
+		['zh_Hans', 'en:chinese-label', '中文'],
+		['pt_BR', 'xx:universal-name', 'Universal name'],
+		['pt_BR', 'en:english-only', 'en:English only'],
+		['pt_BR', 'pt:Desconhecido', 'Desconhecido'],
+		['pt_BR', 'pt_br:especialidade-regional', 'Especialidade regional'],
+		)
+	{
+		my ($language, $tag, $expected) = @{$case_ref};
+		is(display_taxonomy_tag($language, 'regional_test', $tag), $expected, "$language: $tag");
+	}
+	is(
+		display_taxonomy_tag_name('en', 'regional_test', 'pt_BR:especialidade-regional'),
+		'Especialidade regional',
+		'Remove the full regional prefix for display'
+	);
+};
+
+subtest 'Hierarchy, properties and exports' => sub {
+	ok(is_a('regional_test', 'en:regional-child', 'pt_BR:especialidade-regional'),
+		'A parent reference accepts a regional prefix');
+	is(
+		get_property('regional_test', 'en:cream', 'description:pt_BR'),
+		'Nome regional',
+		'Normalize property language codes'
+	);
+	is(get_property('regional_test', 'en:cream', 'url:en'),
+		'https://example.org/cream', 'Do not confuse a three-letter property name with a language');
+	is(
+		get_property('regional_test', 'pt_BR:especialidade-regional', 'description:pt_BR'),
+		'Propriedade regional',
+		'Load regional entries from the separate properties file'
+	);
+	foreach my $suffix ('', '.full', '.extended') {
+		open(my $fh, '<:raw', "$dir/public/taxonomies/regional_test$suffix.json") or die $!;
+		my $export_ref = decode_json(do {local $/; <$fh>});
+		close($fh);
+		is(
+			$export_ref->{'en:cream'}{name},
+			{en => 'Cream', pt => 'Natas', pt_BR => 'Creme de leite'},
+			"Names survive the $suffix JSON export"
+		);
+		is($export_ref->{'en:chinese-label'}{name}{zh_Hant_TW}, '臺灣', 'Preserve script and region');
+		is($export_ref->{'en:numeric-region'}{name}{es_419}, 'Nombre regional', 'Preserve numeric regions');
+		is($export_ref->{'en:three-letter-language'}{name}{kmr_TR}, 'Navê herêmî', 'Preserve three-letter codes');
+	}
+};
+
+subtest 'Prefix normalization leaves values alone' => sub {
+	is(sanitize_taxonomy_line('synonyms:pt-br: Nome'), 'synonyms:pt_BR: Nome', 'Normalize a synonym prefix');
+	is(sanitize_taxonomy_line('stopwords:pt-br: de'), 'stopwords:pt_BR: de', 'Normalize a stopword prefix');
+	is(
+		sanitize_taxonomy_line('description:en: pt_br: is an example'),
+		'description:en: pt_br: is an example',
+		'Do not rewrite a property value'
+	);
+	is(sanitize_taxonomy_line('pt_BR_extra: Invalid'), 'pt_BR_extra: Invalid', 'Reject unsupported suffixes');
+};
+
+done_testing();


### PR DESCRIPTION
### What

This enables the first regional interface language, Brazilian Portuguese, on top of the shared helpers from #14471.

`pt_BR` is registered in a dedicated interface list with its own native name, kept separate from the base language used by product fields, taxonomies, APIs and exports. Writing a product in the Brazilian interface still uses the `pt` field suffix.

The list of variants lives in `$options{interface_language_variants}`, in the section of `Config.pm` shared by all flavors. Enabling another language, such as `zh_TW`, is a configuration change rather than a code change, provided its catalogs exist and its base language is registered in the languages taxonomy. A variant whose code has invalid syntax is ignored with an error log.

Request locales are normalized, so `fr-ca`, `pt_br` and `pt-BR` resolve to the same internal spelling. Only registered interface languages are accepted; anything else falls back to English as before. Templates, translation helpers and calendar locales use the selected variant, and HTML, language links and JSON catalog paths emit BCP-47 tags.

Taxonomies keep regional names and matching. Taxonomy language prefixes accept the full code syntax and are normalized on read, so `pt_BR:` entries are preserved. Lookups try the variant before its base language, including synonyms, and script subtags survive the fallback, for example `zh_Hant_TW` to `zh_Hant` to `zh`. Stopwords and string normalization inherit the base language's rules when a variant has none of its own.

`$BUILD_TAGS_VERSION` is bumped, so merging this triggers a full taxonomy rebuild.

### Tests

`scripts/build_lang.pl` finishes with the real catalogs and generates `html/data/i18n/pt-BR/`, which is not produced on #14471.

580 assertions passed across the focused test files, covering catalog compilation and reload, the configuration-driven registry, request selection, rendered language links, product writes that keep the `pt` field suffix, and regional taxonomy matching and display. Two taxonomy fixtures were added for the regional cases.

Perltidy and `git diff --check` passed. The full unit suite was not re-run on this branch.

Depends on #14471, which must be merged first.

Related to #6688, which stays open.
