### PR TITLE
fix(taxonomy): resolve duplicate synonyms in three-letter languages

### DIFF
--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -6783,7 +6783,7 @@ io: Bulgaria
 is: Búlgaría, Bulgaria
 it: Bulgaria
 ja: ブルガリア, ブルガリア国民議会, 勃牙利, ブルガリアの下院, ブルガリヤ, ブルガリア共和国, 勃
-jbo: bylgAri, bylgarias, bulgar, balgarias, Bulgaria, bulgarias
+jbo: bylgArias, bulgar, balgarias, Bulgaria, bulgarias
 jv: Bulgaria
 ka: ბულგარეთი
 kaa: Bolgariya
@@ -38200,7 +38200,7 @@ io: Slovenia
 is: Slóvenía
 it: Slovenia
 ja: スロベニア, スロヴェニア
-jbo: slovEni
+jbo: slovEnias
 jv: Slovénia
 ka: სლოვენია
 kaa: Sloveniya

--- a/taxonomies/countries.txt
+++ b/taxonomies/countries.txt
@@ -1729,7 +1729,6 @@ fa: سرزمین جنوبی
 fiu-vro: Antarktiga
 fr: Région antarctique
 gd: An Antartaig
-got: 𐌰𐌽𐍄𐌰𐍂𐌺𐍄𐌹𐌺𐌰
 gu: એન્ટાર્કટીકા
 hsb: Antarktis
 hu: Antarktisz
@@ -6784,7 +6783,7 @@ io: Bulgaria
 is: Búlgaría, Bulgaria
 it: Bulgaria
 ja: ブルガリア, ブルガリア国民議会, 勃牙利, ブルガリアの下院, ブルガリヤ, ブルガリア共和国, 勃
-jbo: bylgAri, as, bylgarias, bulgar, balgarias, Bulgaria, bulgarias
+jbo: bylgAri, bylgarias, bulgar, balgarias, Bulgaria, bulgarias
 jv: Bulgaria
 ka: ბულგარეთი
 kaa: Bolgariya
@@ -11278,7 +11277,6 @@ ce: Халкъа куьйгаллийца йолу Пачхьалкх Конго
 ceb: Republikang Demokratiko sa Congo
 chy: Democratic Republic of the Congo
 ckb: کۆماری دیموکراتیکی کۆنگۆ
-crh: Kongo
 cs: Demokratická republika Kongo
 cv: Конго Демократиллĕ Республики
 cy: Gweriniaeth Ddemocrataidd Congo
@@ -18570,7 +18568,6 @@ bo: ཧོང་དུ་ར་སི།
 bpy: হন্ডুরাস
 br: Honduras
 bs: Honduras
-bxr: Гренада
 ca: Hondures
 ce: Гондурас
 ceb: Honduras
@@ -38203,7 +38200,7 @@ io: Slovenia
 is: Slóvenía
 it: Slovenia
 ja: スロベニア, スロヴェニア
-jbo: slovEni, as
+jbo: slovEni
 jv: Slovénia
 ka: სლოვენია
 kaa: Sloveniya

--- a/taxonomies/languages.txt
+++ b/taxonomies/languages.txt
@@ -2254,7 +2254,6 @@ oc: Bokmål
 os: Букмол
 pa: ਬੂਕਮਾਲ ਨਾਰਵੇਜਿਅਨ
 pl: Bokmål
-pms: Lenga norvegèisa
 pnb: بکمال
 ps: بوکمول
 pt: Bokmål norueguês
@@ -6281,7 +6280,6 @@ nb: Grønlandsk, Kalaallisut språk, Grønlandsk språk, Kalaallisut
 nl: Groenlands, Kalaallisut
 nn: Grønlandsk, Grønlandsk språk
 pl: Język grenlandzki, Kalaallisut
-pms: Lenga inuktitut
 pt: Groenlandês, Groelandês, Gronelandês
 pt-br: Groenlandês, Groelandês
 qu: Kalalit simi, Kalaallisut
