### PR TITLE
fix: Prepare language codes and catalogs for variants

### DIFF
--- a/lib/ProductOpener/I18N.pm
+++ b/lib/ProductOpener/I18N.pm
@@ -39,6 +39,12 @@ The functions used in this module take the directory to look for the .po files a
 package ProductOpener::I18N;
 
 use ProductOpener::PerlStandards;
+use Exporter qw/import/;
+
+our @EXPORT_OK = qw/$language_code_re normalize_language_code language_tag base_language
+	language_fallbacks lookup_with_language_fallback/;
+our %EXPORT_TAGS = (all => \@EXPORT_OK);
+our $language_code_re = qr/[a-z]{2,3}(?:[-_][a-z]{4})?(?:[-_](?:[a-z]{2}|[0-9]{3}))?/iaa;
 
 use File::Basename;
 use File::Find::Rule;
@@ -79,6 +85,119 @@ my @metadata_fields = qw<
 
 =head1 FUNCTIONS
 
+=head2 normalize_language_code( $code )
+
+=head3 Arguments
+
+C<$code> is a two- or three-letter language, optionally followed by a script and
+a region. C<$language_code_re> is the same grammar, without anchors or captures,
+for use in filenames and taxonomy prefixes. Hyphens, underscores and mixed case
+are accepted; callers can require the normalized spelling.
+
+=head3 Return values
+
+The internal spelling (C<pt_BR>, C<zh_Hant_TW>), or undef for unsupported syntax.
+This does not register or enable a language.
+
+=cut
+
+sub normalize_language_code ($code) {
+	return if not defined $code or $code !~ /\A$language_code_re\z/;
+	my ($language, @subtags) = split /[-_]/, $code;
+	return join('_', lc($language), map {length($_) == 4 ? ucfirst(lc($_)) : uc($_)} @subtags);
+}
+
+=head2 language_tag( $code )
+
+=head3 Arguments
+
+C<$code> is a supported internal or external language code.
+
+=head3 Return values
+
+The BCP-47 spelling (C<pt-BR>), or undef for unsupported syntax.
+
+=cut
+
+sub language_tag ($code) {
+	my $tag = normalize_language_code($code);
+	return if not defined $tag;
+	$tag =~ s/_/-/g;
+	return $tag;
+}
+
+=head2 base_language( $code )
+
+=head3 Arguments
+
+C<$code> is a supported internal or external language code.
+
+=head3 Return values
+
+The language without script or region (C<pt>, C<zh>), or undef for invalid syntax.
+
+=cut
+
+sub base_language ($code) {
+	my $canonical = normalize_language_code($code);
+	return if not defined $canonical;
+	return (split /_/, $canonical)[0];
+}
+
+=head2 language_fallbacks( $code )
+
+=head3 Arguments
+
+C<$code> is a supported language code.
+
+=head3 Return values
+
+An ordered list of normalized codes, from specific to general, for example
+C<zh_Hant_TW>, C<zh_Hant>, C<zh>. An invalid code returns an empty list.
+No unrelated language is added.
+
+=cut
+
+sub language_fallbacks ($code) {
+	my $canonical = normalize_language_code($code);
+	return () if not defined $canonical;
+	my @languages = ($canonical);
+	while ($canonical =~ s/_[^_]+$//) {
+		push @languages, $canonical;
+	}
+	return @languages;
+}
+
+=head2 lookup_with_language_fallback( $hash_ref, $code, $matched_code_ref = undef )
+
+=head3 Arguments
+
+C<$hash_ref> maps normalized language codes to values. C<$code> selects the
+language. The optional C<$matched_code_ref> receives the code that supplied the
+value, or undef on a miss. Non-language keys such as C<no_language> are exact-only.
+
+=head3 Return values
+
+The first defined value in the language's fallback chain, or undef. Zero and
+empty strings are values too. The hash is not modified, and English fallback is
+left to the caller.
+
+=cut
+
+sub lookup_with_language_fallback ($hash_ref, $code, $matched_code_ref = undef) {
+	$$matched_code_ref = undef if defined $matched_code_ref;
+	return if not defined $code or not defined $hash_ref;
+	my @languages = language_fallbacks($code);
+	@languages = ($code) if not @languages;
+	foreach my $language (@languages) {
+		if (defined $hash_ref->{$language}) {
+			$$matched_code_ref = $language if defined $matched_code_ref;
+			return $hash_ref->{$language};
+		}
+	}
+	return;
+}
+
 =head2 read_po_files( $dir, $languages_ref )
 
 Read and merge .po files into one hash, removing gettext metadata and empty
@@ -88,9 +207,9 @@ translations written by Crowdin.
 
 C<$dir> is the directory containing the .po files.
 
-Basenames must use two or three lowercase language letters, optionally followed by
-C<_> and two uppercase region letters or three digits: C<en.po>, C<pt_BR.po>,
-C<kmr_TR.po>, C<es_419.po>. The complete code remains the translation key.
+Basenames must use the normalized spelling: C<en.po>, C<pt_BR.po>, C<kmr_TR.po>,
+C<es_419.po>, C<zh_Hant.po> or C<zh_Hant_TW.po>.
+The complete code remains the translation key.
 
 The optional C<$languages_ref> hash restricts loading to its keys, matched exactly
 including case (C<pt_BR>, not C<pt_br>). Omit it to load all matching catalogs.
