### PR TITLE
refactor(perf): sort remaining taxonomy entries alphabetically in suggestions once

### DIFF
--- a/lib/ProductOpener/TaxonomySuggestions.pm
+++ b/lib/ProductOpener/TaxonomySuggestions.pm
@@ -187,12 +187,12 @@ sub generate_sorted_list_of_taxonomy_entries ($country, $tagtype, $search_lc, $c
 		@tags = generate_popular_suggestions_according_to_context($country, $tagtype, $search_lc, $context_ref,
 			\%seen_tags);
 
+		# Sort the remaining entries alphabetically before adding them
+		my @all_tags = sort({cmp_taxonomy_tags_alphabetically($tagtype, $search_lc, $a, $b)}
+			keys %{$translations_to{$tagtype}});
+
 		# add all remaining entries in alphabetical order
-		foreach my $tag (
-			sort({cmp_taxonomy_tags_alphabetically($tagtype, $search_lc, $a, $b)}
-				keys %{$translations_to{$tagtype}})
-			)
-		{
+		foreach my $tag (@all_tags) {
 			next if defined $seen_tags{$tag};
 			push @tags, $tag;
 		}


### PR DESCRIPTION
### What

Moves sorting of tags before the loop to avoid redundant execution. This should speed up `/api/v3/taxonomy_suggestions` for larger taxonomies.

### Large Language Models usage disclosure

None

### Screenshot or video

Tested `tests/unit/taxonomy_suggestions.t` with `categories` instead of the `tests` taxonomy to actually get a few iterations in. 

#### `Devel::NYTProf` before

> Profile of tests/unit/taxonomy_suggestions.t for 5.01s (of 7.09s), executing 6906569 statements and 1617356 subroutine calls in 725 source files and 340 string evals.

<img width="1200" height="514" alt="NYTProf flame graph before optimization" src="https://github.com/user-attachments/assets/2e782c4e-7cbc-4818-82fc-4bf5792f376f" />

#### `Devel::NYTProf` after

> Profile of tests/unit/taxonomy_suggestions.t for 3.51s (of 3.96s), executing 1155926 statements and 456627 subroutine calls in 725 source files and 341 string evals.

<img width="1200" height="514" alt="NYTProf flame graph after optimization" src="https://github.com/user-attachments/assets/917aa078-6e66-4106-afa4-91a7453cb5f0" />

### Related issue(s) and discussion

None.