@@ -7128,7 +7126,6 @@ fo: Ungarskt mál
 fr: hongrois, hu, langue hongroise, magyar
 fy: Hongaarsk
 ga: An Ungáiris
-gag: Uygur dili
 gd: Ungairis
 gl: lingua húngara
 gsw: Ungarischi Sproch
@@ -12219,6 +12216,7 @@ oc: Norvegian
 os: Норвегиаг æвзаг
 pa: ਨਾਰਵੇਈ ਭਾਸ਼ਾ
 pl: język norweski
+pms: Lenga norvegèisa
 ps: ناروېژي ژبه
 pt: Norueguês
 pt-br: Norueguês
@@ -12334,7 +12332,6 @@ li: Nynorsk
 lmo: Nynorsk
 lt: Naujoji norvegų kalba
 lv: Jaunnorvēģu valoda
-mdf: Норвегонь кяль
 ms: Nynorsk
 mzn: نینورسک
 nb: nynorsk, Norsk (nynorsk), Norsk Nynorsk
@@ -12344,7 +12341,6 @@ nn: nynorsk
 oc: Nynorsk
 os: Нюнорск
 pl: Nynorsk
-pms: Lenga norvegèisa
 pnb: نائنورسک
 ps: نينورشک
 pt: Novo norueguês


### PR DESCRIPTION
### What

Eight names in `countries.txt` and `languages.txt` are each mapped to two different entries. The taxonomy builder reports them as `duplicate_synonym` errors.

**countries**

- `got: 𐌰𐌽𐍄𐌰𐍂𐌺𐍄𐌹𐌺𐌰` is on both `en:Antarctic` and `en:Antarctica`. The Gothic name transliterates *Antarktika*, so it stays on Antarctica. German already distinguishes the two entries the same way, with `de: Antarktis` and `de: Antarktika`.
- `bxr: Гренада` is on both `en:Grenada` and `en:Honduras`. It means Grenada, so it is removed from Honduras.
- `crh: Kongo` is on both `en:Democratic Republic of the Congo` and `en:Republic of the Congo`. Turkish, the closest relative in this taxonomy, uses `Demokratik Kongo Cumhuriyeti` and `Kongo Cumhuriyeti`, so plain *Kongo* is the Republic of the Congo and is removed from the DRC.
- `jbo: as` is an artifact of splitting the Lojban names `bylgAri,as` (Bulgaria) and `slovEni,as` (Slovenia) at their internal comma. Restore the complete names as `bylgArias` and `slovEnias`, following the review suggestions. In Lojban, this comma is an optional syllable separator; omitting it preserves the name and avoids the taxonomy synonym delimiter. See [Bulgaria](https://www.wikidata.org/wiki/Q219), [Slovenia](https://www.wikidata.org/wiki/Q215), and the [Lojban reference grammar](https://www.lojban.org/publications/cll.before-20160606/cll_v1.1_xhtml-section-chunks/section-lojban-characters.html).

**languages**

- `pms: Lenga inuktitut` is on both `en:Greenlandic` and `en:Inuktitut`. It means Inuktitut, so it is removed from Greenlandic.
- `pms: Lenga norvegèisa` is on both `en:Bokmål` and `en:Nynorsk`. It names the Norwegian macrolanguage, so it moves to `en:Norwegian`, where the same Romance pattern already appears as `lij: Lengua norvegeise` and `lmo: Lengua nurvegesa`.
- `mdf: Норвегонь кяль` is on both `en:Norwegian` and `en:Nynorsk`, and likewise stays on Norwegian.
- `gag: Uygur dili` is on both `en:Hungarian` and `en:Uyghur`. It means Uyghur, so it is removed from Hungarian.

Most of these look like Wikidata imports that landed on a neighbouring entry.

### Impact

None today. The builder only reads two-letter language prefixes, so every line above is currently ignored and no entry changes. The errors appear as soon as three-letter prefixes are read, which makes the affected taxonomies fail to build.

### Tests

All 35 taxonomies build with no error, against a builder that reads three-letter prefixes. The eight fixes are sufficient: no other taxonomy file has a hidden duplicate of this kind.