@@ -123,13 +242,14 @@ sub read_po_files ($dir, $languages_ref = undef) {
 		$log->debug("Reading po file");
 
 		my $lc;
-		if ($filename =~ /\A([a-z]{2,3}(?:_(?:[A-Z]{2}|[0-9]{3}))?)\.po\z/) {
-			$lc = $1;
+		if ($filename =~ /\A($language_code_re)\.po\z/) {
+			$lc = normalize_language_code($1);
 		}
 		else {
-			$log->debug("Skipping file (not in language.po or language_REGION.po format)");
+			$log->debug("Skipping file (not in language.po format)");
 			next;
 		}
+		next if $filename ne "$lc.po";
 
 		if ((defined $languages_ref) and (not exists $languages_ref->{$lc})) {
 			$log->debug("Skipping file (language code is not registered with this exact case)", {lc => $lc});
@@ -226,4 +346,3 @@ sub split_tags {
 1;
 
 __END__
-

--- a/lib/ProductOpener/I18N.pm
+++ b/lib/ProductOpener/I18N.pm
@@ -329,8 +329,11 @@ sub split_tags {
 	my ($l10n) = @_;
 
 	my (%singular, %plural);
-	$singular{":langname"} = $plural{":langname"} = delete $l10n->{":langname"};
-	$singular{":langtag"} = $plural{":langtag"} = delete $l10n->{":langtag"};
+	# Do not create undefined entries: po/tags catalogs do not all define these keys.
+	foreach my $key (":langname", ":langtag") {
+		next if not exists $l10n->{$key};
+		$singular{$key} = $plural{$key} = delete $l10n->{$key};
+	}
 
 	for my $key (keys %{$l10n}) {
 		my ($tag, $kind) = split /:/, $key;

--- a/lib/ProductOpener/I18N.pm
+++ b/lib/ProductOpener/I18N.pm
@@ -79,24 +79,31 @@ my @metadata_fields = qw<
 
 =head1 FUNCTIONS
 
-=head2 read_po_files()
+=head2 read_po_files( $dir, $languages_ref )
 
-C<read_po_files()> takes directory of the .po files as an input parameter, reads and merges them in one hash
-That hash is returned as a reference. (Done to spare the stack) Returning a reference uses a bit less memory since there's no copy.
-This function also cleans up the %Lexicon from gettext metadata 
-and cleans up the empty values that are put in .po files by Crowdin when the string is not translated.
+Read and merge .po files into one hash, removing gettext metadata and empty
+translations written by Crowdin.
 
 =head3 Arguments
 
-The directory containing .po files are passed as an argument.
+C<$dir> is the directory containing the .po files.
+
+Basenames must use two or three lowercase language letters, optionally followed by
+C<_> and two uppercase region letters or three digits: C<en.po>, C<pt_BR.po>,
+C<kmr_TR.po>, C<es_419.po>. The complete code remains the translation key.
+
+The optional C<$languages_ref> hash restricts loading to its keys, matched exactly
+including case (C<pt_BR>, not C<pt_br>). Omit it to load all matching catalogs.
+Callers handle language registration and translation fallbacks.
 
 =head3 Return values
 
-Returns a reference to a hash on successful execution.
+A hash reference mapping string IDs to translations by language. Returning a
+reference avoids copying the hash and spares the stack.
 
 =cut
 
-sub read_po_files ($dir) {
+sub read_po_files ($dir, $languages_ref = undef) {
 
 	local $log->context->{directory} = $dir;
 	$log->debug("Reading po files from disk");
@@ -111,16 +118,21 @@ sub read_po_files ($dir) {
 
 	for my $file (sort @files) {
 		# read the .po file
-		local $log->context->{file} = basename($file);
+		my $filename = basename($file);
+		local $log->context->{file} = $filename;
 		$log->debug("Reading po file");
 
 		my $lc;
-
-		if ($file =~ /\/(\w\w).po/) {
+		if ($filename =~ /\A([a-z]{2,3}(?:_(?:[A-Z]{2}|[0-9]{3}))?)\.po\z/) {
 			$lc = $1;
 		}
 		else {
-			$log->debug("Skipping file (not in [2-letter code].po format)");
+			$log->debug("Skipping file (not in language.po or language_REGION.po format)");
+			next;
+		}
+
+		if ((defined $languages_ref) and (not exists $languages_ref->{$lc})) {
+			$log->debug("Skipping file (language code is not registered with this exact case)", {lc => $lc});
 			next;
 		}
 

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -293,8 +293,9 @@ else {
 my @debug_taxonomies = ("categories", "labels", "additives");
 
 # Build hashes to map a translated tag type (e.g. "catégorie") in singular or plural to the tag type (e.g. "categories")
+# The registry must include en, which supplies the fallback paths for all languages.
 
-sub build_lang_tags() {
+sub build_lang_tags ($Languages_ref) {
 
 	# Tags types to path components in URLS: in ascii, lowercase, unaccented,
 	# transliterated (in Roman characters)
@@ -302,11 +303,13 @@ sub build_lang_tags() {
 	# Note: a lot of plurals are currently missing below, commented-out are
 	# the singulars that need to be changed to plurals
 	my ($tag_type_singular_ref, $tag_type_plural_ref)
-		= ProductOpener::I18N::split_tags(ProductOpener::I18N::read_po_files("$data_root/po/tags/"));
+		= ProductOpener::I18N::split_tags(ProductOpener::I18N::read_po_files("$data_root/po/tags/", $Languages_ref));
 	%tag_type_singular = %{$tag_type_singular_ref};
 	%tag_type_plural = %{$tag_type_plural_ref};
+	%tag_type_from_singular = ();
+	%tag_type_from_plural = ();
 
-	foreach my $l (@Langs) {
+	foreach my $l (sort keys %{$Languages_ref}) {
 
 		my $short_l = undef;
 		if ($l =~ /_/) {
@@ -372,7 +375,9 @@ sub build_lang ($Languages_ref) {
 	# UI strings, non-Roman characters can be used
 	my $path = "$data_root/po/common/";
 	$log->info("Loading common \%Lang", {path => $path});
-	%Lang = %{ProductOpener::I18N::read_po_files($path)};
+	# Only compile registered languages. Otherwise, regional entries in the 'add' key
+	# would become selectable languages when Lang.sto is loaded, without initialization.
+	%Lang = %{ProductOpener::I18N::read_po_files($path, $Languages_ref)};
 
 	# Load the .pot file
 	my %common_keys = %{ProductOpener::I18N::read_pot_file($path . "common.pot")};

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -51,6 +51,7 @@ BEGIN {
 		%Langs
 		@Langs
 
+		&language_locale
 		&lang
 		&f_lang
 		&f_lang_in_lc
@@ -64,7 +65,7 @@ BEGIN {
 }
 
 use vars @EXPORT_OK;
-use ProductOpener::I18N;
+use ProductOpener::I18N qw/normalize_language_code language_tag lookup_with_language_fallback/;
 use ProductOpener::Store qw/get_string_id_for_lang retrieve/;
 use ProductOpener::Config qw/:all/;
 use ProductOpener::Paths qw/%BASE_DIRS ensure_dir_created_or_die/;
@@ -80,6 +81,26 @@ use Log::Any qw($log);
 $lc = "en";
 
 =head1 FUNCTIONS
+
+=head2 language_locale( $code )
+
+Return the calendar locale for a language, falling back through its language
+parents and then to English when missing.
+Chinese catalog region codes need an explicit script for DateTime::Locale.
+
+=cut
+
+sub language_locale ($code) {
+	my %chinese_locales = (zh_CN => 'zh-Hans-CN', zh_TW => 'zh-Hant-TW', zh_HK => 'zh-Hant-HK');
+	my $canonical = normalize_language_code($code);
+	state %available = map {
+		my $language = normalize_language_code($_);
+		defined $language ? ($language => $_) : ()
+	} DateTime::Locale->codes;
+	my $requested = defined $canonical ? ($chinese_locales{$canonical} // $canonical) : undef;
+	my $locale = lookup_with_language_fallback(\%available, $requested) // 'en';
+	return DateTime::Locale->load($locale);
+}
 
 =head2 separator_before_colon( $l )
 
@@ -309,35 +330,16 @@ sub build_lang_tags ($Languages_ref) {
 	%tag_type_from_singular = ();
 	%tag_type_from_plural = ();
 
+	foreach my $paths_ref (\%tag_type_singular, \%tag_type_plural) {
+		foreach my $type (keys %{$paths_ref}) {
+			my %translations = %{$paths_ref->{$type}};
+			foreach my $l (sort keys %{$Languages_ref}) {
+				$paths_ref->{$type}{$l} = lookup_with_language_fallback(\%translations, $l) // $translations{en};
+			}
+		}
+	}
+
 	foreach my $l (sort keys %{$Languages_ref}) {
-
-		my $short_l = undef;
-		if ($l =~ /_/) {
-			$short_l = $`;    # pt_pt
-		}
-
-		foreach my $type (keys %tag_type_singular) {
-
-			if (not defined $tag_type_singular{$type}{$l}) {
-				if ((defined $short_l) and (defined $tag_type_singular{$type}{$short_l})) {
-					$tag_type_singular{$type}{$l} = $tag_type_singular{$type}{$short_l};
-				}
-				else {
-					$tag_type_singular{$type}{$l} = $tag_type_singular{$type}{en};
-				}
-			}
-		}
-
-		foreach my $type (keys %tag_type_plural) {
-			if (not defined $tag_type_plural{$type}{$l}) {
-				if ((defined $short_l) and (defined $tag_type_plural{$type}{$short_l})) {
-					$tag_type_plural{$type}{$l} = $tag_type_plural{$type}{$short_l};
-				}
-				else {
-					$tag_type_plural{$type}{$l} = $tag_type_plural{$type}{en};
-				}
-			}
-		}
 
 		$tag_type_from_singular{$l} or $tag_type_from_singular{$l} = {};
 		$tag_type_from_plural{$l} or $tag_type_from_plural{$l} = {};
@@ -407,24 +409,10 @@ sub build_lang ($Languages_ref) {
 
 	foreach my $key (sort keys %common_keys) {
 		if ((defined $Lang{$key}{en}) and ($Lang{$key}{en} ne '')) {
+			my %translations = %{$Lang{$key}};
 			foreach my $l (@Langs) {
-
-				my $short_l = undef;
-				if ($l =~ /_/) {
-					$short_l = $`;    # pt_pt
-				}
-
-				if (not defined $Lang{$key}{$l}) {
-					if ((defined $short_l) and (defined $Lang{$key}{$short_l})) {
-						$Lang{$key}{$l} = $Lang{$key}{$short_l};
-					}
-					elsif (defined $Lang{$key}{en}) {
-						$Lang{$key}{$l} = $Lang{$key}{en};
-					}
-					else {
-						$Lang{$key}{$l} = $Lang{$key}{fr};
-					}
-				}
+				$Lang{$key}{$l} = lookup_with_language_fallback(\%translations, $l) // $translations{en}
+					// $translations{fr};
 
 				my $tagid = get_string_id_for_lang($l, $Lang{$key}{$l});
 			}
@@ -467,16 +455,8 @@ sub build_lang ($Languages_ref) {
 		}
 	}
 
-	my $en_locale = DateTime::Locale->load('en');
-	my @locale_codes = DateTime::Locale->codes;
 	foreach my $l (@Langs) {
-		my $locale;
-		if (grep {$_ eq $l} @locale_codes) {
-			$locale = DateTime::Locale->load($l);
-		}
-		else {
-			$locale = $en_locale;
-		}
+		my $locale = language_locale($l);
 
 		my @months = ();
 		foreach my $month (1 .. 12) {
@@ -508,27 +488,12 @@ sub build_json {
 	}
 
 	foreach my $l (@Langs) {
-		my $target_dir = "$i18n_root/$l";
+		my $target_dir = "$i18n_root/" . language_tag($l);
 		ensure_dir_created_or_die($target_dir);
-
-		my $short_l = undef;
-		if ($l =~ /_/) {
-			$short_l = $`;    # pt_pt
-		}
 
 		my %result = ();
 		foreach my $s (keys %Lang) {
-			my $value;
-
-			if (defined $Lang{$s}{$l}) {
-				$value = $Lang{$s}{$l};
-			}
-			elsif ((defined $short_l) and (defined $Lang{$s}{$short_l}) and ($Lang{$s}{$short_l} ne '')) {
-				$value = $Lang{$s}{$short_l};
-			}
-			elsif ((defined $Lang{$s}{en}) and ($Lang{$s}{en} ne '')) {
-				$value = $Lang{$s}{en};
-			}
+			my $value = lookup_with_language_fallback($Lang{$s}, $l) // $Lang{$s}{en};
 
 			$result{$s} = $value if $value;
 		}

--- a/lib/ProductOpener/Lang.pm
+++ b/lib/ProductOpener/Lang.pm
@@ -332,6 +332,7 @@ sub build_lang_tags ($Languages_ref) {
 
 	foreach my $paths_ref (\%tag_type_singular, \%tag_type_plural) {
 		foreach my $type (keys %{$paths_ref}) {
+			next if not defined $paths_ref->{$type};
 			my %translations = %{$paths_ref->{$type}};
 			foreach my $l (sort keys %{$Languages_ref}) {
 				$paths_ref->{$type}{$l} = lookup_with_language_fallback(\%translations, $l) // $translations{en};

--- a/lib/ProductOpener/Store.pm
+++ b/lib/ProductOpener/Store.pm
@@ -57,6 +57,7 @@ BEGIN {
 use vars @EXPORT_OK;    # no 'my' keyword for these
 
 use ProductOpener::Config qw/:all/;
+use ProductOpener::I18N qw/lookup_with_language_fallback/;
 use ProductOpener::Paths qw/:all/;
 
 use Storable qw(lock_store lock_retrieve);
@@ -130,14 +131,9 @@ sub get_string_id_for_lang ($lc, $string) {
 	my $unaccent = $string_normalization_for_lang{default}{unaccent};
 	my $lowercase = $string_normalization_for_lang{default}{lowercase};
 
-	if (defined $string_normalization_for_lang{$lc}) {
-		if (defined $string_normalization_for_lang{$lc}{unaccent}) {
-			$unaccent = $string_normalization_for_lang{$lc}{unaccent};
-		}
-		if (defined $string_normalization_for_lang{$lc}{lowercase}) {
-			$lowercase = $string_normalization_for_lang{$lc}{lowercase};
-		}
-	}
+	my $normalization_ref = lookup_with_language_fallback(\%string_normalization_for_lang, $lc) // {};
+	$unaccent = $normalization_ref->{unaccent} // $unaccent;
+	$lowercase = $normalization_ref->{lowercase} // $lowercase;
 
 	if ($lowercase) {
 		# do not lowercase UUIDs

--- a/scripts/build_lang.pl
+++ b/scripts/build_lang.pl
@@ -43,7 +43,7 @@ retrieve_tags_taxonomy("languages");
 init_languages();
 
 ProductOpener::Lang::build_lang(\%Languages);
-my $tags_ref = ProductOpener::Lang::build_lang_tags();
+my $tags_ref = ProductOpener::Lang::build_lang_tags(\%Languages);
 
 print STDERR "Build \%Lang - done, saving sto files \n";
 # use $server_domain in part of the name so that we have different files

--- a/tests/unit/i18n_language_variants.t
+++ b/tests/unit/i18n_language_variants.t
@@ -1,0 +1,101 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use File::Temp qw/tempdir/;
+use Test2::V0;
+use Test2::Plugin::UTF8;
+use Log::Any::Adapter 'TAP';
+
+use ProductOpener::I18N;
+
+sub write_po_file ($path, $translation) {
+
+	open(my $fh, '>:encoding(UTF-8)', $path) or die "Cannot write $path: $!";
+	print {$fh} <<PO;
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Language: ignored\\n"
+
+msgctxt "greeting"
+msgid "Hello"
+msgstr "$translation"
+
+msgctxt "untranslated"
+msgid "Not translated yet"
+msgstr ""
+
+PO
+	close($fh) or die "Cannot close $path: $!";
+	return;
+}
+
+subtest 'Load regional catalogs without merging their translations' => sub {
+	my $dir = tempdir(CLEANUP => 1);
+	my %translations = (
+		ast => 'Asturian translation',
+		en => 'Hello',
+		en_GB => 'Hello from the UK',
+		es => 'Hola',
+		es_419 => 'Latin American Spanish translation',
+		kmr_TR => 'Kurdish translation',
+		pt => 'Olá',
+		pt_PT => 'Olá de Portugal',
+		pt_BR => 'Olá do Brasil',
+		zh => '你好',
+		zh_CN => '简体中文',
+		zh_TW => '繁體中文',
+		zh_HK => '香港繁體中文',
+	);
+	foreach my $language (sort keys %translations) {
+		write_po_file("$dir/$language.po", $translations{$language});
+	}
+
+	my $terms_ref = ProductOpener::I18N::read_po_files($dir);
+	is($terms_ref->{greeting}, \%translations, 'Catalog names determine the language, not the PO header');
+	is($terms_ref->{untranslated}, {}, 'Empty translations stay absent so the caller can apply a fallback');
+	is([sort keys %{$terms_ref}], ['greeting', 'untranslated'], 'Gettext metadata is not exposed as translations');
+	is(ProductOpener::I18N::read_po_files("$dir/"), $terms_ref, 'A trailing slash does not change the result');
+	is(
+		ProductOpener::I18N::read_po_files($dir, {pt => {}, zh => {}})->{greeting},
+		{pt => $translations{pt}, zh => $translations{zh}},
+		'Loading catalogs for a language registry does not implicitly enable variants'
+	);
+	is(
+		ProductOpener::I18N::read_po_files($dir, {ast => {}, es_419 => {}, kmr_TR => {}, pt_BR => {}, zh_TW => {}})
+			->{greeting},
+		{map {$_ => $translations{$_}} qw/ast es_419 kmr_TR pt_BR zh_TW/},
+		'Explicitly registered variants retain their full language codes'
+	);
+	is(ProductOpener::I18N::read_po_files($dir, {pt_br => {}}), {}, 'Registry keys must match the catalog code case');
+	is(ProductOpener::I18N::read_po_files($dir, {}), {}, 'An empty language registry loads no catalogs');
+	done_testing();
+};
+
+subtest 'Validate the complete catalog filename' => sub {
+	my $dir = tempdir(CLEANUP => 1);
+	foreach my $filename (
+		'ptXpo.po', 'pt.po.backup.po', 'pt_BR_extra.po', 'invalid.po', 'abcd.po', 'ast_TR_extra.po',
+		'es_41.po', 'es_4190.po', 'es_4A9.po', 'pt_br.po', 'pt-BR.po', 'PT.po'
+		)
+	{
+		write_po_file("$dir/$filename", 'Not a language catalog');
+	}
+	is(ProductOpener::I18N::read_po_files($dir), {}, 'Ignore filenames that only partially match a language code');
+	done_testing();
+};
+
+subtest 'Use the filename, not a parent directory, as the language code' => sub {
+	my $dir = tempdir(CLEANUP => 1);
+	mkdir("$dir/fr.po") or die "Cannot create nested directory: $!";
+	write_po_file("$dir/fr.po/pt_BR.po", 'Olá do Brasil');
+	is(
+		ProductOpener::I18N::read_po_files($dir),
+		{greeting => {pt_BR => 'Olá do Brasil'}, untranslated => {}},
+		'A directory that looks like a catalog does not change the language'
+	);
+	done_testing();
+};
+
+done_testing();

--- a/tests/unit/i18n_language_variants.t
+++ b/tests/unit/i18n_language_variants.t
@@ -47,6 +47,8 @@ subtest 'Load regional catalogs without merging their translations' => sub {
 		zh_CN => '简体中文',
 		zh_TW => '繁體中文',
 		zh_HK => '香港繁體中文',
+		zh_Hant => '繁體',
+		zh_Hant_TW => '臺灣',
 	);
 	foreach my $language (sort keys %translations) {
 		write_po_file("$dir/$language.po", $translations{$language});
@@ -76,8 +78,10 @@ subtest 'Load regional catalogs without merging their translations' => sub {
 subtest 'Validate the complete catalog filename' => sub {
 	my $dir = tempdir(CLEANUP => 1);
 	foreach my $filename (
-		'ptXpo.po', 'pt.po.backup.po', 'pt_BR_extra.po', 'invalid.po', 'abcd.po', 'ast_TR_extra.po',
-		'es_41.po', 'es_4190.po', 'es_4A9.po', 'pt_br.po', 'pt-BR.po', 'PT.po'
+		'ptXpo.po', 'pt.po.backup.po', 'pt_BR_extra.po', 'invalid.po',
+		'abcd.po', 'ast_TR_extra.po', 'es_41.po', 'es_4190.po',
+		'es_4A9.po', 'pt_br.po', 'pt-BR.po', 'PT.po',
+		'zh_hant.po', 'zh-Hant.po', 'zh_Hant_tw.po', 'zh_Hant_TW_extra.po'
 		)
 	{
 		write_po_file("$dir/$filename", 'Not a language catalog');

--- a/tests/unit/lang_tags.t
+++ b/tests/unit/lang_tags.t
@@ -162,6 +162,9 @@ subtest 'Compile, export and reload a registered variant with both fallback leve
 		},
 		pt_BR => {add => 'Adicionar Brasil', base_only => ''},
 		pt_PT => {add => 'Unregistered translation'},
+		zh => {add => '添加', greeting => '中文'},
+		zh_Hant => {add => '新增', base_only => '繁體'},
+		zh_Hant_TW => {add => '新增臺灣'},
 	);
 	foreach my $catalog (sort keys %catalogs, 'common') {
 		my $extension = $catalog eq 'common' ? 'pot' : 'po';
@@ -186,6 +189,9 @@ subtest 'Compile, export and reload a registered variant with both fallback leve
 		en => {en => 'English'},
 		pt => {pt => 'Português'},
 		pt_BR => {pt_BR => 'Português (Brasil)'},
+		zh => {zh => '中文'},
+		zh_Hant => {zh_Hant => '繁體中文'},
+		zh_Hant_TW => {zh_Hant_TW => '臺灣'},
 	};
 	local $ProductOpener::Lang::data_root = $case_dir;
 	local $BASE_DIRS{PUBLIC_DATA} = "$case_dir/public";
@@ -193,12 +199,19 @@ subtest 'Compile, export and reload a registered variant with both fallback leve
 	ProductOpener::Lang::build_lang($languages_ref);
 	my $lang_ref = \%ProductOpener::Lang::Lang;
 	is($lang_ref->{add}{pt_BR}, 'Adicionar Brasil', 'Keep the regional translation');
+	is($lang_ref->{base_only}{zh_Hant_TW}, '繁體', 'Use the script catalog before the base language');
+	is($lang_ref->{greeting}{zh_Hant_TW},
+		'中文', 'An initialized English fallback does not mask the original base catalog');
 	is($lang_ref->{base_only}{pt_BR}, 'Texto português', 'An empty regional translation falls back to Portuguese');
 	is($lang_ref->{english_only}{pt_BR}, 'English fallback', 'Fall back to English when Portuguese is also missing');
 	is($lang_ref->{greeting}{pt_BR}, "Bem-vindo a $options{site_name}", 'Resolve site placeholders after fallback');
 	is(ProductOpener::Lang::f_lang_in_lc('pt_BR', 'formatted', {name => 'Alice'}),
 		'Olá Alice', 'Formatted messages use the compiled base-language fallback');
-	is([sort keys %{$lang_ref->{add}}], [qw/en pt pt_BR/], 'Only registered languages enter the compiled catalog');
+	is(
+		[sort keys %{$lang_ref->{add}}],
+		[qw/en pt pt_BR zh zh_Hant zh_Hant_TW/],
+		'Only registered languages enter the compiled catalog'
+	);
 
 	my $compiled_tags_ref = ProductOpener::Lang::build_lang_tags($languages_ref);
 	is($compiled_tags_ref->{tag_type_singular}{categories}{pt_BR}, 'categoria-br', 'Compile the regional tag path');
@@ -206,13 +219,13 @@ subtest 'Compile, export and reload a registered variant with both fallback leve
 		'categorias-base', 'Compile the base-language fallback for the tag path');
 
 	ProductOpener::Lang::build_json();
-	open(my $json_fh, '<:raw', "$case_dir/public/i18n/pt_BR/lang.json") or die "Cannot read JSON catalog: $!";
+	open(my $json_fh, '<:raw', "$case_dir/public/i18n/pt-BR/lang.json") or die "Cannot read JSON catalog: $!";
 	my $json_ref = decode_json(do {local $/; <$json_fh>});
 	close($json_fh) or die "Cannot close JSON catalog: $!";
 	is($json_ref->{add}, 'Adicionar Brasil', 'Export the regional translation to JavaScript');
 	is($json_ref->{base_only}, 'Texto português', 'Export the Portuguese fallback to JavaScript');
 	is($json_ref->{english_only}, 'English fallback', 'Export the English fallback to JavaScript');
-	ok(!-d "$case_dir/public/i18n/pt_PT", 'Do not export an unregistered locale');
+	ok(!-d "$case_dir/public/i18n/pt-PT", 'Do not export an unregistered locale');
 
 	store("$case_dir/data/Lang.$server_domain.sto", $lang_ref);
 	store("$case_dir/data/Lang_tags.$server_domain.sto", $compiled_tags_ref);
@@ -239,7 +252,11 @@ PERL
 	ok(close($reload_fh), 'Reload both compiled catalogs in a fresh process');
 	is($reloaded_ref->{lang}, $lang_ref, 'All translations and fallbacks survive reloading');
 	is($reloaded_ref->{tags}, $compiled_tags_ref, 'All tag paths and reverse indexes survive reloading');
-	is($reloaded_ref->{languages}, [qw/en pt pt_BR/], 'Reloading does not activate an unregistered locale');
+	is(
+		$reloaded_ref->{languages},
+		[qw/en pt pt_BR zh zh_Hant zh_Hant_TW/],
+		'Reloading does not activate an unregistered locale'
+	);
 	is(
 		$reloaded_ref->{names},
 		{map {$_ => $languages_ref->{$_}{$_}} keys %{$languages_ref}},

--- a/tests/unit/lang_tags.t
+++ b/tests/unit/lang_tags.t
@@ -265,4 +265,42 @@ PERL
 	done_testing();
 };
 
+subtest 'Catalogs without language name keys' => sub {
+	# po/tags/*.po define no :langname and no :langtag, unlike the fixtures above.
+	my $plain_dir = tempdir(CLEANUP => 1);
+	make_path("$plain_dir/po/tags");
+	open(my $fh, '>:encoding(UTF-8)', "$plain_dir/po/tags/en.po") or die "Cannot write catalog: $!";
+	print {$fh} <<'PO';
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgctxt "categories:singular"
+msgid "category"
+msgstr "category"
+
+msgctxt "categories:plural"
+msgid "categories"
+msgstr "categories"
+
+PO
+	close($fh) or die "Cannot close catalog: $!";
+
+	local $ProductOpener::Lang::data_root = $plain_dir;
+	local %ProductOpener::Lang::tag_type_singular;
+	local %ProductOpener::Lang::tag_type_plural;
+	local %ProductOpener::Lang::tag_type_from_singular;
+	local %ProductOpener::Lang::tag_type_from_plural;
+
+	my $plain_tags_ref;
+	ok(lives {$plain_tags_ref = ProductOpener::Lang::build_lang_tags({en => {}})}, 'Build without the language keys')
+		or note($@);
+	is($plain_tags_ref->{tag_type_singular}{categories}, {en => 'category'}, 'Tag paths are still built');
+	ok(
+		!exists $plain_tags_ref->{tag_type_singular}{':langname'},
+		'No empty entry is created for a missing language name'
+	);
+	done_testing();
+};
+
 done_testing();

--- a/tests/unit/lang_tags.t
+++ b/tests/unit/lang_tags.t
@@ -1,0 +1,251 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+
+use File::Path qw/make_path/;
+use File::Temp qw/tempdir/;
+use JSON::MaybeXS qw/decode_json/;
+use Test2::V0;
+use Test2::Plugin::UTF8;
+use Log::Any::Adapter 'TAP';
+
+use ProductOpener::Config qw/$server_domain %options/;
+use ProductOpener::Lang;
+use ProductOpener::Paths qw/%BASE_DIRS/;
+use ProductOpener::Store qw/store/;
+
+sub write_tag_catalog ($dir, $language, $singular, $plural) {
+
+	open(my $fh, '>:encoding(UTF-8)', "$dir/po/tags/$language.po") or die "Cannot write catalog: $!";
+	print {$fh} <<PO;
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt ":langname"
+msgid "Language name"
+msgstr "$language"
+
+msgctxt ":langtag"
+msgid "Language code"
+msgstr "$language"
+
+msgctxt "categories:singular"
+msgid "category"
+msgstr "$singular"
+
+msgctxt "categories:plural"
+msgid "categories"
+msgstr "$plural"
+
+PO
+	close($fh) or die "Cannot close catalog: $!";
+	return;
+}
+
+my $dir = tempdir(CLEANUP => 1);
+make_path("$dir/po/tags");
+write_tag_catalog($dir, 'en', 'category', 'categories');
+write_tag_catalog($dir, 'pt_BR', 'categoria', 'categorias');
+
+local $ProductOpener::Lang::data_root = $dir;
+local @ProductOpener::Lang::Langs = ();
+local %ProductOpener::Lang::Langs = ();
+local %ProductOpener::Lang::tag_type_singular;
+local %ProductOpener::Lang::tag_type_plural;
+local %ProductOpener::Lang::tag_type_from_singular;
+local %ProductOpener::Lang::tag_type_from_plural;
+
+my $tags_ref = ProductOpener::Lang::build_lang_tags({en => {}, pt_BR => {}});
+is(
+	$tags_ref->{tag_type_singular}{categories},
+	{en => 'category', pt_BR => 'categoria'},
+	'Build singular paths from the explicit registry without calling build_lang first'
+);
+is(
+	$tags_ref->{tag_type_plural}{categories},
+	{en => 'categories', pt_BR => 'categorias'},
+	'Build plural paths from the same explicit registry'
+);
+is(
+	$tags_ref->{tag_type_from_singular},
+	{en => {category => 'categories'}, pt_BR => {categoria => 'categories'}},
+	'Reverse singular paths include both registered languages'
+);
+is(
+	$tags_ref->{tag_type_from_plural},
+	{en => {categories => 'categories'}, pt_BR => {categorias => 'categories'}},
+	'Reverse plural paths include both registered languages'
+);
+
+$tags_ref = ProductOpener::Lang::build_lang_tags({en => {}});
+is($tags_ref->{tag_type_singular}{categories}, {en => 'category'}, 'Only load catalogs from the new registry');
+is(
+	$tags_ref->{tag_type_from_singular},
+	{en => {category => 'categories'}},
+	'Rebuilding does not keep singular paths for languages from a previous build'
+);
+is(
+	$tags_ref->{tag_type_from_plural},
+	{en => {categories => 'categories'}},
+	'Rebuilding does not keep plural paths for languages from a previous build'
+);
+
+foreach my $case_ref (
+	{
+		name => 'Missing regional singular falls back to pt while the regional plural is kept',
+		regional => ['', 'categorias-regionais'],
+		expected => ['categoria-base', 'categorias-regionais'],
+	},
+	{
+		name => 'Missing regional plural falls back to pt while the regional singular is kept',
+		regional => ['categoria-regional', ''],
+		expected => ['categoria-regional', 'categorias-base'],
+	},
+	{
+		name => 'Both missing regional paths fall back to pt',
+		regional => ['', ''],
+		expected => ['categoria-base', 'categorias-base'],
+	},
+	)
+{
+	subtest $case_ref->{name} => sub {
+		my $case_dir = tempdir(CLEANUP => 1);
+		make_path("$case_dir/po/tags");
+		write_tag_catalog($case_dir, 'en', 'category', 'categories');
+		write_tag_catalog($case_dir, 'pt', 'categoria-base', 'categorias-base');
+		write_tag_catalog($case_dir, 'pt_BR', @{$case_ref->{regional}});
+		local $ProductOpener::Lang::data_root = $case_dir;
+		my $tags_ref = ProductOpener::Lang::build_lang_tags({en => {}, pt => {}, pt_BR => {}});
+		my ($singular, $plural) = @{$case_ref->{expected}};
+		is($tags_ref->{tag_type_singular}{categories}{pt_BR}, $singular, 'Resolve the singular path');
+		is($tags_ref->{tag_type_plural}{categories}{pt_BR}, $plural, 'Resolve the plural path');
+		is(
+			$tags_ref->{tag_type_from_singular}{pt_BR},
+			{$singular => 'categories'},
+			'Reverse lookup uses the resolved singular'
+		);
+		is(
+			$tags_ref->{tag_type_from_plural}{pt_BR},
+			{$plural => 'categories'},
+			'Reverse lookup uses the resolved plural'
+		);
+		done_testing();
+	};
+}
+
+write_tag_catalog($dir, 'pt', 'categoria-base', 'categorias-base');
+write_tag_catalog($dir, 'pt_BR', '', '');
+$tags_ref = ProductOpener::Lang::build_lang_tags({en => {}, pt_BR => {}});
+is($tags_ref->{tag_type_singular}{categories}{pt_BR},
+	'category', 'Use English when the base language is not registered');
+is($tags_ref->{tag_type_plural}{categories}{pt_BR},
+	'categories', 'Use English for the plural when the base language is not registered');
+
+subtest 'Compile, export and reload a registered variant with both fallback levels' => sub {
+	my $case_dir = tempdir(CLEANUP => 1);
+	make_path("$case_dir/po/common", "$case_dir/po/tags", "$case_dir/public", "$case_dir/data");
+	my %english = (
+		add => 'Add',
+		base_only => 'Base fallback',
+		english_only => 'English fallback',
+		greeting => 'Welcome to <<site_name>>',
+		formatted => 'Hello {name}',
+	);
+	my %catalogs = (
+		en => \%english,
+		pt => {
+			add => 'Adicionar',
+			base_only => 'Texto português',
+			greeting => 'Bem-vindo a <<site_name>>',
+			formatted => 'Olá {name}',
+		},
+		pt_BR => {add => 'Adicionar Brasil', base_only => ''},
+		pt_PT => {add => 'Unregistered translation'},
+	);
+	foreach my $catalog (sort keys %catalogs, 'common') {
+		my $extension = $catalog eq 'common' ? 'pot' : 'po';
+		open(my $fh, '>:encoding(UTF-8)', "$case_dir/po/common/$catalog.$extension")
+			or die "Cannot write catalog: $!";
+		print {$fh} "msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; charset=UTF-8\\n\"\n\n";
+		my $strings_ref = $catalog eq 'common' ? \%english : $catalogs{$catalog};
+		foreach my $key (sort keys %{$strings_ref}) {
+			my $translation = $catalog eq 'common' ? '' : $strings_ref->{$key};
+			print {$fh} "msgctxt \"$key\"\nmsgid \"$english{$key}\"\nmsgstr \"$translation\"\n\n";
+		}
+		close($fh) or die "Cannot close catalog: $!";
+	}
+	write_tag_catalog($case_dir, 'en', 'category', 'categories');
+	write_tag_catalog($case_dir, 'pt', 'categoria-base', 'categorias-base');
+	write_tag_catalog($case_dir, 'pt_BR', 'categoria-br', '');
+	write_tag_catalog($case_dir, 'pt_PT', 'unregistered', 'unregistered');
+
+	# The builders take an explicit registry. Normalizing the taxonomy-derived registry
+	# and enabling regional request languages are separate from catalog compilation.
+	my $languages_ref = {
+		en => {en => 'English'},
+		pt => {pt => 'Português'},
+		pt_BR => {pt_BR => 'Português (Brasil)'},
+	};
+	local $ProductOpener::Lang::data_root = $case_dir;
+	local $BASE_DIRS{PUBLIC_DATA} = "$case_dir/public";
+	local %ProductOpener::Lang::Lang;
+	ProductOpener::Lang::build_lang($languages_ref);
+	my $lang_ref = \%ProductOpener::Lang::Lang;
+	is($lang_ref->{add}{pt_BR}, 'Adicionar Brasil', 'Keep the regional translation');
+	is($lang_ref->{base_only}{pt_BR}, 'Texto português', 'An empty regional translation falls back to Portuguese');
+	is($lang_ref->{english_only}{pt_BR}, 'English fallback', 'Fall back to English when Portuguese is also missing');
+	is($lang_ref->{greeting}{pt_BR}, "Bem-vindo a $options{site_name}", 'Resolve site placeholders after fallback');
+	is(ProductOpener::Lang::f_lang_in_lc('pt_BR', 'formatted', {name => 'Alice'}),
+		'Olá Alice', 'Formatted messages use the compiled base-language fallback');
+	is([sort keys %{$lang_ref->{add}}], [qw/en pt pt_BR/], 'Only registered languages enter the compiled catalog');
+
+	my $compiled_tags_ref = ProductOpener::Lang::build_lang_tags($languages_ref);
+	is($compiled_tags_ref->{tag_type_singular}{categories}{pt_BR}, 'categoria-br', 'Compile the regional tag path');
+	is($compiled_tags_ref->{tag_type_plural}{categories}{pt_BR},
+		'categorias-base', 'Compile the base-language fallback for the tag path');
+
+	ProductOpener::Lang::build_json();
+	open(my $json_fh, '<:raw', "$case_dir/public/i18n/pt_BR/lang.json") or die "Cannot read JSON catalog: $!";
+	my $json_ref = decode_json(do {local $/; <$json_fh>});
+	close($json_fh) or die "Cannot close JSON catalog: $!";
+	is($json_ref->{add}, 'Adicionar Brasil', 'Export the regional translation to JavaScript');
+	is($json_ref->{base_only}, 'Texto português', 'Export the Portuguese fallback to JavaScript');
+	is($json_ref->{english_only}, 'English fallback', 'Export the English fallback to JavaScript');
+	ok(!-d "$case_dir/public/i18n/pt_PT", 'Do not export an unregistered locale');
+
+	store("$case_dir/data/Lang.$server_domain.sto", $lang_ref);
+	store("$case_dir/data/Lang_tags.$server_domain.sto", $compiled_tags_ref);
+	my $reload_script = <<'PERL';
+$ProductOpener::Config::data_root = shift;
+$ProductOpener::Paths::BASE_DIRS{PRIVATE_DATA} = "$ProductOpener::Config::data_root/data";
+require ProductOpener::Lang;
+require JSON::MaybeXS;
+print JSON::MaybeXS::encode_json({
+    lang => \%ProductOpener::Lang::Lang,
+    names => \%ProductOpener::Lang::Langs,
+    languages => \@ProductOpener::Lang::Langs,
+    tags => {
+        tag_type_singular => \%ProductOpener::Lang::tag_type_singular,
+        tag_type_plural => \%ProductOpener::Lang::tag_type_plural,
+        tag_type_from_singular => \%ProductOpener::Lang::tag_type_from_singular,
+        tag_type_from_plural => \%ProductOpener::Lang::tag_type_from_plural,
+    },
+});
+PERL
+	open(my $reload_fh, '-|', $^X, '-MProductOpener::Paths', '-e', $reload_script, $case_dir)
+		or die "Cannot reload translations: $!";
+	my $reloaded_ref = decode_json(do {local $/; <$reload_fh>});
+	ok(close($reload_fh), 'Reload both compiled catalogs in a fresh process');
+	is($reloaded_ref->{lang}, $lang_ref, 'All translations and fallbacks survive reloading');
+	is($reloaded_ref->{tags}, $compiled_tags_ref, 'All tag paths and reverse indexes survive reloading');
+	is($reloaded_ref->{languages}, [qw/en pt pt_BR/], 'Reloading does not activate an unregistered locale');
+	is(
+		$reloaded_ref->{names},
+		{map {$_ => $languages_ref->{$_}{$_}} keys %{$languages_ref}},
+		'Reloading preserves the registered language names'
+	);
+	done_testing();
+};
+
+done_testing();

--- a/tests/unit/language_codes.t
+++ b/tests/unit/language_codes.t
@@ -1,0 +1,74 @@
+#!/usr/bin/perl -w
+
+use ProductOpener::PerlStandards;
+use Test2::V0;
+use Test2::Plugin::UTF8;
+
+use ProductOpener::I18N qw/$language_code_re normalize_language_code language_tag base_language
+	language_fallbacks lookup_with_language_fallback/;
+use ProductOpener::Lang qw/language_locale/;
+use ProductOpener::Store qw/get_string_id_for_lang/;
+
+foreach my $case_ref (
+	['pt_BR', 'pt_BR', 'pt-BR', 'pt'],
+	['PT-br', 'pt_BR', 'pt-BR', 'pt'],
+	['pt_br', 'pt_BR', 'pt-BR', 'pt'],
+	['EN', 'en', 'en', 'en'],
+	['es-419', 'es_419', 'es-419', 'es'],
+	['kmr-tr', 'kmr_TR', 'kmr-TR', 'kmr'],
+	['zh-hant-tw', 'zh_Hant_TW', 'zh-Hant-TW', 'zh'],
+	['zh_HANS', 'zh_Hans', 'zh-Hans', 'zh'],
+	)
+{
+	my ($input, $normalized, $tag, $base) = @{$case_ref};
+	like($input, qr/\A$language_code_re\z/, "Shared grammar accepts $input");
+	is(normalize_language_code($input), $normalized, 'Normalize the code');
+	is(language_tag($input), $tag, 'Format a BCP-47 tag');
+	is(base_language($input), $base, 'Return the root language');
+}
+
+foreach my $invalid (undef, '', 'pt-BR-extra', "pt_BR\n", '../pt', 'pt_4A9', 'pt_KK') {
+	is(normalize_language_code($invalid), undef, 'Reject invalid language syntax');
+	is(language_tag($invalid), undef, 'No BCP-47 tag for invalid input');
+	is(base_language($invalid), undef, 'No base language for invalid input');
+	is([language_fallbacks($invalid)], [], 'No fallback chain for invalid input');
+}
+
+is([language_fallbacks('zh-hant-tw')], [qw/zh_Hant_TW zh_Hant zh/], 'Keep the script before the root language');
+is([language_fallbacks('pt-br')], [qw/pt_BR pt/], 'Region falls back to root');
+is([language_fallbacks('en')], ['en'], 'A base language has no implicit English or other fallback');
+
+my %values = (zh => 'base', zh_Hant => 'script', zh_Hans => 'other script', en => 'English');
+my $matched;
+is(lookup_with_language_fallback(\%values, 'zh-hant-tw', \$matched), 'script', 'Choose the closest defined value');
+is($matched, 'zh_Hant', 'Report the language of the value');
+is(lookup_with_language_fallback(\%values, 'pt_BR', \$matched), undef, 'Do not add an English fallback');
+is($matched, undef, 'Clear a previous match on a miss');
+is(lookup_with_language_fallback({pt_PT => 'Portugal'}, 'pt_BR'), undef, 'Do not cross into a sibling region');
+is(lookup_with_language_fallback({zh_Hans => 'Simplified'}, 'zh_Hant_TW'), undef, 'Do not cross into another script');
+is(lookup_with_language_fallback({pt_BR => undef, pt => 'base'}, 'pt_BR'), 'base', 'Skip undefined values');
+is(lookup_with_language_fallback({pt_BR => 0, pt => 1}, 'pt_BR'), 0, 'Preserve zero');
+is(lookup_with_language_fallback({pt_BR => '', pt => 'base'}, 'pt_BR'), '', 'Preserve an explicit empty value');
+is(lookup_with_language_fallback({no_language => 'special', no => 'Norwegian'}, 'no_language'),
+	'special', 'Preserve exact non-language configuration keys');
+is(lookup_with_language_fallback({no => 'Norwegian'}, 'no_language'),
+	undef, 'Do not derive a language from a special key');
+is(lookup_with_language_fallback(undef, 'pt_BR'), undef, 'Accept an absent dictionary');
+is(lookup_with_language_fallback(\%values, undef), undef, 'Accept an absent language');
+is(
+	\%values,
+	{zh => 'base', zh_Hant => 'script', zh_Hans => 'other script', en => 'English'},
+	'Lookups leave the dictionary unchanged'
+);
+
+is(language_locale('pt_br')->id, 'pt-BR', 'Normalize before mapping the calendar locale');
+is(language_locale('pt_ZZ')->id, 'pt', 'Use a Portuguese calendar when a region is unavailable');
+is(language_locale('zh-TW')->id, 'zh-Hant-TW', 'Keep the traditional Chinese calendar mapping');
+is(language_locale('zh_HK')->id, 'zh-Hant-HK', 'Keep the Hong Kong calendar mapping');
+is(language_locale('zh_CN')->id, 'zh-Hans-CN', 'Keep the simplified Chinese calendar mapping');
+is(language_locale('invalid')->id, 'en', 'Unknown calendar locales retain English fallback');
+is(get_string_id_for_lang('fr_CA', 'Café crème'), 'cafe-creme', 'Inherit French accent normalization');
+is(get_string_id_for_lang('de_AT', 'Äpfel'), 'äpfel', 'Inherit German accent normalization');
+is(get_string_id_for_lang('no_language', 'Café crème'), 'cafe-creme', 'Keep special normalization settings');
+
+done_testing();


### PR DESCRIPTION
Replaces #14471, which was closed when the source fork was deleted. This restores the same code without changes.

### What

This prepares the shared code for language variants :) Language codes and catalog fallbacks now have one implementation in `I18N.pm`. No new locale is enabled.

`$language_code_re` defines the syntax used by the normalizer, PO loader and future taxonomy changes. It supports two- or three-letter languages, scripts and regions. Catalog filenames must use the normalized spelling, such as `pt_BR.po` or `zh_Hant_TW.po`.

The shared helpers normalize codes, format BCP-47 tags, return the root language and look up values through the fallback chain. For example, `zh_Hant_TW` tries `zh_Hant` before `zh`. English fallback stays with the caller, since ingredient matching and interface translations have different rules.

Catalog compilation and JSON export use those helpers. JSON directories use BCP-47 names. Calendar locales keep the Chinese script mappings, and string normalization inherits the base language's rules.

Tag catalogs can omit `:langname` and `:langtag`, as the real catalogs do. `split_tags` leaves missing keys out, and `build_lang_tags` skips undefined entries. A test covers this case so the shared fallback code doesn't break `build_lang.pl`.

This changes production code in `I18N.pm`, `Lang.pm` and `Store.pm`. The current registry, request handling, language selector and templates are unchanged. No locale is activated.

### Tests

The validation results below are carried over from #14471; these checks have not been rerun for this replacement PR.

`scripts/build_lang.pl` finishes with the real catalogs and writes both stored catalogs and the JSON exports. No `pt-BR` directory is generated on this branch.

Four focused test files, 340 assertions: all passed (`language_codes.t`, `i18n_language_variants.t`, `lang_tags.t`, `lang.t`). They cover the shared helpers, strict filenames, script fallback, missing language-name keys, catalog compilation, JSON export and fresh-process reload.

The translation and calendar data were also compared with the original preparation commit: all 189 registered languages, their names, translations and calendars are identical. There are no regional languages in that registry.

All 306 tracked PO paths were checked with the shared normalizer: 153 in `po/common` and 153 in `po/tags`, including the `nl.po` symlink. Every filename already has the canonical spelling. None is rejected by the filename filter, and no normalization collisions were found.

Perltidy, Perlcritic and `git diff --check` passed.

Related to #6688, which stays open.
